### PR TITLE
The docs should show that @expectedExceptionMessage uses assertContains not assertSame

### DIFF
--- a/branches/3.6/en/annotations.xml
+++ b/branches/3.6/en/annotations.xml
@@ -317,6 +317,25 @@ public function testBalanceIsInitiallyZero()
         throw new Exception('Some Message', 20);
     }
 }</programlisting>
+
+      The expected message can be a substring of the exception Message.
+      This can be useful to only assert that a certain name or parameter that
+      was passed in shows up in the exception and not fixate the whole
+      exception message in the test.
+
+      <programlisting>class MyTest extends PHPUnit_Framework_TestCase
+{
+     /**
+      * @expectedException        Exception
+      * @expectedExceptionMessage broken
+      */
+     public function testExceptionHasRightMessage()
+     {
+         $param = "broken";
+         throw new Exception('Invalid parameter "'.$param.'".', 20);
+     }
+}</programlisting>
+
     </para>
   </section>
 


### PR DESCRIPTION
The docs don't show that @expectedExceptionMessage matches on substrings which can lead to confusion as to why 

```
"@expectedExceptionMessage a" 
```

works with 

```
throw new Exception("Some failure");
```

and so on. 

Also the feature it's self is useful as the docs try to describe.

---

Patch only for 3.6 as the 3.5 annotation stuff is just "...". I'll backport that after this request if you like :)
