### PR TITLE
Example extends wrong class

### DIFF
--- a/branches/3.6/en/database.xml
+++ b/branches/3.6/en/database.xml
@@ -242,7 +242,7 @@ class MyTest extends PHPUnit_Framework_TestCase
     <screen>
 require_once &quot;PHPUnit/Extensions/Database/TestCase.php&quot;;
 
-class MyGuestbookTest extends PHPUnit_Framework_TestCase
+class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     /**
      * @return PHPUnit_Extensions_Database_DB_IDatabaseConnection


### PR DESCRIPTION
Fixed incorrect extended class from PHPUnit_Framework_TestCase to PHPUnit_Extensions_Database_TestCase
