### PR TITLE
Fixed a dead link for documentation of Selenium commands

### DIFF
--- a/branches/3.0/en/ch17.xml
+++ b/branches/3.0/en/ch17.xml
@@ -246,7 +246,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
   </section>

--- a/branches/3.1/en/ch17.xml
+++ b/branches/3.1/en/ch17.xml
@@ -285,7 +285,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
   </section>

--- a/branches/3.2/en/selenium.xml
+++ b/branches/3.2/en/selenium.xml
@@ -373,7 +373,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
 

--- a/branches/3.3/en/selenium.xml
+++ b/branches/3.3/en/selenium.xml
@@ -373,7 +373,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
 

--- a/branches/3.4/en/selenium.xml
+++ b/branches/3.4/en/selenium.xml
@@ -370,7 +370,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
 

--- a/branches/3.5/en/selenium.xml
+++ b/branches/3.5/en/selenium.xml
@@ -366,7 +366,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
 

--- a/branches/3.6/en/selenium.xml
+++ b/branches/3.6/en/selenium.xml
@@ -364,7 +364,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Please refer to the <ulink url="http://seleniumhq.org/docs/04_selenese_commands.html">documentation of Selenium commands</ulink>
+      Please refer to the <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentation of Selenium commands</ulink>
       for a reference of the commands available and how they are used.
     </para>
 


### PR DESCRIPTION
Changed http://seleniumhq.org/docs/04_selenese_commands.html (which is now a 404) to http://release.seleniumhq.org/selenium-core/1.0.1/reference.html in all branches except 2.3 (which doesn't appear to contain information regarding Selenium).
