### PR TITLE
Fixed typo at assertTag() description

### DIFF
--- a/branches/3.3/en/api.xml
+++ b/branches/3.3/en/api.xml
@@ -1189,7 +1189,7 @@ Tests: 1, Assertions: 2, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> is an associative array that specifies the match criteria for the assertion:</para>
       <itemizedlist>
         <listitem><literal>id</literal>: The node with the given <literal>id</literal> attribute must match the corresponsing value.</listitem>
-        <listitem><literal>tags</literal>: The node type must match the corresponding value.</listitem>
+        <listitem><literal>tag</literal>: The node type must match the corresponding value.</listitem>
         <listitem><literal>attributes</literal>: The node's attributes must match the corresponsing values in the <literal>$attributes</literal> associative array.</listitem>
         <listitem><literal>content</literal>: The text content must match the given value.</listitem>
         <listitem><literal>parent</literal>: The node's parent must match the <literal>$parent</literal> associative array.</listitem>

--- a/branches/3.3/ja/api.xml
+++ b/branches/3.3/ja/api.xml
@@ -1190,7 +1190,7 @@ Tests: 1, Assertions: 2, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> は連想配列で、アサーションに使用するマッチ条件を指定します。</para>
       <itemizedlist>
         <listitem><literal>id</literal>: 指定した <literal>id</literal> 属性のノードが対応する値にマッチすること。</listitem>
-        <listitem><literal>tags</literal>: ノードの型が対応する値にマッチすること。</listitem>
+        <listitem><literal>tag</literal>: ノードの型が対応する値にマッチすること。</listitem>
         <listitem><literal>attributes</literal>: ノードの属性が、対応する値の連想配列 <literal>$attributes</literal> にマッチすること。</listitem>
         <listitem><literal>content</literal>: テキストの内容が指定した値にマッチすること。</listitem>
         <listitem><literal>parent</literal>: ノードの親が連想配列 <literal>$parent</literal> にマッチすること。</listitem>

--- a/branches/3.4/en/api.xml
+++ b/branches/3.4/en/api.xml
@@ -1261,7 +1261,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> is an associative array that specifies the match criteria for the assertion:</para>
       <itemizedlist>
         <listitem><literal>id</literal>: The node with the given <literal>id</literal> attribute must match the corresponsing value.</listitem>
-        <listitem><literal>tags</literal>: The node type must match the corresponding value.</listitem>
+        <listitem><literal>tag</literal>: The node type must match the corresponding value.</listitem>
         <listitem><literal>attributes</literal>: The node's attributes must match the corresponsing values in the <literal>$attributes</literal> associative array.</listitem>
         <listitem><literal>content</literal>: The text content must match the given value.</listitem>
         <listitem><literal>parent</literal>: The node's parent must match the <literal>$parent</literal> associative array.</listitem>

--- a/branches/3.4/ja/api.xml
+++ b/branches/3.4/ja/api.xml
@@ -1261,7 +1261,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> は連想配列で、アサーションに使用するマッチ条件を指定します。</para>
       <itemizedlist>
         <listitem><literal>id</literal>: 指定した <literal>id</literal> 属性のノードが対応する値にマッチすること。</listitem>
-        <listitem><literal>tags</literal>: ノードの型が対応する値にマッチすること。</listitem>
+        <listitem><literal>tag</literal>: ノードの型が対応する値にマッチすること。</listitem>
         <listitem><literal>attributes</literal>: ノードの属性が、対応する値の連想配列 <literal>$attributes</literal> にマッチすること。</listitem>
         <listitem><literal>content</literal>: テキストの内容が指定した値にマッチすること。</listitem>
         <listitem><literal>parent</literal>: ノードの親が連想配列 <literal>$parent</literal> にマッチすること。</listitem>

--- a/branches/3.5/en/writing-tests-for-phpunit.xml
+++ b/branches/3.5/en/writing-tests-for-phpunit.xml
@@ -2265,7 +2265,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> is an associative array that specifies the match criteria for the assertion:</para>
       <itemizedlist>
         <listitem><literal>id</literal>: The node with the given <literal>id</literal> attribute must match the corresponsing value.</listitem>
-        <listitem><literal>tags</literal>: The node type must match the corresponding value.</listitem>
+        <listitem><literal>tag</literal>: The node type must match the corresponding value.</listitem>
         <listitem><literal>attributes</literal>: The node's attributes must match the corresponsing values in the <literal>$attributes</literal> associative array.</listitem>
         <listitem><literal>content</literal>: The text content must match the given value.</listitem>
         <listitem><literal>parent</literal>: The node's parent must match the <literal>$parent</literal> associative array.</listitem>

--- a/branches/3.5/ja/writing-tests-for-phpunit.xml
+++ b/branches/3.5/ja/writing-tests-for-phpunit.xml
@@ -2284,7 +2284,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> は連想配列で、アサーションに使用するマッチ条件を指定します。</para>
       <itemizedlist>
         <listitem><literal>id</literal>: 指定した <literal>id</literal> 属性のノードが対応する値にマッチすること。</listitem>
-        <listitem><literal>tags</literal>: ノードの型が対応する値にマッチすること。</listitem>
+        <listitem><literal>tag</literal>: ノードの型が対応する値にマッチすること。</listitem>
         <listitem><literal>attributes</literal>: ノードの属性が、対応する値の連想配列 <literal>$attributes</literal> にマッチすること。</listitem>
         <listitem><literal>content</literal>: テキストの内容が指定した値にマッチすること。</listitem>
         <listitem><literal>parent</literal>: ノードの親が連想配列 <literal>$parent</literal> にマッチすること。</listitem>

--- a/branches/3.6/en/writing-tests-for-phpunit.xml
+++ b/branches/3.6/en/writing-tests-for-phpunit.xml
@@ -2439,7 +2439,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> is an associative array that specifies the match criteria for the assertion:</para>
       <itemizedlist>
         <listitem><literal>id</literal>: The node with the given <literal>id</literal> attribute must match the corresponsing value.</listitem>
-        <listitem><literal>tags</literal>: The node type must match the corresponding value.</listitem>
+        <listitem><literal>tag</literal>: The node type must match the corresponding value.</listitem>
         <listitem><literal>attributes</literal>: The node's attributes must match the corresponsing values in the <literal>$attributes</literal> associative array.</listitem>
         <listitem><literal>content</literal>: The text content must match the given value.</listitem>
         <listitem><literal>parent</literal>: The node's parent must match the <literal>$parent</literal> associative array.</listitem>

--- a/branches/3.6/ja/writing-tests-for-phpunit.xml
+++ b/branches/3.6/ja/writing-tests-for-phpunit.xml
@@ -2460,7 +2460,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> は連想配列で、アサーションに使用するマッチ条件を指定します。</para>
       <itemizedlist>
         <listitem><literal>id</literal>: 指定した <literal>id</literal> 属性のノードが対応する値にマッチすること。</listitem>
-        <listitem><literal>tags</literal>: ノードの型が対応する値にマッチすること。</listitem>
+        <listitem><literal>tag</literal>: ノードの型が対応する値にマッチすること。</listitem>
         <listitem><literal>attributes</literal>: ノードの属性が、対応する値の連想配列 <literal>$attributes</literal> にマッチすること。</listitem>
         <listitem><literal>content</literal>: テキストの内容が指定した値にマッチすること。</listitem>
         <listitem><literal>parent</literal>: ノードの親が連想配列 <literal>$parent</literal> にマッチすること。</listitem>

--- a/branches/3.7/en/writing-tests-for-phpunit.xml
+++ b/branches/3.7/en/writing-tests-for-phpunit.xml
@@ -2446,7 +2446,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> is an associative array that specifies the match criteria for the assertion:</para>
       <itemizedlist>
         <listitem><literal>id</literal>: The node with the given <literal>id</literal> attribute must match the corresponsing value.</listitem>
-        <listitem><literal>tags</literal>: The node type must match the corresponding value.</listitem>
+        <listitem><literal>tag</literal>: The node type must match the corresponding value.</listitem>
         <listitem><literal>attributes</literal>: The node's attributes must match the corresponsing values in the <literal>$attributes</literal> associative array.</listitem>
         <listitem><literal>content</literal>: The text content must match the given value.</listitem>
         <listitem><literal>parent</literal>: The node's parent must match the <literal>$parent</literal> associative array.</listitem>

--- a/branches/3.7/ja/writing-tests-for-phpunit.xml
+++ b/branches/3.7/ja/writing-tests-for-phpunit.xml
@@ -2468,7 +2468,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para><literal>$matcher</literal> は連想配列で、アサーションに使用するマッチ条件を指定します。</para>
       <itemizedlist>
         <listitem><literal>id</literal>: 指定した <literal>id</literal> 属性のノードが対応する値にマッチすること。</listitem>
-        <listitem><literal>tags</literal>: ノードの型が対応する値にマッチすること。</listitem>
+        <listitem><literal>tag</literal>: ノードの型が対応する値にマッチすること。</listitem>
         <listitem><literal>attributes</literal>: ノードの属性が、対応する値の連想配列 <literal>$attributes</literal> にマッチすること。</listitem>
         <listitem><literal>content</literal>: テキストの内容が指定した値にマッチすること。</listitem>
         <listitem><literal>parent</literal>: ノードの親が連想配列 <literal>$parent</literal> にマッチすること。</listitem>


### PR DESCRIPTION
I found a typo in assertTag() description.
