### PR TITLE
Fixed wrong order of execution of @dataProvider and @depends tests

### DIFF
--- a/branches/3.7/en/writing-tests-for-phpunit.xml
+++ b/branches/3.7/en/writing-tests-for-phpunit.xml
@@ -350,7 +350,7 @@ class CsvFileIterator implements Iterator {
 
         When a test receives input from both a <literal>@dataProvider</literal>
         method and from one or more tests it <literal>@depends</literal> on, the
-        arguments from the data provider will come before the ones from
+        arguments from the data provider will come after the ones from
         depended-upon tests.
       </para>
     </note>


### PR DESCRIPTION
Hello Sebastian

I notice one little bug during translation PHPUnit documentation into russian. Test get arguments from depended-upon tests first. This even more logical because test runner should check that producer test pass before run any consumer test.
Test case in this gist demonstrate this: https://gist.github.com/3625648
