### PR TITLE
Fix IsTrue constraint example

### DIFF
--- a/branches/3.6/en/extending-phpunit.xml
+++ b/branches/3.6/en/extending-phpunit.xml
@@ -90,7 +90,7 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
      * @param mixed $other Value or object to evaluate.
      * @return bool
      */
-    public function evaluate($other)
+    public function matches($other)
     {
         return $other === TRUE;
     }

--- a/branches/3.7/en/extending-phpunit.xml
+++ b/branches/3.7/en/extending-phpunit.xml
@@ -90,7 +90,7 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
      * @param mixed $other Value or object to evaluate.
      * @return bool
      */
-    public function evaluate($other)
+    public function matches($other)
     {
         return $other === TRUE;
     }


### PR DESCRIPTION
If you look at the actual source code in PHPUnit for `PHPUnit_Framework_Constraint_IsTrue`, you will find the method used is matches().

Using evaluate() would cause the constraint to never fail.
