### PR TITLE
Selenium code coverage setup

### DIFF
--- a/branches/3.7/en/selenium.xml
+++ b/branches/3.7/en/selenium.xml
@@ -344,8 +344,8 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </para>
 
     <orderedlist>
-      <listitem>Copy <filename>PHPUnit/Extensions/SeleniumTestCase/phpunit_coverage.php</filename> into your webserver's document root directory.</listitem>
-      <listitem>In your webserver's <filename>php.ini</filename> configuration file, configure <filename>PHPUnit/Extensions/SeleniumTestCase/prepend.php</filename> and <filename>PHPUnit/Extensions/SeleniumTestCase/append.php</filename> as the <literal>auto_prepend_file</literal> and <literal>auto_append_file</literal>, respectively.</listitem>
+      <listitem>Copy <filename>PHPUnit/Extensions/SeleniumCommon/phpunit_coverage.php</filename> into your webserver's document root directory.</listitem>
+      <listitem>In your webserver's <filename>php.ini</filename> configuration file, configure <filename>PHPUnit/Extensions/SeleniumCommon/prepend.php</filename> and <filename>PHPUnit/Extensions/SeleniumCommon/append.php</filename> as the <literal>auto_prepend_file</literal> and <literal>auto_append_file</literal>, respectively.</listitem>
       <listitem>In your test case class that extends <literal>PHPUnit_Extensions_SeleniumTestCase</literal>, use <programlisting>protected $coverageScriptUrl = 'http://host/phpunit_coverage.php';</programlisting> to configure the URL for the <filename>phpunit_coverage.php</filename> script.</listitem>
     </orderedlist>
 

--- a/branches/3.8/en/selenium.xml
+++ b/branches/3.8/en/selenium.xml
@@ -344,8 +344,8 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </para>
 
     <orderedlist>
-      <listitem>Copy <filename>PHPUnit/Extensions/SeleniumTestCase/phpunit_coverage.php</filename> into your webserver's document root directory.</listitem>
-      <listitem>In your webserver's <filename>php.ini</filename> configuration file, configure <filename>PHPUnit/Extensions/SeleniumTestCase/prepend.php</filename> and <filename>PHPUnit/Extensions/SeleniumTestCase/append.php</filename> as the <literal>auto_prepend_file</literal> and <literal>auto_append_file</literal>, respectively.</listitem>
+      <listitem>Copy <filename>PHPUnit/Extensions/SeleniumCommon/phpunit_coverage.php</filename> into your webserver's document root directory.</listitem>
+      <listitem>In your webserver's <filename>php.ini</filename> configuration file, configure <filename>PHPUnit/Extensions/SeleniumCommon/prepend.php</filename> and <filename>PHPUnit/Extensions/SeleniumCommon/append.php</filename> as the <literal>auto_prepend_file</literal> and <literal>auto_append_file</literal>, respectively.</listitem>
       <listitem>In your test case class that extends <literal>PHPUnit_Extensions_SeleniumTestCase</literal>, use <programlisting>protected $coverageScriptUrl = 'http://host/phpunit_coverage.php';</programlisting> to configure the URL for the <filename>phpunit_coverage.php</filename> script.</listitem>
     </orderedlist>
 


### PR DESCRIPTION
Files (`phpunit_coverage.php`, `prepent.php`, `append.php`) are located in [PHPUnit/Extensions/SeleniumCommon](https://github.com/sebastianbergmann/phpunit-selenium/tree/master/PHPUnit/Extensions/SeleniumCommon), not [PHPUnit/Extensions/SeleniumTestCase](https://github.com/sebastianbergmann/phpunit-selenium/tree/master/PHPUnit/Extensions/SeleniumTestCase)
