### PR TITLE
A typo and some mistakes in descriptions of some methods

### DIFF
--- a/branches/3.7/en/writing-tests-for-phpunit.xml
+++ b/branches/3.7/en/writing-tests-for-phpunit.xml
@@ -1009,7 +1009,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <para>Reports an error identified by <literal>$message</literal> if <literal>$haystack</literal> does not contain only variables of type <literal>$type</literal>.</para>
       <para><literal>$isNativeType</literal> is a flag used to indicate whether <literal>$type</literal> is a native PHP type or not.</para>
       <para><literal>assertNotContainsOnly()</literal> is the inverse of this assertion and takes the same arguments.</para>
-      <para><literal>assertAttributeContainsOnly()</literal> and <literal>assertAttributeNotContainsOnly()</literal> are convenience wrappers that use a <literal>public</literal>, <literal>protected</literal>, or <literal>private</literal> attribute of a class or object as the actual value.</para>
+      <para><literal>assertAttributeContainsOnly()</literal> and <literal>assertAttributeNotContainsOnly()</literal> are convenience wrappers that use a <literal>public</literal>, <literal>protected</literal>, or <literal>private</literal> attribute of a class or object as the haystack.</para>
       <example id="writing-tests-for-phpunit.assertions.assertContainsOnly.example">
         <title>Usage of assertContainsOnly()</title>
         <programlisting><![CDATA[<?php


### PR DESCRIPTION
I was reading the documentation that found out the description written for some methods was wrong and also a typo found.
Which description was against what they are supposed to do (by their name) and their examples.
