### PR TITLE
[en] Fix typo: accross -> across

### DIFF
--- a/branches/3.5/en/database.xml
+++ b/branches/3.5/en/database.xml
@@ -267,7 +267,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <para>
         To allow the clean-up and fixture loading functionalities to work
         the PHPUnit Database Extension requires access to a database
-        connection abstracted accross vendors through the PDO library. It
+        connection abstracted across vendors through the PDO library. It
         is important to note that your application does not need to be
         based on PDO to use PHPUnit's database extension, the connection is
         merely used for the clean-up and fixture setup.

--- a/branches/3.6/en/database.xml
+++ b/branches/3.6/en/database.xml
@@ -262,7 +262,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <para>
         To allow the clean-up and fixture loading functionalities to work
         the PHPUnit Database Extension requires access to a database
-        connection abstracted accross vendors through the PDO library. It
+        connection abstracted across vendors through the PDO library. It
         is important to note that your application does not need to be
         based on PDO to use PHPUnit's database extension, the connection is
         merely used for the clean-up and fixture setup.

--- a/branches/3.7/en/database.xml
+++ b/branches/3.7/en/database.xml
@@ -262,7 +262,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <para>
         To allow the clean-up and fixture loading functionalities to work
         the PHPUnit Database Extension requires access to a database
-        connection abstracted accross vendors through the PDO library. It
+        connection abstracted across vendors through the PDO library. It
         is important to note that your application does not need to be
         based on PDO to use PHPUnit's database extension, the connection is
         merely used for the clean-up and fixture setup.

--- a/branches/3.8/en/database.xml
+++ b/branches/3.8/en/database.xml
@@ -262,7 +262,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <para>
         To allow the clean-up and fixture loading functionalities to work
         the PHPUnit Database Extension requires access to a database
-        connection abstracted accross vendors through the PDO library. It
+        connection abstracted across vendors through the PDO library. It
         is important to note that your application does not need to be
         based on PDO to use PHPUnit's database extension, the connection is
         merely used for the clean-up and fixture setup.


### PR DESCRIPTION
Fixed in versions 3.5 through 3.8
