### PR TITLE
Removed ':' in section id of the xml structure

### DIFF
--- a/branches/3.8/en/database.xml
+++ b/branches/3.8/en/database.xml
@@ -335,7 +335,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
         </listitem>
       </orderedlist>
     </section>
-    <section id="tip:-use-your-own-abstract-database-testcase">
+    <section id="tip-use-your-own-abstract-database-testcase">
       <title>Tip: Use your own Abstract Database TestCase</title>
       <para>
         From the previous implementation example you can easily see that


### PR DESCRIPTION
ePub invalidates against http://validator.idpf.org/ due to colon in xml id tag. This prevents the ePub from being readable by books.google.com
