### PR TITLE
Minor typo in switches documentation

### DIFF
--- a/branches/3.8/en/textui.xml
+++ b/branches/3.8/en/textui.xml
@@ -148,9 +148,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   -d key[=value]            Sets a php.ini value.
 
   -h|--help                 Prints this usage information.
-  --version                 Prints the version and exits.
-
-  --debug                   Output debugging information.]]></screen>
+  --version                 Prints the version and exits.]]></screen>
 
     <variablelist>
       <varlistentry>


### PR DESCRIPTION
Hello,

I've found this minor typo in the documentation of the command line switches.

Hope this helps !

Needless to say, PHPUnit is awsome. Thank you to bring quality to PHP !
