### PR TITLE
Add missing CLI switches to 3.7 docs.

### DIFF
--- a/src/3.7/en/textui.xml
+++ b/src/3.7/en/textui.xml
@@ -97,7 +97,7 @@ OK (2 tests, 2 assertions)</screen>
     </para>
 
     <screen><userinput>phpunit --help</userinput>
-<![CDATA[PHPUnit 3.7.0 by Sebastian Bergmann.
+<![CDATA[PHPUnit 3.7.13 by Sebastian Bergmann.
 
 Usage: phpunit [switches] UnitTest [UnitTest.php]
        phpunit [switches] <directory>
@@ -116,9 +116,12 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --testdox-text <file>     Write agile documentation in Text format to file.
 
   --filter <pattern>        Filter which tests to run.
+  --testsuite <pattern>     Filter which testsuite to run.
   --group ...               Only runs tests from the specified group(s).
   --exclude-group ...       Exclude tests from the specified group(s).
   --list-groups             List available test groups.
+  --test-suffix ...         Only search for test in files with specified
+                            suffix(es). Default: Test.php,.phpt
 
   --loader <loader>         TestSuiteLoader implementation to use.
   --printer <printer>       TestSuiteListener implementation to use.
@@ -135,7 +138,7 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
   --stop-on-incomplete      Stop execution upon first incomplete test.
   --strict                  Run tests in strict mode.
   -v|--verbose              Output more verbose information.
-  --debug                   Display debbuging information during test execution.
+  --debug                   Display debugging information during test execution.
 
   --process-isolation       Run each test in a separate PHP process.
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
@@ -303,6 +306,15 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
         </listitem>
       </varlistentry>
 
+     <varlistentry>
+        <term><literal>--testsuite</literal></term>
+        <listitem>
+          <para>
+            Only runs the test suite whose name matches the given pattern.
+          </para>
+        </listitem>
+      </varlistentry>
+
       <varlistentry>
         <indexterm><primary>Test Groups</primary></indexterm>
         <indexterm><primary>Annotation</primary></indexterm>
@@ -343,6 +355,15 @@ Usage: phpunit [switches] UnitTest [UnitTest.php]
         <listitem>
           <para>
             List available test groups.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><literal>--test-suffix</literal></term>
+        <listitem>
+          <para>
+            Only search for test files with specified suffix(es).
           </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
Adding a couple of command line switches added to 3.7 after 3.7.0 to the docs.
