### PR TITLE
delete last br before code closing tag (code highlighter) 

### DIFF
--- a/build/scripts/highlight.php
+++ b/build/scripts/highlight.php
@@ -442,13 +442,15 @@ function highlight($string)
             "\r",
             "\n",
             '<code>&nbsp;<br /><span class="default">&lt;?php',
-            '?&gt;</span><br />&nbsp;<br />&nbsp;<br />'
+            '?&gt;</span><br />&nbsp;<br />&nbsp;<br />',
+            '<br /></code>'
           ),
           array(
             '',
             '',
             '<code><span class="default">&lt;?php',
-            '?&gt;</span>'
+            '?&gt;</span>',
+            '</code>'
           ),
           $highlighter->toHtml(TRUE, FALSE, NULL, FALSE)
         );


### PR DESCRIPTION
The toHTML() method of the Highlighter adds a br  to every line (line 298).
This strips the br  from the last line. 

http://i.imgur.com/UJDGRt8.png
