### PR TITLE
Updating the `testException` example so that it throws an exception

### DIFF
--- a/src/3.7/en/writing-tests-for-phpunit.xml
+++ b/src/3.7/en/writing-tests-for-phpunit.xml
@@ -503,6 +503,7 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
     public function testException()
     {
         $this->setExpectedException('InvalidArgumentException');
+        throw new InvalidArgumentException();
     }
 
     public function testExceptionHasRightMessage()


### PR DESCRIPTION
The other example tests (`testExceptionHasRightMessage` and `testExceptionHasRightCode`) throw an `InvalidArgumentException`, but `testException` doesn't.  For consistency, I'd recommend throwing an `InvalidArgumentException` in `testException`.
