### PR TITLE
Added a new class to the toc section: hideOverflow

### DIFF
--- a/build/scripts/webify.php
+++ b/build/scripts/webify.php
@@ -6,7 +6,7 @@ function webify_directory($directory, $language, $version)
 {
     $toc = get_substring(
       file_get_contents($directory . DIRECTORY_SEPARATOR . 'index.html'),
-      '<dl class="toc">',
+      '<dl class="toc hideOverflow">',
       '</dl>',
       TRUE,
       TRUE,


### PR DESCRIPTION
hideOverflow is a twitter bootstrap css class that hides the text if it overflows the box of the table of contents and adds '...' to show that the text was cut/hidden.
