### PR TITLE
Update to the sidebar-nav css to clip the text overflow.

### DIFF
--- a/build/assets/css/style.css
+++ b/build/assets/css/style.css
@@ -13,6 +13,11 @@ body {
  padding: 9px 0;
 }
 
+.sidebar-nav dt {
+ text-overflow: ellipsis;
+ overflow-x: hidden;
+}
+
 pre.programlisting, pre.screen, code {
   font-family: 'Source Code Pro', sans-serif;
   font-size: 1em;


### PR DESCRIPTION
Update to the sidebar-nav css to clip the size of the text when the page width is decreased.

.sidebar-nav dt {
text-overflow: ellipsis;
overflow-x: hidden;
}
