### PR TITLE
Fixing getMockForTrait reference to getObjectForTrait

### DIFF
--- a/src/3.8/en/test-doubles.xml
+++ b/src/3.8/en/test-doubles.xml
@@ -809,9 +809,9 @@ class FooTest extends PHPUnit_Framework_TestCase
     <title>Mocking Traits and Abstract Classes</title>
 
     <para>
-      <indexterm><primary>getMockForTrait()</primary></indexterm>
+      <indexterm><primary>getObjectForTrait()</primary></indexterm>
 
-      The <literal>getMockForTrait()</literal> method returns a mock object
+      The <literal>getObjectForTrait()</literal> method returns a mock object
       that uses a specified trait. All abstract methods of the given trait
       are mocked. This allows for testing the concrete methods of a trait.
     </para>
@@ -833,7 +833,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
 {
     public function testConcreteMethod()
     {
-        $mock = $this->getMockForTrait('AbstractTrait');
+        $mock = $this->getObjectForTrait('AbstractTrait');
         $mock->expects($this->any())
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));

--- a/src/3.8/ja/test-doubles.xml
+++ b/src/3.8/ja/test-doubles.xml
@@ -828,9 +828,9 @@ class FooTest extends PHPUnit_Framework_TestCase
     <title>トレイトと抽象クラスのモック</title>
 
     <para>
-      <indexterm><primary>getMockForTrait()</primary></indexterm>
+      <indexterm><primary>getObjectForTrait()</primary></indexterm>
 
-      <literal>getMockForTrait()</literal> メソッドは、指定したトレイトを使ったモックオブジェクトを返します。
+      <literal>getObjectForTrait()</literal> メソッドは、指定したトレイトを使ったモックオブジェクトを返します。
       そのトレイトのすべての抽象メソッドがモックの対象となります。
       これを使えば、トレイトの具象メソッドをテストすることができます。
     </para>
@@ -852,7 +852,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
 {
     public function testConcreteMethod()
     {
-        $mock = $this->getMockForTrait('AbstractTrait');
+        $mock = $this->getObjectForTrait('AbstractTrait');
         $mock->expects($this->any())
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));

--- a/src/3.8/zh_cn/test-doubles.xml
+++ b/src/3.8/zh_cn/test-doubles.xml
@@ -684,9 +684,9 @@ class FooTest extends PHPUnit_Framework_TestCase
     <title>对性状(Trait)与抽象类进行模仿</title>
 
     <para>
-      <indexterm><primary>getMockForTrait()</primary></indexterm>
+      <indexterm><primary>getObjectForTrait()</primary></indexterm>
 
-      <literal>getMockForTrait()</literal> 方法返回一个使用了特定性状(trait)的仿件对象。给定性状的所有抽象方法将都被模仿。这样就能对性状的具体方法进行测试。
+      <literal>getObjectForTrait()</literal> 方法返回一个使用了特定性状(trait)的仿件对象。给定性状的所有抽象方法将都被模仿。这样就能对性状的具体方法进行测试。
     </para>
 
     <example id="test-doubles.mock-objects.examples.TraitClassTest.php">
@@ -706,7 +706,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
 {
     public function testConcreteMethod()
     {
-        $mock = $this->getMockForTrait('AbstractTrait');
+        $mock = $this->getObjectForTrait('AbstractTrait');
         $mock->expects($this->any())
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));


### PR DESCRIPTION
The current 3.8 documentation references a `getMockForTrait` method that does not exist; the appropriate method is `getObjectForTrait`. This change fixes all references to the `getMockForTrait` in the 3.8 version.
- Only en, ja, zh_cn were changed as other languages did not have the appropriate translation for testing traits
- Other versions were not changed as they do not have references to testing traits
