### PR TITLE
Add XML Schema Definition references for 3.7/3.8.

### DIFF
--- a/src/3.7/en/configuration.xml
+++ b/src/3.7/en/configuration.xml
@@ -11,7 +11,10 @@
       be used to configure PHPUnit's core functionality.
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/path/to/bootstrap.php"-->
          cacheTokens="false"

--- a/src/3.7/fr/configuration.xml
+++ b/src/3.7/fr/configuration.xml
@@ -11,7 +11,10 @@
       utilisés pour configurer les fonctionnalités du coeur de PHPUnit.
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/chemin/vers/amorce.php"-->
          cacheTokens="true"

--- a/src/3.7/ja/configuration.xml
+++ b/src/3.7/ja/configuration.xml
@@ -11,7 +11,10 @@
       PHPUnit のコア機能を設定します。
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/path/to/bootstrap.php"-->
          cacheTokens="false"

--- a/src/3.7/pt_br/configuration.xml
+++ b/src/3.7/pt_br/configuration.xml
@@ -10,28 +10,32 @@
       Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem ser usados para configurar a funcionalidade do núcleo do PHPUnit.
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
-backupStaticAttributes="false"
-<!--bootstrap="/caminho/para/bootstrap.php"-->
-cacheTokens="false"
-colors="false"
-convertErrorsToExceptions="true"
-convertNoticesToExceptions="true"
-convertWarningsToExceptions="true"
-forceCoversAnnotation="false"
-mapTestClassNameToCoveredClassName="false"
-printerClass="PHPUnit_TextUI_ResultPrinter"
-<!--printerFile="/caminho/para/ResultPrinter.php"-->
-processIsolation="false"
-stopOnError="false"
-stopOnFailure="false"
-stopOnIncomplete="false"
-stopOnSkipped="false"
-testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
-<!--testSuiteLoaderFile="/caminho/para/StandardTestSuiteLoader.php"-->
-strict="false"
-verbose="false">
-<!-- ... -->
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+
+         backupGlobals="true"
+         backupStaticAttributes="false"
+         <!--bootstrap="/caminho/para/bootstrap.php"-->
+         cacheTokens="false"
+         colors="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         forceCoversAnnotation="false"
+         mapTestClassNameToCoveredClassName="false"
+         printerClass="PHPUnit_TextUI_ResultPrinter"
+         <!--printerFile="/caminho/para/ResultPrinter.php"-->
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         stopOnIncomplete="false"
+         stopOnSkipped="false"
+         testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+         <!--testSuiteLoaderFile="/caminho/para/StandardTestSuiteLoader.php"-->
+         strict="false"
+         verbose="false">
+   <!-- ... -->
 </phpunit>]]></screen>
 
     <para>

--- a/src/3.7/zh_cn/configuration.xml
+++ b/src/3.7/zh_cn/configuration.xml
@@ -10,7 +10,10 @@
       <literal><![CDATA[<phpunit>]]></literal> 元素的属性用于配置 PHPUnit 的核心功能。
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/path/to/bootstrap.php"-->
          cacheTokens="false"

--- a/src/3.8/en/configuration.xml
+++ b/src/3.8/en/configuration.xml
@@ -11,7 +11,10 @@
       be used to configure PHPUnit's core functionality.
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.8/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/path/to/bootstrap.php"-->
          cacheTokens="false"

--- a/src/3.8/fr/configuration.xml
+++ b/src/3.8/fr/configuration.xml
@@ -11,7 +11,10 @@
       utilisés pour configurer les fonctionnalités du coeur de PHPUnit.
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.8/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/chemin/vers/amorce.php"-->
          cacheTokens="true"

--- a/src/3.8/ja/configuration.xml
+++ b/src/3.8/ja/configuration.xml
@@ -11,7 +11,10 @@
       PHPUnit のコア機能を設定します。
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.8/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/path/to/bootstrap.php"-->
          cacheTokens="false"

--- a/src/3.8/pt_br/configuration.xml
+++ b/src/3.8/pt_br/configuration.xml
@@ -10,28 +10,31 @@
       Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem ser usados para configurar a funcionalidade do núcleo do PHPUnit.
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
-backupStaticAttributes="false"
-<!--bootstrap="/caminho/para/bootstrap.php"-->
-cacheTokens="false"
-colors="false"
-convertErrorsToExceptions="true"
-convertNoticesToExceptions="true"
-convertWarningsToExceptions="true"
-forceCoversAnnotation="false"
-mapTestClassNameToCoveredClassName="false"
-printerClass="PHPUnit_TextUI_ResultPrinter"
-<!--printerFile="/caminho/para/ResultPrinter.php"-->
-processIsolation="false"
-stopOnError="false"
-stopOnFailure="false"
-stopOnIncomplete="false"
-stopOnSkipped="false"
-testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
-<!--testSuiteLoaderFile="/caminho/para/StandardTestSuiteLoader.php"-->
-strict="false"
-verbose="false">
-<!-- ... -->
+    <screen><![CDATA[<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.8/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        <!--bootstrap="/caminho/para/bootstrap.php"-->
+        cacheTokens="false"
+        colors="false"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        mapTestClassNameToCoveredClassName="false"
+        printerClass="PHPUnit_TextUI_ResultPrinter"
+        <!--printerFile="/caminho/para/ResultPrinter.php"-->
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+        <!--testSuiteLoaderFile="/caminho/para/StandardTestSuiteLoader.php"-->
+        strict="false"
+        verbose="false">
+    <!-- ... -->
 </phpunit>]]></screen>
 
     <para>

--- a/src/3.8/zh_cn/configuration.xml
+++ b/src/3.8/zh_cn/configuration.xml
@@ -10,7 +10,10 @@
       <literal><![CDATA[<phpunit>]]></literal> 元素的属性用于配置 PHPUnit 的核心功能。
     </para>
 
-    <screen><![CDATA[<phpunit backupGlobals="true"
+    <screen><![CDATA[<phpunit
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.8/phpunit.xsd"
+         backupGlobals="true"
          backupStaticAttributes="false"
          <!--bootstrap="/path/to/bootstrap.php"-->
          cacheTokens="false"


### PR DESCRIPTION
I made those additions only in the section on the configuration file
in the assumption that this is where people will pick an initial XML
configuration template. I did not want to make the other places look
more complex than they have to be, espacially as the XSD is not
necessary for running PHPUnit.

I also did not elaborate on using the XSD or its potential benefits
to avoid the need of additional translations (haven't written any
Japanese or Chinese for a while).
