### PR TITLE
Fix typo "effiency" to "efficiency" in 3.4 - 3.8.

### DIFF
--- a/src/3.4/en/code-coverage-analysis.xml
+++ b/src/3.4/en/code-coverage-analysis.xml
@@ -18,7 +18,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       Knowing what should be tested is beautiful, and knowing what is being

--- a/src/3.4/ja/code-coverage-analysis.xml
+++ b/src/3.4/ja/code-coverage-analysis.xml
@@ -17,7 +17,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       - テストの美学は、どれだけ汗を流したかではなく

--- a/src/3.5/en/code-coverage-analysis.xml
+++ b/src/3.5/en/code-coverage-analysis.xml
@@ -18,7 +18,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       Knowing what should be tested is beautiful, and knowing what is being

--- a/src/3.5/ja/code-coverage-analysis.xml
+++ b/src/3.5/ja/code-coverage-analysis.xml
@@ -17,7 +17,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       - テストの美学は、どれだけ汗を流したかではなく

--- a/src/3.6/en/code-coverage-analysis.xml
+++ b/src/3.6/en/code-coverage-analysis.xml
@@ -18,7 +18,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       Knowing what should be tested is beautiful, and knowing what is being

--- a/src/3.6/ja/code-coverage-analysis.xml
+++ b/src/3.6/ja/code-coverage-analysis.xml
@@ -17,7 +17,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       - テストの美学は、どれだけ汗を流したかではなく

--- a/src/3.7/en/code-coverage-analysis.xml
+++ b/src/3.7/en/code-coverage-analysis.xml
@@ -6,7 +6,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       Knowing what should be tested is beautiful, and knowing what is being

--- a/src/3.7/ja/code-coverage-analysis.xml
+++ b/src/3.7/ja/code-coverage-analysis.xml
@@ -6,7 +6,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       - テストの美学は、どれだけ汗を流したかではなく

--- a/src/3.8/en/code-coverage-analysis.xml
+++ b/src/3.8/en/code-coverage-analysis.xml
@@ -6,7 +6,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       Knowing what should be tested is beautiful, and knowing what is being

--- a/src/3.8/ja/code-coverage-analysis.xml
+++ b/src/3.8/ja/code-coverage-analysis.xml
@@ -6,7 +6,7 @@
   <blockquote>
     <attribution>Murali Nandigama</attribution>
     <para>
-      The beauty of testing is found not in the effort but in the effiency.
+      The beauty of testing is found not in the effort but in the efficiency.
     </para>
     <para>
       - テストの美学は、どれだけ汗を流したかではなく


### PR DESCRIPTION
The quote in the beginning of the code coverage documentation is wrong.

Source: "Beautiful Testing" http://shop.oreilly.com/product/9780596159825.do

Chapter 11 written by Murali Nandigama starts with:

> **The beauty of testing is found not in the effort** but in the efficiency. 
> Knowing what should be tested is beautiful, and knowing what is being tested
> is beautiful.
