### PR TITLE
Add Japanese translation to webify.php

### DIFF
--- a/build/scripts/webify.php
+++ b/build/scripts/webify.php
@@ -134,14 +134,17 @@ function webify_file($file, $toc, $languageList, $versionList, $language)
     $prev_text = array(
         'en' => 'Prev',
         'zh_cn' => '上一章',
+        'ja' => '戻る',
     );
     $next_text = array(
         'en' => 'Next',
         'zh_cn' => '下一章',
+        'ja' => '次へ',
     );
     $suggestions_text = array(
         'en' => 'Please <a href="https://github.com/sebastianbergmann/phpunit-documentation/issues">open a ticket</a> on GitHub to suggest improvements to this page. Thanks!',
         'zh_cn' => '请在 GitHub 上 <a href="https://github.com/sebastianbergmann/phpunit-documentation/issues">开启任务单</a> 来对本页提出改进建议。万分感谢！',
+        'ja' => 'このページの改善案を<a href="https://github.com/sebastianbergmann/phpunit-documentation/issues">GitHubで提案</a>してください!',
     );
 
     if ($filename !== 'index.html') {


### PR DESCRIPTION
## Before

[PHPUnit Manual – 第2章 PHPUnit の目標](http://phpunit.de/manual/3.7/ja/goals.html)

![Before screenshot](http://gyazo.com/b51ea98b32245f97ed4c90275eba6a24.png)
## After

![After screenshot](http://gyazo.com/077e1f2558c9c6394dad626b9ccf0ebc.png)
## Translation

**戻る** means "go back"
**次へ** means "to next"

**このページの改善案** means "improvement plan of this page"
**GitHubで提案** means "suggest in GitHub"
**ください** means "please"

"Thanks" I omitted it because it was unnatural in Japanese.
