### PR TITLE
Add `addRiskyTest` to listener implementation

### DIFF
--- a/src/4.0/en/extending-phpunit.xml
+++ b/src/4.0/en/extending-phpunit.xml
@@ -149,6 +149,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("Test '%s' is incomplete.\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("Test '%s' is deemed risky.\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("Test '%s' has been skipped.\n", $test->getName());

--- a/src/4.0/fr/extending-phpunit.xml
+++ b/src/4.0/fr/extending-phpunit.xml
@@ -150,6 +150,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("Test '%s' is incomplete.\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("Test '%s' is deemed risky.\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("Test '%s' has been skipped.\n", $test->getName());

--- a/src/4.0/ja/extending-phpunit.xml
+++ b/src/4.0/ja/extending-phpunit.xml
@@ -148,6 +148,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("テスト '%s' は未完成\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("テスト '%s' は危険です\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("テスト '%s' をスキップ\n", $test->getName());

--- a/src/4.0/pt_br/extending-phpunit.xml
+++ b/src/4.0/pt_br/extending-phpunit.xml
@@ -138,6 +138,11 @@ public function addIncompleteTest(PHPUnit_Framework_Test $teste, Exception $e, $
 printf("O Teste '%s' está incompleto.\n", $teste->getName());
 }
 
+public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+{
+printf("O Teste '%s' é arriscado.\n", $test->getName());
+}
+
 public function addSkippedTest(PHPUnit_Framework_Test $teste, Exception $e, $tempo)
 {
 printf("O Teste '%s' foi pulado.\n", $teste->getName());

--- a/src/4.0/zh_cn/extending-phpunit.xml
+++ b/src/4.0/zh_cn/extending-phpunit.xml
@@ -127,6 +127,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("Test '%s' is incomplete.\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("Test '%s' is deemed risky.\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("Test '%s' has been skipped.\n", $test->getName());

--- a/src/4.1/en/extending-phpunit.xml
+++ b/src/4.1/en/extending-phpunit.xml
@@ -149,6 +149,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("Test '%s' is incomplete.\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("Test '%s' is deemed risky.\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("Test '%s' has been skipped.\n", $test->getName());

--- a/src/4.1/fr/extending-phpunit.xml
+++ b/src/4.1/fr/extending-phpunit.xml
@@ -150,6 +150,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("Test '%s' is incomplete.\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("Test '%s' is deemed risky.\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("Test '%s' has been skipped.\n", $test->getName());

--- a/src/4.1/ja/extending-phpunit.xml
+++ b/src/4.1/ja/extending-phpunit.xml
@@ -148,6 +148,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("テスト '%s' は未完成\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("テスト '%s' は危険です\n", $test->getName());
+    }
+
     public function addSkippedTest(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
         printf("テスト '%s' をスキップ\n", $test->getName());

--- a/src/4.1/pt_br/extending-phpunit.xml
+++ b/src/4.1/pt_br/extending-phpunit.xml
@@ -138,6 +138,11 @@ public function addIncompleteTest(PHPUnit_Framework_Test $teste, Exception $e, $
 printf("O Teste '%s' está incompleto.\n", $teste->getName());
 }
 
+public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+{
+printf("O Teste '%s' é arriscado.\n", $test->getName());
+}
+
 public function addSkippedTest(PHPUnit_Framework_Test $teste, Exception $e, $tempo)
 {
 printf("O Teste '%s' foi pulado.\n", $teste->getName());

--- a/src/4.1/zh_cn/extending-phpunit.xml
+++ b/src/4.1/zh_cn/extending-phpunit.xml
@@ -132,6 +132,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
         printf("Test '%s' has been skipped.\n", $test->getName());
     }
 
+    public function addRiskyTest(PHPUnit_Framework_Test $test, Exception $e, $time)
+    {
+        printf("Test '%s' is deemed risky.\n", $test->getName());
+    }
+
     public function startTest(PHPUnit_Framework_Test $test)
     {
         printf("Test '%s' started.\n", $test->getName());


### PR DESCRIPTION
The `addRiskyTest` method from `PHPUnit_Framework_TestListener` was missing from the example implementation. My translations may need to be checked over though.
- [ ] Check message "Test '%s' is deemed risky" (`en`, `fr`, `zh_cn`)
- [ ] Check message "テスト '%s' は危険です" (`jp`)
- [ ] Check message "O Teste '%s' é arriscado" (`pt_br`)
