### PR TITLE
Fix #197: Manual lacks a link back to PHPUnit homepage.

### DIFF
--- a/build/scripts/templates/page.html
+++ b/build/scripts/templates/page.html
@@ -21,7 +21,7 @@
       </button>
     </div>
     <div class="collapse navbar-collapse">
-      <ul class="nav navbar-nav navbar-left">{versions}</ul>
+      <ul class="nav navbar-nav navbar-left"><li><a href="http://phpunit.de/">PHPUnit</a></li>{versions}</ul>
       <ul class="nav navbar-nav navbar-right">{languages}</ul>
     </div>
   </nav>

--- a/build/scripts/webify.php
+++ b/build/scripts/webify.php
@@ -97,7 +97,7 @@ function webify_directory($directory, $language, $version)
         }
 
         $versionList .= sprintf(
-          '<li%s><a href="../../%s/%s/index.html">PHPUnit %s (%s)</a></li>',
+          '<li%s><a href="../../%s/%s/index.html">%s (%s)</a></li>',
           $version == $_version ? ' class="active"' : '',
           $_version,
           $language,


### PR DESCRIPTION
Adds a first link to the PHPUnit homepage to the primary navigation.

In exchange, removes the "PHPUnit" prefix from version links, to avoid visual clutter.

![phpunit-docs-nav-home](https://cloud.githubusercontent.com/assets/41992/3737758/112d3f14-173a-11e4-902b-207201423090.png)
