### PR TITLE
Remove references to PHPUnit_Extensions_TestSetup

### DIFF
--- a/src/3.7/en/extending-phpunit.xml
+++ b/src/3.7/en/extending-phpunit.xml
@@ -198,13 +198,11 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
 
     <para>
       <indexterm><primary>PHPUnit_Extensions_RepeatedTest</primary></indexterm>
-      <indexterm><primary>PHPUnit_Extensions_TestSetup</primary></indexterm>
 
-      PHPUnit ships with two concrete test decorators:
-      <literal>PHPUnit_Extensions_RepeatedTest</literal> and
-      <literal>PHPUnit_Extensions_TestSetup</literal>. The former is used to
-      run a test repeatedly and only count it as a success if all iterations
-      are successful. The latter was discussed in <xref linkend="fixtures" />.
+      PHPUnit ships with one concrete test decorator:
+      <literal>PHPUnit_Extensions_RepeatedTest</literal>. It is used to run a
+      test repeatedly and only count it as a success if all iterations are
+      successful.
     </para>
 
     <para>

--- a/src/4.1/en/extending-phpunit.xml
+++ b/src/4.1/en/extending-phpunit.xml
@@ -226,13 +226,11 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
 
     <para>
       <indexterm><primary>PHPUnit_Extensions_RepeatedTest</primary></indexterm>
-      <indexterm><primary>PHPUnit_Extensions_TestSetup</primary></indexterm>
 
-      PHPUnit ships with two concrete test decorators:
-      <literal>PHPUnit_Extensions_RepeatedTest</literal> and
-      <literal>PHPUnit_Extensions_TestSetup</literal>. The former is used to
-      run a test repeatedly and only count it as a success if all iterations
-      are successful. The latter was discussed in <xref linkend="fixtures" />.
+      PHPUnit ships with one concrete test decorator:
+      <literal>PHPUnit_Extensions_RepeatedTest</literal>. It is used to run a
+      test repeatedly and only count it as a success if all iterations are
+      successful.
     </para>
 
     <para>

--- a/src/4.2/en/extending-phpunit.xml
+++ b/src/4.2/en/extending-phpunit.xml
@@ -226,13 +226,11 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
 
     <para>
       <indexterm><primary>PHPUnit_Extensions_RepeatedTest</primary></indexterm>
-      <indexterm><primary>PHPUnit_Extensions_TestSetup</primary></indexterm>
 
-      PHPUnit ships with two concrete test decorators:
-      <literal>PHPUnit_Extensions_RepeatedTest</literal> and
-      <literal>PHPUnit_Extensions_TestSetup</literal>. The former is used to
-      run a test repeatedly and only count it as a success if all iterations
-      are successful. The latter was discussed in <xref linkend="fixtures" />.
+      PHPUnit ships with one concrete test decorator:
+      <literal>PHPUnit_Extensions_RepeatedTest</literal>. It is used to run a
+      test repeatedly and only count it as a success if all iterations are
+      successful.
     </para>
 
     <para>


### PR DESCRIPTION
AFAICT, this hasn't been shipped in awhile.

Fixed the 3 versions of documentation currently viewable at phpunit.de
