### PR TITLE
Fixed reference to the provider's method.

### DIFF
--- a/src/4.1/en/writing-tests-for-phpunit.xml
+++ b/src/4.1/en/writing-tests-for-phpunit.xml
@@ -251,7 +251,7 @@ OK (3 tests, 3 assertions)]]></screen>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@dataProvider</primary></indexterm>
       A test method can accept arbitrary arguments. These arguments are to be
-      provided by a data provider method (<literal>provider()</literal> in
+      provided by a data provider method (<literal>additionProvider()</literal> in
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
       The data provider method to be used is specified using the
       <literal>@dataProvider</literal> annotation.


### PR DESCRIPTION
The example 2.5 doesn't contain the provider() method, it contains the additionProvider() method.
