### PR TITLE
Missing `sudo` in PHAR installation instructions

### DIFF
--- a/src/4.2/en/installation.xml
+++ b/src/4.2/en/installation.xml
@@ -68,7 +68,7 @@
 
     <screen><userinput>wget https://phar.phpunit.de/phpunit.phar</userinput>
 <userinput>chmod +x phpunit.phar</userinput>
-<userinput>mv phpunit.phar /usr/local/bin/phpunit</userinput></screen>
+<userinput>sudo mv phpunit.phar /usr/local/bin/phpunit</userinput></screen>
 
     <note>
       <para>

--- a/src/4.3/en/installation.xml
+++ b/src/4.3/en/installation.xml
@@ -68,7 +68,7 @@
 
     <screen><userinput>wget https://phar.phpunit.de/phpunit.phar</userinput>
 <userinput>chmod +x phpunit.phar</userinput>
-<userinput>mv phpunit.phar /usr/local/bin/phpunit</userinput></screen>
+<userinput>sudo mv phpunit.phar /usr/local/bin/phpunit</userinput></screen>
 
     <note>
       <para>


### PR DESCRIPTION
http://phpunit.de/manual/current/en/installation.html#installation.phar
