### PR TITLE
Improved Requirements and PHAR installation chapters

### DIFF
--- a/src/4.2/en/installation.xml
+++ b/src/4.2/en/installation.xml
@@ -26,6 +26,17 @@
     </para>
 
     <para>
+      PHPUnit also requires the
+      <ulink
+      url="http://php.net/manual/en/pcre.installation.php">pcre</ulink>,
+      <ulink
+      url="http://php.net/manual/en/reflection.installation.php">reflection</ulink>,
+      and <ulink url="http://php.net/manual/en/spl.installation.php">spl</ulink>
+      extensions. They are required by PHP core since 5.3.0 and normally cannot
+      be disabled.
+    </para>
+
+    <para>
       The code coverage report feature requires the
       <ulink url="http://xdebug.org/">Xdebug</ulink> (2.1.3 or later) and
       <ulink url="http://php.net/manual/en/tokenizer.installation.php">tokenizer</ulink>

--- a/src/4.3/en/installation.xml
+++ b/src/4.3/en/installation.xml
@@ -26,6 +26,17 @@
     </para>
 
     <para>
+      PHPUnit also requires the
+      <ulink
+      url="http://php.net/manual/en/pcre.installation.php">pcre</ulink>,
+      <ulink
+      url="http://php.net/manual/en/reflection.installation.php">reflection</ulink>,
+      and <ulink url="http://php.net/manual/en/spl.installation.php">spl</ulink>
+      extensions. They are required by PHP core since 5.3.0 and normally cannot
+      be disabled.
+    </para>
+
+    <para>
       The code coverage report feature requires the
       <ulink url="http://xdebug.org/">Xdebug</ulink> (2.1.3 or later) and
       <ulink url="http://php.net/manual/en/tokenizer.installation.php">tokenizer</ulink>


### PR DESCRIPTION
- Removed always enabled PHP extensions from Requirements. (pointless)
- Shortened remaining Requirements.
- Moved PHAR-specific requirements into PHAR chapter.
- Clarified extra Suhosin `php.ini` configuration step for using PHARs.
