### PR TITLE
Mixed content errors after enabling HTTPS

### DIFF
--- a/build/scripts/templates/page.html
+++ b/build/scripts/templates/page.html
@@ -4,11 +4,11 @@
   <meta charset="utf-8">
   <title>{title}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="canonical" href="http://phpunit.de/manual/current/{language}/{filename}">
+  <link rel="canonical" href="https://phpunit.de/manual/current/{language}/{filename}">
   <link href="css/bootstrap.min.css" rel="stylesheet">
   <link href="css/highlight.css" rel="stylesheet">
   <link href="css/style.css" rel="stylesheet">
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700%7CSource+Code+Pro:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700%7CSource+Code+Pro:400,700' rel='stylesheet' type='text/css'>
   <!--[if lt IE 9]><script src="js/html5shiv.min.js"></script><![endif]-->
  </head>
  <body>
@@ -22,7 +22,7 @@
       </button>
     </div>
     <div class="collapse navbar-collapse">
-      <ul class="nav navbar-nav navbar-left"><li><a href="http://phpunit.de/">PHPUnit</a></li>{versions}</ul>
+      <ul class="nav navbar-nav navbar-left"><li><a href="https://phpunit.de/">PHPUnit</a></li>{versions}</ul>
       <ul class="nav navbar-nav navbar-right">{languages}</ul>
     </div>
   </nav>

--- a/src/4.2/en/code-coverage-analysis.xml
+++ b/src/4.2/en/code-coverage-analysis.xml
@@ -46,7 +46,7 @@
     <indexterm><primary>Xdebug</primary></indexterm>
 
     PHPUnit's code coverage functionality makes use of the
-    <ulink url="http://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
+    <ulink url="https://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
     component, which in turn leverages the statement coverage functionality
     provided by the <ulink url="http://www.xdebug.org/">Xdebug</ulink>
     extension for PHP.

--- a/src/4.2/en/database.xml
+++ b/src/4.2/en/database.xml
@@ -324,7 +324,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
             <ulink url="http://www.propelorm.org/">Propel</ulink>
             you can use their APIs to create the database schema you
             need once before you run the tests. You can utilize
-            <ulink url="http://www.phpunit.de/manual/current/en/textui.html">PHPUnit's Bootstrap and Configuration</ulink>
+            <ulink url="textui.html">PHPUnit's Bootstrap and Configuration</ulink>
             capabilities to execute this code whenever your tests are run.
           </para>
         </listitem>
@@ -367,7 +367,7 @@ abstract class MyApp_Tests_DatabaseTestCase extends PHPUnit_Extensions_Database_
         This has the database connection hardcoded in the PDO connection
         though. PHPUnit has another awesome feature that could make this
         testcase even more generic. If you use the
-        <ulink url="http://www.phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">XML Configuration</ulink>
+        <ulink url="appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">XML Configuration</ulink>
         you could make the database connection configurable per test-run.
         First let's create a <quote>phpunit.xml</quote> file in our tests/
         directory of the application that looks like:

--- a/src/4.2/en/installation.xml
+++ b/src/4.2/en/installation.xml
@@ -267,7 +267,7 @@ Primary key fingerprint: D840 6D0D 8294 7747 2937  7831 4AA3 9408 6372 C20A]]></
     <para>
       Simply add a dependency on <literal>phpunit/phpunit</literal> to your
       project's <literal>composer.json</literal> file if you use
-      <ulink url="http://getcomposer.org/">Composer</ulink> to manage the
+      <ulink url="https://getcomposer.org/">Composer</ulink> to manage the
       dependencies of your project. Here is a minimal example of a
       <literal>composer.json</literal> file that just defines a development-time
       dependency on PHPUnit 4.2:

--- a/src/4.2/en/organizing-tests.xml
+++ b/src/4.2/en/organizing-tests.xml
@@ -29,7 +29,7 @@
 
     <para>
       Lets take a look at the test suite of the
-      <ulink url="http://github.com/sebastianbergmann/money/">sebastianbergmann/money</ulink>
+      <ulink url="https://github.com/sebastianbergmann/money/">sebastianbergmann/money</ulink>
       library. Looking at this project's directory structure, we see that the
       test case classes in the <filename>tests</filename> directory mirror the
       package and class structure of the System Under Test (SUT) in the

--- a/src/4.2/en/test-doubles.xml
+++ b/src/4.2/en/test-doubles.xml
@@ -944,12 +944,12 @@ class GoogleTest extends PHPUnit_Framework_TestCase
 
         $element = new StdClass;
         $element->summary = '';
-        $element->URL = 'http://www.phpunit.de/';
+        $element->URL = 'https://phpunit.de/';
         $element->snippet = '...';
         $element->title = '<b>PHPUnit</b>';
         $element->cachedSize = '11k';
         $element->relatedInformationPresent = TRUE;
-        $element->hostName = 'www.phpunit.de';
+        $element->hostName = 'phpunit.de';
         $element->directoryCategory = $directoryCategory;
         $element->directoryTitle = '';
 
@@ -1009,7 +1009,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
     <para>
       Simply add a dependency on <literal>mikey179/vfsStream</literal> to your
       project's <literal>composer.json</literal> file if you use
-      <ulink url="http://getcomposer.org/">Composer</ulink> to manage the
+      <ulink url="https://getcomposer.org/">Composer</ulink> to manage the
       dependencies of your project. Here is a minimal example of a
       <literal>composer.json</literal> file that just defines a development-time
       dependency on PHPUnit 4.2 and vfsStream:

--- a/src/4.3/en/code-coverage-analysis.xml
+++ b/src/4.3/en/code-coverage-analysis.xml
@@ -46,7 +46,7 @@
     <indexterm><primary>Xdebug</primary></indexterm>
 
     PHPUnit's code coverage functionality makes use of the
-    <ulink url="http://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
+    <ulink url="https://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
     component, which in turn leverages the statement coverage functionality
     provided by the <ulink url="http://www.xdebug.org/">Xdebug</ulink>
     extension for PHP.

--- a/src/4.3/en/database.xml
+++ b/src/4.3/en/database.xml
@@ -324,7 +324,7 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
             <ulink url="http://www.propelorm.org/">Propel</ulink>
             you can use their APIs to create the database schema you
             need once before you run the tests. You can utilize
-            <ulink url="http://www.phpunit.de/manual/current/en/textui.html">PHPUnit's Bootstrap and Configuration</ulink>
+            <ulink url="textui.html">PHPUnit's Bootstrap and Configuration</ulink>
             capabilities to execute this code whenever your tests are run.
           </para>
         </listitem>
@@ -367,7 +367,7 @@ abstract class MyApp_Tests_DatabaseTestCase extends PHPUnit_Extensions_Database_
         This has the database connection hardcoded in the PDO connection
         though. PHPUnit has another awesome feature that could make this
         testcase even more generic. If you use the
-        <ulink url="http://www.phpunit.de/manual/current/en/appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">XML Configuration</ulink>
+        <ulink url="appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">XML Configuration</ulink>
         you could make the database connection configurable per test-run.
         First let's create a <quote>phpunit.xml</quote> file in our tests/
         directory of the application that looks like:

--- a/src/4.3/en/installation.xml
+++ b/src/4.3/en/installation.xml
@@ -267,7 +267,7 @@ Primary key fingerprint: D840 6D0D 8294 7747 2937  7831 4AA3 9408 6372 C20A]]></
     <para>
       Simply add a dependency on <literal>phpunit/phpunit</literal> to your
       project's <literal>composer.json</literal> file if you use
-      <ulink url="http://getcomposer.org/">Composer</ulink> to manage the
+      <ulink url="https://getcomposer.org/">Composer</ulink> to manage the
       dependencies of your project. Here is a minimal example of a
       <literal>composer.json</literal> file that just defines a development-time
       dependency on PHPUnit 4.3:

--- a/src/4.3/en/organizing-tests.xml
+++ b/src/4.3/en/organizing-tests.xml
@@ -29,7 +29,7 @@
 
     <para>
       Lets take a look at the test suite of the
-      <ulink url="http://github.com/sebastianbergmann/money/">sebastianbergmann/money</ulink>
+      <ulink url="https://github.com/sebastianbergmann/money/">sebastianbergmann/money</ulink>
       library. Looking at this project's directory structure, we see that the
       test case classes in the <filename>tests</filename> directory mirror the
       package and class structure of the System Under Test (SUT) in the

--- a/src/4.3/en/test-doubles.xml
+++ b/src/4.3/en/test-doubles.xml
@@ -944,12 +944,12 @@ class GoogleTest extends PHPUnit_Framework_TestCase
 
         $element = new StdClass;
         $element->summary = '';
-        $element->URL = 'http://www.phpunit.de/';
+        $element->URL = 'https://phpunit.de/';
         $element->snippet = '...';
         $element->title = '<b>PHPUnit</b>';
         $element->cachedSize = '11k';
         $element->relatedInformationPresent = TRUE;
-        $element->hostName = 'www.phpunit.de';
+        $element->hostName = 'phpunit.de';
         $element->directoryCategory = $directoryCategory;
         $element->directoryTitle = '';
 
@@ -1009,7 +1009,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
     <para>
       Simply add a dependency on <literal>mikey179/vfsStream</literal> to your
       project's <literal>composer.json</literal> file if you use
-      <ulink url="http://getcomposer.org/">Composer</ulink> to manage the
+      <ulink url="https://getcomposer.org/">Composer</ulink> to manage the
       dependencies of your project. Here is a minimal example of a
       <literal>composer.json</literal> file that just defines a development-time
       dependency on PHPUnit 4.3 and vfsStream:


### PR DESCRIPTION
Caused by https://github.com/sebastianbergmann/phpunit-website/issues/18

Not sure whether the intention was to redirect all HTTP to HTTPS, but that's the case now, and the mixed content errors occur on HTTPS either way.

While being there, grepped for `http:` within manual pages and adjusted them.
