### PR TITLE
[ja] Minor wording improvement(textui command-line option)

### DIFF
--- a/src/3.7/ja/textui.xml
+++ b/src/3.7/ja/textui.xml
@@ -98,7 +98,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.0/ja/textui.xml
+++ b/src/4.0/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.1/ja/textui.xml
+++ b/src/4.1/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.2/ja/textui.xml
+++ b/src/4.2/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.3/ja/textui.xml
+++ b/src/4.3/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.4/ja/textui.xml
+++ b/src/4.4/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.5/ja/textui.xml
+++ b/src/4.5/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。

--- a/src/4.6/ja/textui.xml
+++ b/src/4.6/ja/textui.xml
@@ -107,7 +107,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <section id="textui.clioptions">
-    <title>Command-Line switches</title>
+    <title>コマンドラインオプション</title>
 
     <para>
       以下のコードで、コマンドライン版テストランナーのオプションの一覧を見てみましょう。


### PR DESCRIPTION
@m-takagi 

[ja] Fixes "switches" to "option" in 3.7 - 4.6.

ref. 
version 3.6
`Command-Line Switches`
https://phpunit.de/manual/3.6/en/textui.html#textui.clioptions

version 3.7 later
`Command-Line Options`
https://phpunit.de/manual/3.7/en/textui.html#textui.clioptions
