### PR TITLE
a plural has no 'a' set before it

### DIFF
--- a/src/4.6/en/writing-tests-for-phpunit.xml
+++ b/src/4.6/en/writing-tests-for-phpunit.xml
@@ -1071,7 +1071,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Edge cases</title>
 
       <para>
-        When a comparison fails PHPUnit creates a textual representations of the
+        When a comparison fails PHPUnit creates textual representations of the
         input values and compares those. Due to that implementation a diff
         might show more problems than actually exist.
       </para>


### PR DESCRIPTION
When a comparison fails PHPUnit creates >>a<< textual representations of the input values.
Delete the 'a'.
