### PR TITLE
"an" is only used before a vocal

### DIFF
--- a/src/4.6/en/textui.xml
+++ b/src/4.6/en/textui.xml
@@ -204,7 +204,7 @@ Miscellaneous Options:
             <literal>UnitTest</literal> must be either a class that inherits
             from <literal>PHPUnit_Framework_TestCase</literal> or a class that
             provides a <literal>public static suite()</literal> method which
-            returns an <literal>PHPUnit_Framework_Test</literal> object, for
+            returns a <literal>PHPUnit_Framework_Test</literal> object, for
             example an instance of the
             <literal>PHPUnit_Framework_TestSuite</literal> class.
           </para>


### PR DESCRIPTION
method which returns an PHPUnit_Framework_Test object

==> a PHPUnit_Framework_Test object
