### PR TITLE
missing article

### DIFF
--- a/src/4.6/en/fixtures.xml
+++ b/src/4.6/en/fixtures.xml
@@ -40,7 +40,7 @@
 
   <para>
     In <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> we
-    used the producer-consumer relationship between tests to share fixture. This
+    used the producer-consumer relationship between tests to share a fixture. This
     is not always desired or even possible. <xref linkend="fixtures.examples.StackTest.php"/>
     shows how we can write the tests of the <literal>StackTest</literal> in such
     a way that not the fixture itself is reused but the code that creates it.


### PR DESCRIPTION
 we used the producer-consumer relationship between tests to share ==> a fixture.
