### PR TITLE
Use plural 'tests'

### DIFF
--- a/src/4.6/en/organizing-tests.xml
+++ b/src/4.6/en/organizing-tests.xml
@@ -95,7 +95,7 @@ OK (2 test, 2 assertions)</screen>
     <note>
       <para>
         A drawback of this approach is that we have no control over the order in
-        which the test are run. This can lead to problems with regard to test
+        which the tests are run. This can lead to problems with regard to test
         dependencies, see <xref linkend="writing-tests-for-phpunit.test-dependencies"/>.
         In the next section you will see how you can make the test execution
         order explicit by using the XML configuration file.


### PR DESCRIPTION
we have no control over the order in which the >>tests<< are run
