### PR TITLE
$user and $password must not be empty

### DIFF
--- a/src/4.6/en/database.xml
+++ b/src/4.6/en/database.xml
@@ -933,6 +933,8 @@ class MySqlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     public function getConnection()
     {
         $database = 'my_database';
+        $user = 'my_user';
+        $password = 'my_password';
         $pdo = new PDO('mysql:...', $user, $password);
         return $this->createDefaultDBConnection($pdo, $database);
     }


### PR DESCRIPTION
You must initialzed the local variables $user and $password.