### PR TITLE
too many verbs "are"

### DIFF
--- a/src/4.6/en/database.xml
+++ b/src/4.6/en/database.xml
@@ -1136,7 +1136,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
 ?>]]></programlisting>
       <para>
         Except the <literal>getTableMetaData()</literal> method it is
-        pretty self-explainatory. The methods are used are all required for
+        pretty self-explainatory. The used methods are all required for
         the different assertions of the Database Extension that are
         explained in the next chapter. The
         <literal>getTableMetaData()</literal> method has to return an


### PR DESCRIPTION
"The methods are used are all required for the different assertions of the Database Extension that are explained in the next chapter."

==> The used methods