### PR TITLE
misspelling

### DIFF
--- a/src/4.6/en/test-doubles.xml
+++ b/src/4.6/en/test-doubles.xml
@@ -18,7 +18,7 @@
       environment. This could be because they aren't available, they will not
       return the results needed for the test or because executing them would
       have undesirable side effects. In other cases, our test strategy requires
-      us to have more control or visibility of the internal behavior of the SUT.
+      us to have more control or visibility of the internal behaviour of the SUT.
     </para>
 
     <para>
@@ -56,7 +56,7 @@
       Please note that <literal>final</literal>, <literal>private</literal>
       and <literal>static</literal> methods cannot be stubbed or mocked. They
       are ignored by PHPUnit's test double functionality and retain their
-      original behavior.
+      original behaviour.
     </para>
   </note>
 
@@ -67,7 +67,7 @@
         Please pay attention to the fact that the parameters managing has been changed.
         The previous implementation clones all object parameters. It did not allow to check whether the same object was passed to method or not.
         <xref linkend="test-doubles.mock-objects.examples.clone-object-parameters-usecase.php" /> shows where the new implementation could be useful.
-        <xref linkend="test-doubles.mock-objects.examples.enable-clone-object-parameters.php" /> shows how to switch back to previous behavior.
+        <xref linkend="test-doubles.mock-objects.examples.enable-clone-object-parameters.php" /> shows how to switch back to previous behaviour.
     </para>
   </warning>
 
@@ -78,7 +78,7 @@
       <indexterm><primary>Stub</primary></indexterm>
 
       The practice of replacing an object with a test double that (optionally)
-      returns configured return values is refered to as
+      returns configured return values is referred to as
       <emphasis>stubbing</emphasis>. You can use a <emphasis>stub</emphasis> to
       "replace a real component on which the SUT depends so that the test has a
       control point for the indirect inputs of the SUT. This allows the test to
@@ -95,7 +95,7 @@
       object that looks like an object of <literal>SomeClass</literal>
       (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). We then
       use the <ulink url="http://martinfowler.com/bliki/FluentInterface.html">Fluent Interface</ulink>
-      that PHPUnit provides to specify the behavior for the stub. In essence,
+      that PHPUnit provides to specify the behaviour of the stub. In essence,
       this means that you do not need to create several temporary objects and
       wire them together afterwards. Instead, you chain method calls as shown in
       the example. This leads to more readable and "fluent" code.
@@ -144,7 +144,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
     <para>
       "Behind the scenes", PHPUnit automatically generates a new PHP class that
-      implements the desired behavior when the <literal>getMock()</literal>
+      implements the desired behaviour when the <literal>getMock()</literal>
       method is used.
     </para>
 
@@ -188,7 +188,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> can be called on the Mock Builder object to specify the methods that are to be replaced with a configurable test double. The behavior of the other methods is not changed. If you call <literal>setMethods(null)</literal>, then no methods will be replaced.</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> can be called on the Mock Builder object to specify the methods that are to be replaced with a configurable test double. The behaviour of the other methods is not changed. If you call <literal>setMethods(null)</literal>, then no methods will be replaced.</para></listitem>
       <listitem><para><literal>setConstructorArgs(array $args)</literal> can be called to provide a parameter array that is passed to the original class' constructor (which is not replaced with a dummy implementation by default).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> can be used to specify a class name for the generated test double class.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> can be used to disable the call to the original class' constructor.</para></listitem>

--- a/src/4.6/en/test-doubles.xml
+++ b/src/4.6/en/test-doubles.xml
@@ -461,7 +461,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     <para>
       The practice of replacing an object with a test double that verifies
       expectations, for instance asserting that a method has been called, is
-      refered to as <emphasis>mocking</emphasis>.
+      referred to as <emphasis>mocking</emphasis>.
     </para>
 
     <para>


### PR DESCRIPTION
In British English you write "behaviour".
