### PR TITLE
PHP comment broken

### DIFF
--- a/src/4.6/en/writing-tests-for-phpunit.xml
+++ b/src/4.6/en/writing-tests-for-phpunit.xml
@@ -572,7 +572,7 @@ class ExceptionTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException              InvalidArgumentException
-     * @expectedExceptionMessageRegExp /Right.*/
+     * @expectedExceptionMessageRegExp /Right.* /
      */
     public function testExceptionMessageMatchesRegExp()
     {


### PR DESCRIPTION
This line breaks the comments of PHP.

* @expectedExceptionMessageRegExp /Right.* /

	[09-Jan-2015 11:05:10 UTC] PHP Parse error:  syntax error, unexpected '*', expecting function (T_FUNCTION) in /var/www/html/phpunit/franz/ExceptionTest.php on line 16
	[09-Jan-2015 11:05:10 UTC] PHP Stack trace:
	[09-Jan-2015 11:05:10 UTC] PHP   1. {main}() /usr/local/bin/phpunit:0
	[09-Jan-2015 11:05:10 UTC] PHP   2. PHPUnit_TextUI_Command::main() /usr/local/bin/phpunit:612
	[09-Jan-2015 11:05:10 UTC] PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:138
	[09-Jan-2015 11:05:10 UTC] PHP   4. PHPUnit_Runner_BaseTestRunner->getTest() phar:///usr/local/bin/phpunit/phpunit/TextUI/Command.php:160
	[09-Jan-2015 11:05:10 UTC] PHP   5. PHPUnit_Runner_BaseTestRunner->loadSuiteClass() phar:///usr/local/bin/phpunit/phpunit/Runner/BaseTestRunner.php:105
	[09-Jan-2015 11:05:10 UTC] PHP   6. PHPUnit_Runner_StandardTestSuiteLoader->load() phar:///usr/local/bin/phpunit/phpunit/Runner/BaseTestRunner.php:160
	[09-Jan-2015 11:05:10 UTC] PHP   7. PHPUnit_Util_Fileloader::checkAndLoad() phar:///usr/local/bin/phpunit/phpunit/Runner/StandardTestSuiteLoader.php:78
	[09-Jan-2015 11:05:10 UTC] PHP   8. PHPUnit_Util_Fileloader::load() phar:///usr/local/bin/phpunit/phpunit/Util/Fileloader.php:77