### PR TITLE
Plural: in all the previous examples

### DIFF
--- a/src/4.6/en/database.xml
+++ b/src/4.6/en/database.xml
@@ -1260,7 +1260,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
         using the Connection API. Say we wanted to check that after
         insertion of a row into our guestbook we not only have the two
         initial entries that have accompanied us in all the previous
-        example, but a third one:
+        examples, but a third one:
       </para>
       <programlisting><![CDATA[<?php
 class GuestbookTest extends PHPUnit_Extensions_Database_TestCase


### PR DESCRIPTION
wrong: "in all the previous example"