### PR TITLE
Proposed: Add example shell script to Installation documentation

### DIFF
--- a/src/4.5/en/installation.xml
+++ b/src/4.5/en/installation.xml
@@ -251,6 +251,69 @@ Primary key fingerprint: D840 6D0D 8294 7747 2937  7831 4AA3 9408 6372 C20A]]></
         authenticity of a public key, however, is outside the scope of this
         documentation.
       </para>
+      
+      <para>
+        It may be prudent to create a shell script to manage PHPUnit installation
+        that verifies the GnuPG signature before running your test suite. For
+        example:
+      </para>
+      
+      <screen><![CDATA[
+#!/usr/bin/env bash
+clean=1 # Delete phpunit.phar after the tests are complete?
+aftercmd="php phpunit.phar --bootstrap bootstrap.php src/tests"
+gpg --fingerprint D8406D0D82947747293778314AA394086372C20A
+if [ $? -ne 0 ]; then
+    echo -e "\033[33mDownloading PGP Public Key...\033[0m"
+    gpg --recv-keys D8406D0D82947747293778314AA394086372C20A
+    # Sebastian Bergmann <sb@sebastian-bergmann.de>
+    gpg --fingerprint D8406D0D82947747293778314AA394086372C20A
+    if [ $? -ne 0 ]; then
+        echo -e "\033[31mCould not download PGP public key for verification\033[0m"
+        exit
+    fi
+fi
+
+if [ "$clean" -eq 1 ]; then
+    # Let's clean them up, if they exist
+    if [ -f phpunit.phar ]; then
+        rm -f phpunit.phar
+    fi
+    if [ -f phpunit.phar.asc ]; then
+        rm -f phpunit.phar.asc
+    fi
+fi
+
+# Let's grab the latest release and its signature
+if [ ! -f phpunit.phar ]; then
+    wget https://phar.phpunit.de/phpunit.phar
+fi
+if [ ! -f phpunit.phar.asc ]; then
+    wget https://phar.phpunit.de/phpunit.phar.asc
+fi
+
+# Verify before running
+gpg --verify phpunit.phar.asc phpunit.phar
+if [ $? -eq 0 ]; then
+    echo
+    echo -e "\033[33mBegin Unit Testing\033[0m"
+    # Run the testing suite
+    `$after_cmd`
+    # Cleanup
+    if [ "$clean" -eq 1 ]; then
+        echo -e "\033[32mCleaning Up!\033[0m"
+        rm -f phpunit.phar
+        rm -f phpunit.phar.asc
+    fi
+else
+    echo
+    chmod -x phpunit.phar
+    mv phpunit.phar /tmp/bad-phpunit.phar
+    mv phpunit.phar.asc /tmp/bad-phpunit.phar.asc
+    echo -e "\033[31mSignature did not match! PHPUnit has been moved to /tmp/bad-phpunit.phar\033[0m"
+    exit 1
+fi
+      ]]></screen>
     </section>
   </section>
 


### PR DESCRIPTION
Give a shell script that provides automated GPG signature verification. I've used these internally in my own projects. This allows me to always have the latest versions while maintaining confidence that I'm not about to execute `malicious.phar` if the phpunit webserver was ever breached.