### PR TITLE
About using named datasets in data providers

### DIFF
--- a/src/4.6/en/writing-tests-for-phpunit.xml
+++ b/src/4.6/en/writing-tests-for-phpunit.xml
@@ -307,6 +307,54 @@ Failed asserting that 2 matches expected 3.
 FAILURES!
 Tests: 4, Assertions: 4, Failures: 1.]]></screen>
     </example>
+    
+    <para>
+      When using a large number of datasets it's useful to name each one with string key instead of default numeric.
+      Output will be more verbose as it'll contain that name of a dataset that breaks a test.
+    </para>
+
+    <example id="writing-tests-for-phpunit.data-providers.examples.DataTest1.php">
+      <title>Using a data provider with named datasets</title>
+      <programlisting><![CDATA[<?php
+class DataTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider additionProvider
+     */
+    public function testAdd($a, $b, $expected)
+    {
+        $this->assertEquals($expected, $a + $b);
+    }
+
+    public function additionProvider()
+    {
+        return array(
+          'adding zeros' => array(0, 0, 0),
+          'zero plus one' => array(0, 1, 1),
+          'one plus zero' => array(1, 0, 1),
+          'one plus one' => array(1, 1, 3)
+        );
+    }
+}
+?>]]></programlisting>
+
+    <screen><userinput>phpunit DataTest</userinput><![CDATA[
+PHPUnit 4.6.0 by Sebastian Bergmann and contributors.
+
+...F
+
+Time: 0 seconds, Memory: 5.75Mb
+
+There was 1 failure:
+
+1) DataTest::testAdd with data set "one plus one" (1, 1, 3)
+Failed asserting that 2 matches expected 3.
+
+/home/sb/DataTest.php:9
+
+FAILURES!
+Tests: 4, Assertions: 4, Failures: 1.]]></screen>
+    </example>
 
     <example id="writing-tests-for-phpunit.data-providers.examples.DataTest2.php">
       <title>Using a data provider that returns an Iterator object</title>


### PR DESCRIPTION
Looks like it's not so obviuos that you can use string keys for naming datasets. So I think adding this to docs will be useful.

And sorry for my poor english, correct it like you want :)