### PR TITLE
Change static methods called non-statically

### DIFF
--- a/src/4.6/en/annotations.xml
+++ b/src/4.6/en/annotations.xml
@@ -267,7 +267,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
@@ -797,7 +797,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.6/en/assertions.xml
+++ b/src/4.6/en/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -99,7 +99,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.6/en/code-coverage-analysis.xml
+++ b/src/4.6/en/code-coverage-analysis.xml
@@ -300,7 +300,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -313,7 +313,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -331,7 +331,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -346,11 +346,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -360,11 +360,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@coversNothing</primary></indexterm>
 
-      It is also possible to specify that a test should not cover 
-      <emphasis>any</emphasis> method by using the 
+      It is also possible to specify that a test should not cover
+      <emphasis>any</emphasis> method by using the
       <literal>@coversNothing</literal> annotation (see
       <xref linkend="appendixes.annotations.coversNothing"/>). This can be
-      helpful when writing integration tests to make sure you only 
+      helpful when writing integration tests to make sure you only
       generate code coverage with unit tests.
     </para>
 
@@ -388,7 +388,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -413,7 +413,7 @@ if (false) this_function_call_shows_up_as_covered();
 // Due to how code coverage works internally these two lines are special.
 // This line will show up as non executable
 if (false)
-    // This line will show up as covered because it is actually the 
+    // This line will show up as covered because it is actually the
     // coverage of the if statement in the line above that gets shown here!
     will_also_show_up_as_coveraged();
 
@@ -422,6 +422,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.6/en/database.xml
+++ b/src/4.6/en/database.xml
@@ -220,7 +220,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -1112,8 +1112,8 @@ interface PHPUnit_Extensions_Database_DataSet_IDataSet extends IteratorAggregate
         TestCase to check for dataset quality. From the
         <literal>IteratorAggregate</literal> interface the IDataSet
         inherits the <literal>getIterator()</literal> method to iterate
-        over all tables of the dataset. The reverse iterator allows PHPUnit to 
-        truncate tables opposite the order they were created to satisfy foreign 
+        over all tables of the dataset. The reverse iterator allows PHPUnit to
+        truncate tables opposite the order they were created to satisfy foreign
         key constraints.
       </para>
       <para>
@@ -1237,7 +1237,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1267,12 +1267,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1303,7 +1303,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1365,7 +1365,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1390,7 +1390,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1408,7 +1408,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/en/fixtures.xml
+++ b/src/4.6/en/fixtures.xml
@@ -68,21 +68,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -146,13 +146,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.6/en/incomplete-and-skipped-tests.xml
+++ b/src/4.6/en/incomplete-and-skipped-tests.xml
@@ -53,7 +53,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // Optional: Test anything here, if you want.
-        $this->assertTrue(TRUE, 'This should already work.');
+        self::assertTrue(TRUE, 'This should already work.');
 
         // Stop here and mark this test as incomplete.
         $this->markTestIncomplete(

--- a/src/4.6/en/selenium.xml
+++ b/src/4.6/en/selenium.xml
@@ -12,16 +12,16 @@
       <ulink url="http://seleniumhq.org/">Selenium Server</ulink> is a
       test tool that allows you to write automated user-interface tests for
       web applications in any programming language against any HTTP website
-      using any mainstream browser. It performs automated browser tasks 
+      using any mainstream browser. It performs automated browser tasks
       by driving the browser's process through the operating system.
-      Selenium tests run directly in a browser, just as real users do. These 
-      tests can be used for both <emphasis>acceptance testing</emphasis> 
+      Selenium tests run directly in a browser, just as real users do. These
+      tests can be used for both <emphasis>acceptance testing</emphasis>
       (by performing higher-level tests on the integrated system instead of
-      just testing each unit of the system independently) and <emphasis>browser 
+      just testing each unit of the system independently) and <emphasis>browser
       compatibility testing</emphasis> (by testing the web application on
       different operating systems and browsers).
     </para>
-    
+
     <para>
       The only supported scenario of PHPUnit_Selenium is that of a Selenium 2.x
       server. The server can be accessed through the classic Selenium RC Api, already present in 1.x, or with the WebDriver API (partially implemented) from PHPUnit_Selenium 1.2.
@@ -31,7 +31,7 @@
     </para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>Installation</title>
 
@@ -88,7 +88,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -115,7 +115,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-    <para>    
+    <para>
       The commands of Selenium2TestCase are implemented via __call(). Please refer to <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">the end-to-end test for PHPUnit_Extensions_Selenium2TestCase</ulink> for a list of every supported feature.
     </para>
   </section>
@@ -154,7 +154,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -254,7 +254,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -335,7 +335,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/en/test-doubles.xml
+++ b/src/4.6/en/test-doubles.xml
@@ -136,7 +136,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Calling $stub->doSomething() will now return
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -177,7 +177,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Calling $stub->doSomething() will now return
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -233,10 +233,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') returns 'foo'
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') returns 'bar'
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -271,7 +271,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() returns $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -315,8 +315,8 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() returns different values depending on
         // the provided arguments.
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -353,7 +353,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) returns str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -390,9 +390,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() returns a different value each time
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -921,7 +921,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -959,7 +959,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -1034,7 +1034,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() will now return a stubbed result and
          * the web service's doGoogleSearch() method will not be invoked.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1135,10 +1135,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1184,10 +1184,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/en/textui.xml
+++ b/src/4.6/en/textui.xml
@@ -273,7 +273,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -405,7 +405,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.6/en/writing-tests-for-phpunit.xml
+++ b/src/4.6/en/writing-tests-for-phpunit.xml
@@ -27,14 +27,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -97,7 +97,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -108,8 +108,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -119,8 +119,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -152,7 +152,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -209,13 +209,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -225,7 +225,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -275,7 +275,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -320,7 +320,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -415,13 +415,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -432,7 +432,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -837,7 +837,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -981,7 +981,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1032,7 +1032,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1087,7 +1087,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.6/fr/annotations.xml
+++ b/src/4.6/fr/annotations.xml
@@ -9,7 +9,7 @@
     Une annotation est une forme spéciale de méta donnée syntaxique qui peut
     être ajoutée au code source de certains langages de programmation. Bien que
     PHP n'ait pas de fonctionnalité dédiée à l'annotation du code source, l'utilisation
-    d'étiquettes telles que <literal>@annotation paramètres</literal> dans les blocs de documentation 
+    d'étiquettes telles que <literal>@annotation paramètres</literal> dans les blocs de documentation
     s'est établi dans la communauté PHP pour annoter le code source. En PHP, les blocs de
     documentation sont réflexifs: ils peuvent être accédés via la méthode de l'API de réflexivité
     <literal>getDocComment()</literal> au niveau des fonctions, classes, méthodes et attributs.
@@ -92,7 +92,7 @@ class MonTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
 
-      L'annotation <literal>@backupStaticAttributes</literal> peut également être utilisée au 
+      L'annotation <literal>@backupStaticAttributes</literal> peut également être utilisée au
       niveau d'une méthode de test. Ceci permet une configuration plus fine des opérations
       de sauvegarde et de restauration: <programlisting>/**
  * @backupStaticAttributes disabled
@@ -118,8 +118,8 @@ class MonTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>@codeCoverageIgnoreStart</primary></indexterm>
       <indexterm><primary>@codeCoverageIgnoreEnd</primary></indexterm>
 
-      Les annotations <literal>@codeCoverageIgnore</literal>, 
-      <literal>@codeCoverageIgnoreStart</literal> et 
+      Les annotations <literal>@codeCoverageIgnore</literal>,
+      <literal>@codeCoverageIgnoreStart</literal> et
       <literal>@codeCoverageIgnoreEnd</literal> peuvent être utilisées pour
       exclure des lignes de code de l'analyse de couverture.
     </para>
@@ -137,18 +137,18 @@ class MonTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Code Coverage</primary></indexterm>
       <indexterm><primary>@covers</primary></indexterm>
 
-      L'annotation <literal>@covers</literal> peut être utilisée dans le code de test pour 
+      L'annotation <literal>@covers</literal> peut être utilisée dans le code de test pour
       indique quelle(s) méthode(s) un test veut tester:<programlisting>/**
  * @covers CompteBancaire::getBalance
  */
 public function testBalanceEstInitiallementAZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
     <para>
-      Si elle est fournie, seule l'information de couverture de code pour 
+      Si elle est fournie, seule l'information de couverture de code pour
       la(les) méthode(s) sera prise en considération.
     </para>
 
@@ -216,7 +216,7 @@ public function testBalanceEstInitiallementAZero()
       <indexterm><primary>@coversNothing</primary></indexterm>
 
       L'annotation <literal>@coversNothing</literal> peut être utilisée dans le code de test
-      pour indiquer qu'aucune information de couverture de code ne sera enregistrée pour le 
+      pour indiquer qu'aucune information de couverture de code ne sera enregistrée pour le
       cas de test annoté.
     </para>
 
@@ -226,7 +226,7 @@ public function testBalanceEstInitiallementAZero()
         pour un exemple.
     </para>
 
-    <para>    
+    <para>
         L'annotation peut être utilisée au niveau de la classe et de la méthode
         et sera surchargée par toute étiquette <literal>@covers</literal>.
     </para>
@@ -247,7 +247,7 @@ public function testBalanceEstInitiallementAZero()
     </para>
 
     <para>
-      Voir <xref linkend="writing-tests-for-phpunit.data-providers"/> pour plus de 
+      Voir <xref linkend="writing-tests-for-phpunit.data-providers"/> pour plus de
       détails.
     </para>
   </section>
@@ -297,7 +297,7 @@ public function testBalanceEstInitiallementAZero()
     <para>
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
-      L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec 
+      L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
       <literal>@expectedException</literal> permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
@@ -315,25 +315,25 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
 	Pour faciliter les tests et réduire la duplication, un raccourci peut être utilisé pour
-    indiquer une constante de classe comme un 
+    indiquer une constante de classe comme un
     <literal>@expectedExceptionCode</literal> en utilisant la syntaxe
     "<literal>@expectedExceptionCode ClassName::CONST</literal>".
-                                                                        
-    <programlisting>class MonTest extends PHPUnit_Framework_TestCase 
-  {                                                                      
-      /**                                                                
-        * @expectedException     MonException                             
-        * @expectedExceptionCode MaClasse::CODE_ERREUR                      
-        */                                                               
-      public function testExceptionAUnCodeErreur20()                      
-      {                                                                  
+
+    <programlisting>class MonTest extends PHPUnit_Framework_TestCase
+  {
+      /**
+        * @expectedException     MonException
+        * @expectedExceptionCode MaClasse::CODE_ERREUR
+        */
+      public function testExceptionAUnCodeErreur20()
+      {
         throw new MonException('Un message', 20);
-      }                                                                  
-  }                                                                      
-  class MaClasse                                                          
-  {                                                                      
-      const CODE_ERREUR = 20;                                              
-  }</programlisting>     
+      }
+  }
+  class MaClasse
+  {
+      const CODE_ERREUR = 20;
+  }</programlisting>
     </para>
 
   </section>
@@ -345,7 +345,7 @@ public function testBalanceEstInitiallementAZero()
       <indexterm><primary>@expectedExceptionMessage</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionMessage</literal> fonctionne de manière
-      similaire à <literal>@expectedExceptionCode</literal> en ce qu'il vous permet de 
+      similaire à <literal>@expectedExceptionCode</literal> en ce qu'il vous permet de
       faire une assertion sur le message d'erreur d'une exception.
 
       <programlisting>class MonTest extends PHPUnit_Framework_TestCase
@@ -361,7 +361,7 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
       Le message attendu peut être une partie d'une chaîne d'un message d'exception.
-      Ceci peut être utile pour faire une assertion sur le fait qu'un nom ou un 
+      Ceci peut être utile pour faire une assertion sur le fait qu'un nom ou un
       paramètre qui est passé s'affiche dans une exception sans fixer la totalité
       du message d'exception dans le test.
 
@@ -379,7 +379,7 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
 	Pour faciliter les tests et réduire la duplication, un raccourci peut être utilisé pour
-    indiquer une constante de classe comme un 
+    indiquer une constante de classe comme un
     <literal>@expectedExceptionCode</literal> en utilisant la syntaxe
     "<literal>@expectedExceptionCode ClassName::CONST</literal>".
 
@@ -414,10 +414,10 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
     </para>
 
-    <para> 
+    <para>
       Des tests peuvent être sélectionnés pour l'exécution en se basant sur les groupes
       en utilisant les options <literal>--group</literal> et <literal>--exclude-group</literal>
-      du lanceur de test en ligne de commandes ou en utilisant les directives respectives du 
+      du lanceur de test en ligne de commandes ou en utilisant les directives respectives du
       fichier de configuration XML.
     </para>
   </section>
@@ -474,7 +474,7 @@ public function testBalanceEstInitiallementAZero()
  */
 public function balanceInitialeDoitEtre0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.6/fr/code-coverage-analysis.xml
+++ b/src/4.6/fr/code-coverage-analysis.xml
@@ -18,7 +18,7 @@
     <indexterm><primary>Couverture de code</primary></indexterm>
 
     Dans ce chapitre, vous apprendrez tout sur la fonctionnalité de couverture
-    de code de PHPUnit qui fournit une vision interne des parties du code de 
+    de code de PHPUnit qui fournit une vision interne des parties du code de
     production qui sont exécutées quand les tests sont exécutés. Cela aide à
     répondre à des questions comme :
   </para>
@@ -36,7 +36,7 @@
   </itemizedlist>
 
   <para>
-    Un exemple de ce que peuvent signifier des statistiques de couverture de code est, 
+    Un exemple de ce que peuvent signifier des statistiques de couverture de code est,
     s'il y a une méthode avec 100 lignes de code, et seulement 75 de ces lignes sont réellement
     exécutées quand les tests sont lancés, alors la méthode est considérée comme ayant une couverture
     de code de 75 pour cent.
@@ -45,7 +45,7 @@
   <para>
     <indexterm><primary>Xdebug</primary></indexterm>
 
-    La fonctionnalité de couverture de code de PHPUnit fait usage du composant 
+    La fonctionnalité de couverture de code de PHPUnit fait usage du composant
     <ulink url="http://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
     qui, à son tour, tire partie de la fonctionnalité de couverture d'instructions
     fournie par l'extension <ulink url="http://www.xdebug.org/">Xdebug</ulink>
@@ -96,9 +96,9 @@ Generating report, this may take a moment.</screen>
   </figure>
 
   <para>
-    Le rapport de couverture de code de notre exemple <literal>CompteBancaire</literal> 
+    Le rapport de couverture de code de notre exemple <literal>CompteBancaire</literal>
     montre que nous n'avons actuellement aucun test qui appellent les méthodes
-    <literal>setBalance()</literal>, <literal>deposerArgent()</literal> et 
+    <literal>setBalance()</literal>, <literal>deposerArgent()</literal> et
     <literal>retirerArgent()</literal> avec des valeurs acceptables.
     <xref linkend="code-coverage-analysis.examples.BankAccountTest.php" />
     montre un test qui peut être ajouté à la classe de cas de test
@@ -117,11 +117,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
 
     public function testDeposerRetirerArgent()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->deposerArgent(1);
-        $this->assertEquals(1, $this->compte_bancaire->getBalance());
+        self::assertEquals(1, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->retirerArgent(1);
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -149,7 +149,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       L'annotation <literal>@covers</literal> (voir
       <xref linkend="appendixes.annotations.covers.tables.annotations"/>) peut être
       utilisée dans le code de test pour indiquer quelle(s) méthode(s) une méthode de test
-      veut test. Si elle est fournie, seules les informations de couverture de code pour 
+      veut test. Si elle est fournie, seules les informations de couverture de code pour
       la(les) méthode(s) indiquées seront prises en considération.
       <xref linkend="code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php"/>
       montre un exemple.
@@ -174,7 +174,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceEstInitialementZero()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 
     /**
@@ -187,7 +187,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
         }
 
         catch (CompteBancaireException $e) {
-            $this->assertEquals(0, $this->compte_bancaire->getBalance());
+            self::assertEquals(0, $this->compte_bancaire->getBalance());
 
             return;
         }
@@ -205,7 +205,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
         }
 
         catch (CompteBancaireException $e) {
-            $this->assertEquals(0, $this->compte_bancaire->getBalance());
+            self::assertEquals(0, $this->compte_bancaire->getBalance());
 
             return;
         }
@@ -221,11 +221,11 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
 
     public function testDeposerArgent()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->deposerArgent(1);
-        $this->assertEquals(1, $this->compte_bancaire->getBalance());
+        self::assertEquals(1, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->retirerArgent(1);
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -261,7 +261,7 @@ class IntegrationLivreDOrTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("livre_d_or");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -282,8 +282,8 @@ class IntegrationLivreDOrTest extends PHPUnit_Extensions_Database_TestCase
       voulez ignorer lors de l'analyse de couverture de code. PHPUnit vous permet
       de faire cela en utilisant les annotations
       <literal>@codeCoverageIgnore</literal>,
-      <literal>@codeCoverageIgnoreStart</literal> et 
-      <literal>@codeCoverageIgnoreEnd</literal> comme montré dans 
+      <literal>@codeCoverageIgnoreStart</literal> et
+      <literal>@codeCoverageIgnoreEnd</literal> comme montré dans
       <xref linkend="code-coverage-analysis.ignoring-code-blocks.examples.Sample.php"/>.
     </para>
 
@@ -342,7 +342,7 @@ if (FALSE) {
     <para>
       La liste noire est pré-remplie avec tous les fichiers de code source de
       PHPUnit lui-même ainsi que les tests. Quand la liste blanche est vide (par
-      défaut), le filtrage par liste noire est utilisé. Quand la liste blanche 
+      défaut), le filtrage par liste noire est utilisé. Quand la liste blanche
       n'est pas vide, le filtrage par liste blanche est utilisé. Chaque fichier
       de la liste blanche est ajouté au rapport de couverture de code, qu'il ait
       été exécuté ou pas. Toutes les lignes d'un tel fichier, incluant celles qui
@@ -350,7 +350,7 @@ if (FALSE) {
     </para>
 
     <para>
-      Quand vous configurez 
+      Quand vous configurez
       <literal>processUncoveredFilesFromWhitelist="true"</literal>
       dans votre configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.blacklist-whitelist"/>) alors ces fichiers
@@ -369,8 +369,8 @@ if (FALSE) {
 
     <para>
       Le fichier de configuration XML de PHPUnit (voir <xref linkend="appendixes.configuration.blacklist-whitelist"/>)
-      peut être utilisé pour contrôler les listes noires et blanches. Utiliser une liste 
-      blanche est recommandé comme meilleure pratique pour contrôler la liste des fichiers inclus dans 
+      peut être utilisé pour contrôler les listes noires et blanches. Utiliser une liste
+      blanche est recommandé comme meilleure pratique pour contrôler la liste des fichiers inclus dans
       le rapport de couverture de code.
     </para>
   </section>
@@ -394,8 +394,8 @@ if(false) cet_appel_de_fonction_sera_compte_comme_couvert();
 // Du fait de la façon dont la couverture de code fonctionne en interne, ces deux lignes sont spéciales.
 / Cette ligne sera comptée comme non exécutable
 if(false)
-    // Cette ligne sera comptée comme couverte car c'est en fait la 
-    // couverture de l'instruction if dans la ligne au-dessus qui 
+    // Cette ligne sera comptée comme couverte car c'est en fait la
+    // couverture de l'instruction if dans la ligne au-dessus qui
     // sera montrée ici !
     sera_egalement_comptee_comme_couverte();
 
@@ -404,8 +404,8 @@ if(false) {
     cet_appel_ne_sera_jamais_compte_comme_couvert();
 }
 ?>]]></programlisting>
-    </example>      
-        
+    </example>
+
   </section>
 
 </chapter>

--- a/src/4.6/fr/fixtures.xml
+++ b/src/4.6/fr/fixtures.xml
@@ -18,7 +18,7 @@
     La plupart du temps, cependant, la fixture sera beaucoup plus complexe
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
-    dans le bruit de configuration de la fixture. Ce problème s'aggrave quand 
+    dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
     vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
@@ -46,7 +46,7 @@
     que ce n'est pas la fixture elle-même qui est réutilisée mais le code qui l'a créée.
     D'abord nous déclarons la variable d'instance, <literal>$pile</literal>, que nous
     allons utiliser à la place d'une variable locale à la méthode. Puis nous plaçons
-    la création de la fixture <literal>tableau</literal> dans la méthode 
+    la création de la fixture <literal>tableau</literal> dans la méthode
     <literal>setUp()</literal>. Enfin, nous supprimons le code redondant des méthodes
     de test et nous utilisons la variable d'instance nouvellement introduite.
     <literal>$this->pile</literal>, à la place de la variable locale à la méthode
@@ -67,21 +67,21 @@ class PileTest extends PHPUnit_Framework_TestCase
 
     public function testVide()
     {
-        $this->assertTrue(empty($this->pile));
+        self::assertTrue(empty($this->pile));
     }
 
     public function testPush()
     {
         array_push($this->pile, 'foo');
-        $this->assertEquals('foo', $this->pile[count($this->pile)-1]);
-        $this->assertFalse(empty($this->pile));
+        self::assertEquals('foo', $this->pile[count($this->pile)-1]);
+        self::assertFalse(empty($this->pile));
     }
 
     public function testPop()
     {
         array_push($this->pile, 'foo');
-        $this->assertEquals('foo', array_pop($this->pile));
-        $this->assertTrue(empty($this->pile));
+        self::assertEquals('foo', array_pop($this->pile));
+        self::assertTrue(empty($this->pile));
     }
 }
 ?>]]></programlisting>
@@ -110,7 +110,7 @@ class PileTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>onNotSuccessfulTest()</primary></indexterm>
 
     De plus, les méthodes canevas <literal>setUpBeforeClass()</literal> et
-    <literal>tearDownAfterClass()</literal> sont appelées respectivement avant 
+    <literal>tearDownAfterClass()</literal> sont appelées respectivement avant
     que le premier test de la classe de cas de test ne soit exécuté et après
     que le dernier test de la classe de test a été exécuté.
   </para>
@@ -145,13 +145,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()
@@ -210,15 +210,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
     <para>
       <literal>setUp()</literal> et <literal>tearDown()</literal> sont sympathiquement
-      symétriques en théorie mais pas en pratique. En pratique, vous n'avez besoin 
+      symétriques en théorie mais pas en pratique. En pratique, vous n'avez besoin
       d'implémenter <literal>tearDown()</literal> que si vous avez alloué
       des ressources externes telles que des fichiers ou des sockets dans
       <literal>setUp()</literal>. Si votre <literal>setUp()</literal> ne crée simplement
-      que de purs objets PHP, vous pouvez généralement ignorer <literal>tearDown()</literal>. 
+      que de purs objets PHP, vous pouvez généralement ignorer <literal>tearDown()</literal>.
       Cependant, si vous créez de nombreux objets dans votre <literal>setUp()</literal>, vous
       pourriez vouloir libérer (<literal>unset()</literal>) les variables pointant vers
       ces objets dans votre <literal>tearDown()</literal> de façon à ce qu'ils puissent être
-      récupérés par le ramasse-miettes. Le nettoyage des objets de cas de test n'est pas 
+      récupérés par le ramasse-miettes. Le nettoyage des objets de cas de test n'est pas
       prévisible.
     </para>
   </section>
@@ -262,7 +262,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <para>
       Un bon exemple de fixture qu'il est raisonnable de partager entre plusieurs
       tests est une connexion à une base de données : vous vous connectez une fois
-      à la base de données et vous réutilisez cette connexion au lieu d'en créer 
+      à la base de données et vous réutilisez cette connexion au lieu d'en créer
       une nouvelle pour chaque test. Ceci rend vos tests plus rapides.
     </para>
 
@@ -272,7 +272,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
       <xref linkend="fixtures.sharing-fixture.examples.DatabaseTest.php" />
       utilise les méthodes canevas <literal>setUpBeforeClass()</literal> et
-      <literal>tearDownAfterClass()</literal> pour respectivement établir la connexion à la 
+      <literal>tearDownAfterClass()</literal> pour respectivement établir la connexion à la
       base de données avant le premier test de la classe de cas de test et pour
       de déconnecter de la base de données après le dernier test du cas de test.
     </para>
@@ -302,7 +302,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       entre les tests réduit la valeur de ces tests. Le problème de conception
       sous-jacent est que les objets ne sont pas faiblement couplés. Vous pourrez
       obtenir de meilleurs résultats en résolvant le problème de conception
-      sous-jacent puis en écrivant des tests utilisant des bouchons 
+      sous-jacent puis en écrivant des tests utilisant des bouchons
       (voir <xref linkend="test-doubles" />), plutôt qu'en créant
       des dépendances entre les tests à l'exécution et en ignorant l'opportunité
       d'améliorer votre conception.
@@ -315,7 +315,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     <para>
       <ulink url="http://googletesting.blogspot.com/2008/05/tott-using-dependancy-injection-to.html">Il est difficile de tester du code qui utilise des singletons.</ulink>
       La même chose est vraie pour le code qui utilise des variables globales. Typiquement,
-      le code que vous voulez tester est fortement couplé avec une variable globale et 
+      le code que vous voulez tester est fortement couplé avec une variable globale et
       vous ne pouvez pas contrôler sa création. Un problème additionnel réside dans le fait
       qu'un test qui modifie une variable globale peut faire échouer un autre test.
     </para>
@@ -357,7 +357,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       </para>
       <para>
         L'implémentation des opérations de sauvegarde et de restauration des variables
-        globales et des attributs statiques des classes utilise 
+        globales et des attributs statiques des classes utilise
         <literal>serialize()</literal> et <literal>unserialize()</literal>.
       </para>
       <para>
@@ -372,8 +372,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
       <indexterm><primary><literal>$backupGlobalsBlacklist</literal></primary></indexterm>
 
-      L'annotation <literal>@backupGlobals</literal> qui est discutée dans 
-      <xref linkend="appendixes.annotations.backupGlobals"/> peut être utilisée pour 
+      L'annotation <literal>@backupGlobals</literal> qui est discutée dans
+      <xref linkend="appendixes.annotations.backupGlobals"/> peut être utilisée pour
       contrôler les opérations de sauvegarde et de restauration des variables globales.
       Alternativement, vous pouvez fournir une liste noire des variables globales qui doivent
       être exclues des opérations de sauvegarde et de restauration comme ceci :
@@ -396,8 +396,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
       <indexterm><primary><literal>$backupStaticAttributesBlacklist</literal></primary></indexterm>
 
-      L'annotation <literal>@backupStaticAttributes</literal> qui est discutée dans 
-      <xref linkend="appendixes.annotations.backupStaticAttributes"/> peut être utilisée pour 
+      L'annotation <literal>@backupStaticAttributes</literal> qui est discutée dans
+      <xref linkend="appendixes.annotations.backupStaticAttributes"/> peut être utilisée pour
       contrôler les opérations de sauvegarde et de restauration des attributs statiques.
       Alternativement, vous pouvez fournir une liste noire des attributs statiques qui doivent
       être exclus des opérations de sauvegarde et de restauration comme ceci :

--- a/src/4.6/fr/incomplete-and-skipped-tests.xml
+++ b/src/4.6/fr/incomplete-and-skipped-tests.xml
@@ -8,14 +8,14 @@
 
     <para>
       Quand vous travaillez sur une nouvelle classe de cas de test, vous pourriez vouloir
-      commencer en écrivant des méthodes de test vides comme 
+      commencer en écrivant des méthodes de test vides comme
       <programlisting>public function testQuelquechose()
 {
-}</programlisting> pour garder la trace des tests que vous avez à écrire. Le problème avec 
+}</programlisting> pour garder la trace des tests que vous avez à écrire. Le problème avec
       les méthodes de test vides est qu'elles sont interprétées comme étant réussies par le
       framework PHPUnit. Cette mauvaise interprétation fait que le rapport de tests devient
       inutile -- vous ne pouvez pas voir si un test est effectivement réussi ou s'il n'a tout
-      simplement pas été implémenté. Appeler 
+      simplement pas été implémenté. Appeler
       <literal>$this->fail()</literal> dans une méthode de test non implémentée
       n'aide pas davantage, puisqu'alors le test sera interprété comme étant un échec.
       Ce serait tout aussi faux que d'interpréter un test non implémenté comme étant réussi.
@@ -30,16 +30,16 @@
       comme à un feu rouge, nous avons besoin d'un feu orange additionnel pour signaler
       un test comme étant incomplet ou pas encore implémenté.
       <literal>PHPUnit_Framework_IncompleteTest</literal> est une interface de marquage
-      pour signaler une exception qui est levée par une méthode de test comme résultat 
+      pour signaler une exception qui est levée par une méthode de test comme résultat
       d'un test incomplet ou actuellement pas implémenté.
-      <literal>PHPUnit_Framework_IncompleteTestError</literal> est l'implémentation 
+      <literal>PHPUnit_Framework_IncompleteTestError</literal> est l'implémentation
       standard de cette interface.
     </para>
 
     <para>
       <xref linkend="incomplete-and-skipped-tests.incomplete-tests.examples.SampleTest.php" />
       montre une classe de cas de tests, <literal>ExempleDeTest</literal>, qui contient une unique méthode de test,
-      method, <literal>testSomething()</literal>. En appelant la méthode pratique 
+      method, <literal>testSomething()</literal>. En appelant la méthode pratique
       <literal>markTestIncomplete()</literal> (qui lève automatiquement
       une exception <literal>PHPUnit_Framework_IncompleteTestError</literal>)
       dans la méthode de test, nous marquons le test comme étant incomplet.
@@ -53,7 +53,7 @@ class ExempleDeTest extends PHPUnit_Framework_TestCase
     public function testeQuelquechose()
     {
         // Facultatif: testez tout ce que vous voulez ici.
-        $this->assertTrue(TRUE, 'Ceci devrait toujours fonctionner.');
+        self::assertTrue(TRUE, 'Ceci devrait toujours fonctionner.');
 
         // Cesser ici et marquer ce test comme incomplet.
         $this->markTestIncomplete(
@@ -128,7 +128,7 @@ Tests: 1, Assertions: 1, Incomplete: 1.</screen>
     <para>
       <xref linkend="incomplete-and-skipped-tests.skipping-tests.examples.DatabaseTest.php" />
       montre une classe de cas de tests, <literal>DatabaseTest</literal>, qui contient une méthode de tests
-      <literal>testConnection()</literal>. Dans la méthode canevas <literal>setUp()</literal> 
+      <literal>testConnection()</literal>. Dans la méthode canevas <literal>setUp()</literal>
       de la classe du cas de test, nous pouvons contrôler si l'extension
       MySQLi est disponible et utiliser la méthode <literal>markTestSkipped()</literal>
       pour sauter le test si ce n'est pas le cas.
@@ -277,7 +277,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
  	<para>
 		Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
-        dans la configuration xml pour les inclusions dépendant de la version dans 
+        dans la configuration xml pour les inclusions dépendant de la version dans
         <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/4.6/fr/selenium.xml
+++ b/src/4.6/fr/selenium.xml
@@ -9,28 +9,28 @@
     <para>
       <indexterm><primary>Selenium Server</primary></indexterm>
 
-      <ulink url="http://seleniumhq.org/">Selenium Server</ulink> est un 
-      outil de test qui vous permet d'écrire des tests automatisés de 
+      <ulink url="http://seleniumhq.org/">Selenium Server</ulink> est un
+      outil de test qui vous permet d'écrire des tests automatisés de
       l'interface utilisateur d'applications web dans n'importe quel langage
       et menés sur n'importe quel site web HTTP en utilisant n'importe quel
       navigateur courant. Il réalise des tâches automatisée dans le navigateur
       en pilotant le processus du navigateur via le système d'exploitation.
       Les tests Selenium s'exécutent directement dans un navigateur, exactement
       comme des utilisateurs réels le feraient. Ces tests peuvent être utilisés
-      à la fois comme <emphasis>tests de validation</emphasis> 
+      à la fois comme <emphasis>tests de validation</emphasis>
       (en exécutant des tests au plus haut niveau sur le système intégré au lieu
       de simplement tester chaque unité du système indépendamment) et des
       <emphasis>tests de compatibilité pour les navigateurs</emphasis> (en testant l'application
       web sur différents systèmes d'exploitation et différents navigateurs).
     </para>
-    
+
     <para>
       Le seul scénario géré par PHPUnit_Selenium est celui du serveur Selenium 2.x.
       Le serveur peut être accédé via l'API classique Selenium RC déjà présente dans la version 1.x ou avec l'API serveur
       WebDriver (partiellement implémentée) à partir de PHPUnit_Selenium 1.2.
     </para>
     <para>
-      La raison derrière cette décision est que Selenium 2 est rétro compatible et que Selenium RC n'est désormais plus 
+      La raison derrière cette décision est que Selenium 2 est rétro compatible et que Selenium RC n'est désormais plus
       maintenu.
     </para>
 
@@ -87,7 +87,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -114,7 +114,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     Les commandes de Selenium2TestCase sont implémentées via __call(). Merci de vous référer à <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">the end-to-end test for PHPUnit_Extensions_Selenium2TestCase</ulink> pour la liste de toutes les fonctionnalités prises en charge.
   </para>
   </section>
@@ -152,7 +152,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -252,7 +252,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -333,7 +333,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/fr/skeleton-generator.xml
+++ b/src/4.6/fr/skeleton-generator.xml
@@ -62,7 +62,7 @@ Wrote skeleton for "CalculateurTest" to "/home/sb/CalculateurTest.php".</screen>
     <title>Classes sous espace de nom et le générateur de squelette</title>
 
     <para>
-      Lorsque vous utilisez le générateur de squelette pour générer du code basé sur 
+      Lorsque vous utilisez le générateur de squelette pour générer du code basé sur
       une classe qui est déclarée dans un <ulink url="http://php.net/namespace">espace de nommage (namespace)</ulink>
       vous devez fournir le nom qualifié de la classe ainsi que le chemin d'accès
       au fichier source dans lequel elle est déclarée.
@@ -104,7 +104,7 @@ Tests: 1, Assertions: 0, Incomplete: 1.</screen>
       <indexterm><primary>@assert</primary></indexterm>
 
       Vous pouvez utiliser l'annotation <literal>@assert</literal> dans le bloc
-      de documentation d'une méthode pour générer automatiquement des tests 
+      de documentation d'une méthode pour générer automatiquement des tests
       simples mais significatifs au lieu de cas de tests incomplets.
       <xref linkend="skeleton-generator.test.examples.Calculator.php" />
       montre un exemple.
@@ -131,13 +131,13 @@ class Calculateur
 
     <para>
       Chaque méthode de la classe originelle est contrôlée à la recherche d'annotations
-      <literal>@assert</literal>. Celles-ci sont transformées en code de test comme 
+      <literal>@assert</literal>. Celles-ci sont transformées en code de test comme
       <programlisting>    /**
      * Generated from @assert (0, 0) == 0.
      */
     public function testAdditionner() {
         $o = new Calculateur;
-        $this->assertEquals(0, $o->additionner(0, 0));
+        self::assertEquals(0, $o->additionner(0, 0));
     }</programlisting>
     </para>
 
@@ -254,7 +254,7 @@ class JeuDeBowlingTest extends PHPUnit_Framework_TestCase
     public function testScorePourJeuDansLaRigoleEst0()
     {
         $this->lancePlusieursEtRenverse(20, 0);
-        $this->assertEquals(0, $this->jeu->score());
+        self::assertEquals(0, $this->jeu->score());
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/fr/test-doubles.xml
+++ b/src/4.6/fr/test-doubles.xml
@@ -130,7 +130,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
 
         // Appeler $bouchon->faireQuelquechose() va maintenant retourner
         // 'foo'.
-        $this->assertEquals('foo', $bouchon->faireQuelquechose());
+        self::assertEquals('foo', $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -196,7 +196,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
 
         // Appeler $bouchon->faireQuelquechose() retournera maintenant
         // 'foo'.
-        $this->assertEquals('foo', $bouchon->faireQuelquechose());
+        self::assertEquals('foo', $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -233,10 +233,10 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $bouchon->faireQuelquechose('foo') retourne 'foo'
-        $this->assertEquals('foo', $bouchon->faireQuelquechose('foo'));
+        self::assertEquals('foo', $bouchon->faireQuelquechose('foo'));
 
         // $bouchon->faireQuelquechose('bar') retourne 'bar'
-        $this->assertEquals('bar', $bouchon->faireQuelquechose('bar'));
+        self::assertEquals('bar', $bouchon->faireQuelquechose('bar'));
     }
 }
 ?>]]></programlisting>
@@ -273,7 +273,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $bouchon->faireQuelquechose() retourne $bouchon
-        $this->assertSame($bouchon, $bouchon->faireQuelquechose());
+        self::assertSame($bouchon, $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -320,8 +320,8 @@ class BouchonTest extends PHPUnit_Framework_TestCase
         // $bouchon->faireQuelquechose() retourne
         // différentes valeurs selon les paramètres
         // fournis.
-        $this->assertEquals('d', $bouchon->faireQuelquechose('a', 'b', 'c'));
-        $this->assertEquals('h', $bouchon->faireQuelquechose('e', 'f', 'g'));
+        self::assertEquals('d', $bouchon->faireQuelquechose('a', 'b', 'c'));
+        self::assertEquals('h', $bouchon->faireQuelquechose('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -359,7 +359,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $bouchon->faireQuelquechose($argument) retourne str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $bouchon->faireQuelquechose('quelqueChose'));
+        self::assertEquals('fbzrguvat', $bouchon->faireQuelquechose('quelqueChose'));
     }
 }
 ?>]]></programlisting>
@@ -396,9 +396,9 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $bouchon->faireQuelquechose() retourne une valeur différente à chaque fois
-        $this->assertEquals(2, $bouchon->faireQuelquechose());
-        $this->assertEquals(3, $bouchon->faireQuelquechose());
-        $this->assertEquals(5, $bouchon->faireQuelquechose());
+        self::assertEquals(2, $bouchon->faireQuelquechose());
+        self::assertEquals(3, $bouchon->faireQuelquechose());
+        self::assertEquals(5, $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -713,7 +713,7 @@ class ClasseAbstraiteTest extends PHPUnit_Framework_TestCase
              ->method('methodeAbstraite')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->methodeConcrete());
+        self::assertTrue($stub->methodeConcrete());
     }
 }
 ?>]]></programlisting>
@@ -845,7 +845,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() va maintenant retourner un result bouchon et
          * la méthode doGoogleSearch() du web service ne sera pas invoquée.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -945,10 +945,10 @@ class ExempleTest extends PHPUnit_Framework_TestCase
     public function testReprtoireEstCree()
     {
         $example = new Exemple('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setRepertoire(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -994,10 +994,10 @@ class ExempleTest extends PHPUnit_Framework_TestCase
     public function testRepertoireEstCree()
     {
         $exemple = new Exemple('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $exemple->setRepertoire(vfsStream::url('exempleRepertoire'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/fr/writing-tests-for-phpunit.xml
+++ b/src/4.6/fr/writing-tests-for-phpunit.xml
@@ -27,14 +27,14 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testerPushEtPop()
     {
         $pile = array();
-        $this->assertEquals(0, count($pile));
+        self::assertEquals(0, count($pile));
 
         array_push($pile, 'foo');
-        $this->assertEquals('foo', $pile[count($pile)-1]);
-        $this->assertEquals(1, count($pile));
+        self::assertEquals('foo', $pile[count($pile)-1]);
+        self::assertEquals(1, count($pile));
 
-        $this->assertEquals('foo', array_pop($pile));
-        $this->assertEquals(0, count($pile));
+        self::assertEquals('foo', array_pop($pile));
+        self::assertEquals(0, count($pile));
     }
 }
 ?>]]></programlisting>
@@ -98,7 +98,7 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testVide()
     {
         $pile = array();
-        $this->assertEmpty($pile);
+        self::assertEmpty($pile);
 
         return $pile;
     }
@@ -109,8 +109,8 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testPush(array $pile)
     {
         array_push($pile, 'foo');
-        $this->assertEquals('foo', $pile[count($pile)-1]);
-        $this->assertNotEmpty($pile);
+        self::assertEquals('foo', $pile[count($pile)-1]);
+        self::assertNotEmpty($pile);
 
         return $pile;
     }
@@ -120,8 +120,8 @@ class PileTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $pile)
     {
-        $this->assertEquals('foo', array_pop($pile));
-        $this->assertEmpty($pile);
+        self::assertEquals('foo', array_pop($pile));
+        self::assertEmpty($pile);
     }
 }
 ?>]]></programlisting>
@@ -154,7 +154,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testUn()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -228,7 +228,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdditionne($a, $b, $c)
     {
-        $this->assertEquals($c, $a + $b);
+        self::assertEquals($c, $a + $b);
     }
 
     public function fournisseur()
@@ -273,7 +273,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdditionne($a, $b, $c)
     {
-        $this->assertEquals($c, $a + $b);
+        self::assertEquals($c, $a + $b);
     }
 
     public function fournisseur()
@@ -673,7 +673,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testEcritureFichier() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->ecrit('/non-accessible-en-ecriture/fichier', 'texte'));
+        self::assertFalse(@$writer->ecrit('/non-accessible-en-ecriture/fichier', 'texte'));
     }
 }
 class FileWriter
@@ -825,7 +825,7 @@ class TableauPossedeUneClefTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -862,7 +862,7 @@ class ClassePossedeUnAttributTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -899,7 +899,7 @@ class ClassePossedeUnAttributStatiqueTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -939,7 +939,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -971,7 +971,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -1000,12 +1000,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -1046,7 +1046,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -1087,7 +1087,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -1127,7 +1127,7 @@ class VideTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -1165,7 +1165,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $attendu = new DOMElement('foo');
         $constate = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($attendu, $constate);
+        self::assertEqualXMLStructure($attendu, $constate);
     }
 
     public function testEchecAvecDifferentsAttributsDeNoeud()
@@ -1176,7 +1176,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild, TRUE
         );
     }
@@ -1189,7 +1189,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild
         );
     }
@@ -1202,7 +1202,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild
         );
     }
@@ -1271,17 +1271,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testEchec2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testEchec3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -1338,12 +1338,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSucces()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testEchec()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -1380,7 +1380,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($attendu, $constate);
+        self::assertEquals($attendu, $constate);
     }
 }
 ?>]]></programlisting>
@@ -1429,7 +1429,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $constate->foo = 'bar';
         $constate->baz = 'bar';
 
-        $this->assertEquals($attendu, $constate);
+        self::assertEquals($attendu, $constate);
     }
 }
 ?>]]></programlisting>
@@ -1470,7 +1470,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -1516,7 +1516,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -1553,7 +1553,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFileEquals('/home/sb/attendu', '/home/sb/constate');
+        self::assertFileEquals('/home/sb/attendu', '/home/sb/constate');
     }
 }
 ?>]]></programlisting>
@@ -1596,7 +1596,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFileExists('/chemin/vers/fichier');
+        self::assertFileExists('/chemin/vers/fichier');
     }
 }
 ?>]]></programlisting>
@@ -1633,7 +1633,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -1670,7 +1670,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -1710,7 +1710,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1750,7 +1750,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1789,7 +1789,7 @@ class JsonFileEqualsJsonFile extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'chemin/vers/fixture/fichier', 'chemin/vers/constate/fichier');
     }
 }
@@ -1827,7 +1827,7 @@ class JsonStringEqualsJsonFile extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'chemin/vers/fixture/fichier', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1868,7 +1868,7 @@ class JsonStringEqualsJsonString extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1914,7 +1914,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1951,7 +1951,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1988,7 +1988,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -2025,7 +2025,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -2062,7 +2062,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -2099,7 +2099,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2150,7 +2150,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringMatchesFormatFile('/chemin/vers/attendu.txt', 'foo');
+        self::assertStringMatchesFormatFile('/chemin/vers/attendu.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2191,7 +2191,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -2223,7 +2223,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -2270,22 +2270,22 @@ class SelectCountTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectCount('foo bar', FALSE, $this->xml);
+        self::assertSelectCount('foo bar', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectCount('foo baz', TRUE, $this->xml);
+        self::assertSelectCount('foo baz', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectCount('foo bar', 5, $this->xml);
+        self::assertSelectCount('foo bar', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectCount('foo bar', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectCount('foo bar', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2347,22 +2347,22 @@ class SelectEqualsTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', FALSE, $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Bat', TRUE, $this->xml);
+        self::assertSelectEquals('foo bar', 'Bat', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', 5, $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2424,22 +2424,22 @@ class SelectRegExpTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', FALSE, $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/B[oe]z]/', TRUE, $this->xml);
+        self::assertSelectRegExp('foo bar', '/B[oe]z]/', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', 5, $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2491,7 +2491,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringEndsWith('suffixe', 'foo');
+        self::assertStringEndsWith('suffixe', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2528,7 +2528,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringEqualsFile('/home/sb/attendu', 'constate');
+        self::assertStringEqualsFile('/home/sb/attendu', 'constate');
     }
 }
 ?>]]></programlisting>
@@ -2571,7 +2571,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringStartsWith('prefixe', 'foo');
+        self::assertStringStartsWith('prefixe', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2699,10 +2699,10 @@ $matcher = array(
 );
 
 // Utilise assertTag() pour appliquer un $matcher à un morceau de $html.
-$this->assertTag($matcher, $html);
+self::assertTag($matcher, $html);
 
 // Utilise assertTag() pour appliquer un matcher à un morceau de $xml.
-$this->assertTag($matcher, $xml, '', FALSE);
+self::assertTag($matcher, $xml, '', FALSE);
 ?>]]></programlisting>
       </example>
     </section>
@@ -2734,7 +2734,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $leBiscuit = new Biscuit('Ginger');
         $monBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $leBiscuit,
           $this->logicalNot(
             $this->equalTo($monBiscuit)
@@ -2919,7 +2919,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -2956,7 +2956,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/attendu.xml', '/home/sb/constate.xml');
     }
 }
@@ -3002,7 +3002,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/attendu.xml', '<foo><baz/></foo>');
     }
 }
@@ -3048,7 +3048,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.6/ja/annotations.xml
+++ b/src/4.6/ja/annotations.xml
@@ -269,7 +269,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
@@ -801,7 +801,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.6/ja/assertions.xml
+++ b/src/4.6/ja/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -99,7 +99,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.6/ja/code-coverage-analysis.xml
+++ b/src/4.6/ja/code-coverage-analysis.xml
@@ -294,7 +294,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -307,7 +307,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -325,7 +325,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -340,11 +340,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -381,7 +381,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -415,6 +415,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.6/ja/database.xml
+++ b/src/4.6/ja/database.xml
@@ -215,7 +215,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1251,12 +1251,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1286,7 +1286,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1346,7 +1346,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1389,7 +1389,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/ja/fixtures.xml
+++ b/src/4.6/ja/fixtures.xml
@@ -69,21 +69,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -146,13 +146,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.6/ja/incomplete-and-skipped-tests.xml
+++ b/src/4.6/ja/incomplete-and-skipped-tests.xml
@@ -57,7 +57,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // オプション: お望みなら、ここで何かのテストをしてください。
-        $this->assertTrue(TRUE, 'これは動いているはずです。');
+        self::assertTrue(TRUE, 'これは動いているはずです。');
 
         // ここで処理を止め、テストが未完成であるという印をつけます。
         $this->markTestIncomplete(

--- a/src/4.6/ja/selenium.xml
+++ b/src/4.6/ja/selenium.xml
@@ -24,7 +24,7 @@
       (ウェブアプリケーションを、さまざまなオペレーティングシステムやブラウザでテストする)
       などがあります。
     </para>
-    
+
     <para>
       PHPUnit_Selenium がサポートしている唯一のシナリオは、
       Selenium 2.x サーバを使うものです。
@@ -37,7 +37,7 @@
     </para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>インストール</title>
 
@@ -95,7 +95,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -122,7 +122,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     Selenium2TestCase のコマンドは __call() を使って実装しています。
     サポートする機能の一覧は
     <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">PHPUnit_Extensions_Selenium2TestCase のエンドツーエンドテスト</ulink>
@@ -163,7 +163,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -265,7 +265,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -346,7 +346,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/ja/test-doubles.xml
+++ b/src/4.6/ja/test-doubles.xml
@@ -156,7 +156,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() をコールすると
         // 'foo' を返すようになります
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -195,7 +195,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() をコールすると
         // 'foo' を返すようになります
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -252,10 +252,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') は 'foo' を返します
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') は 'bar' を返します
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -290,7 +290,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() は $stub を返します
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -332,8 +332,8 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnValueMap($map));
 
         // $stub->doSomething() は、渡した引数に応じて異なる値を返します
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -372,7 +372,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) は str_rot13($argument) を返します
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -408,9 +408,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() は毎回異なる値を返します
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -520,12 +520,12 @@ class Subject
 {
     protected $observers = array();
     protected $name;
-    
+
     public function __construct($name)
     {
         $this->name = $name;
     }
-    
+
     public function getName()
     {
         return $this->name;
@@ -936,7 +936,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -974,7 +974,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -1050,7 +1050,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() はスタブが用意した結果を返し、
          * ウェブサービスの doGoogleSearch() が呼び出されることはありません
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1151,10 +1151,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1200,10 +1200,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/ja/textui.xml
+++ b/src/4.6/ja/textui.xml
@@ -401,7 +401,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.6/ja/writing-tests-for-phpunit.xml
+++ b/src/4.6/ja/writing-tests-for-phpunit.xml
@@ -26,14 +26,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -111,7 +111,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -122,8 +122,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -133,8 +133,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -169,7 +169,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -226,13 +226,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -242,7 +242,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -294,7 +294,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -339,7 +339,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -434,13 +434,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -451,7 +451,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -862,7 +862,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -1005,7 +1005,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1055,7 +1055,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1109,7 +1109,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.6/pt_br/annotations.xml
+++ b/src/4.6/pt_br/annotations.xml
@@ -6,25 +6,25 @@
   <para>
     <indexterm><primary>Anotações</primary></indexterm>
 
-    Uma anotação é uma forma especial de metadados sintáticos que podem ser adicionados ao 
-    código-fonte de algumas linguagens de programação. Enquanto o PHP não tem 
-    um recurso de linguagem dedicado a anotação de código-fonte, o uso de tags 
-    como <literal>@annotation arguments</literal> em bloco de documentação tem sido 
-    estabelecido na comunidade do PHP para anotar o código-fonte. Os blocos 
-    de documentação PHP são reflexivos: eles podem ser acessados através do 
-    método <literal>getDocComment()</literal> da API Reflection a nível de função, 
-    classe, método e atributo. Aplicações como o PHPUnit usam essa 
+    Uma anotação é uma forma especial de metadados sintáticos que podem ser adicionados ao
+    código-fonte de algumas linguagens de programação. Enquanto o PHP não tem
+    um recurso de linguagem dedicado a anotação de código-fonte, o uso de tags
+    como <literal>@annotation arguments</literal> em bloco de documentação tem sido
+    estabelecido na comunidade do PHP para anotar o código-fonte. Os blocos
+    de documentação PHP são reflexivos: eles podem ser acessados através do
+    método <literal>getDocComment()</literal> da API Reflection a nível de função,
+    classe, método e atributo. Aplicações como o PHPUnit usam essa
     informação em tempo de execução para configurar seu comportamento.
   </para>
 
   <note>
     <para>
-      Um comentário de documentação em PHP deve começar com <literal>/**</literal> e terminar com 
-      <literal>*/</literal>. Anotações em algum outro estilo de comentário será 
+      Um comentário de documentação em PHP deve começar com <literal>/**</literal> e terminar com
+      <literal>*/</literal>. Anotações em algum outro estilo de comentário será
       ignorada.
     </para>
   </note>
-  
+
   <para>
     Este apêndice mostra todas as variedades de anotações suportadas pelo PHPUnit.
   </para>
@@ -37,17 +37,17 @@
 
       A anotação <literal>@author</literal> é um apelido para a anotação
       <literal>@group</literal> (veja <xref
-      linkend="appendixes.annotations.group"/>) e permite filtrar os testes baseado 
+      linkend="appendixes.annotations.group"/>) e permite filtrar os testes baseado
       em seus autores.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.after">
     <title>@after</title>
 
     <para>
 
-      A anotação <literal>@after</literal> pode ser usada para especificar métodos 
+      A anotação <literal>@after</literal> pode ser usada para especificar métodos
       que devem ser chamados depois de cada método em uma classe de caso de teste.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -69,14 +69,14 @@
 }</programlisting>
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.afterClass">
     <title>@afterClass</title>
 
     <para>
 
-      A anotação <literal>@afterClass</literal> pode ser usada para especificar 
-      métodos estáticos que devem ser chamados depois de todos os métodos de teste em uma classe 
+      A anotação <literal>@afterClass</literal> pode ser usada para especificar
+      métodos estáticos que devem ser chamados depois de todos os métodos de teste em uma classe
       de teste foram executados para limpar ambientes compartilhados.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -105,7 +105,7 @@
     <para>
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
-      As operações de cópia de segurança e restauração para variáveis globais podem ser completamente 
+      As operações de cópia de segurança e restauração para variáveis globais podem ser completamente
       desabilitadas para todos os testes de uma classe de caso de teste como esta <programlisting>/**
  * @backupGlobals disabled
  */
@@ -118,8 +118,8 @@ class MyTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
-      A anotação <literal>@backupGlobals</literal> também pode ser usada a nível 
-      de método de teste. Isso permite uma configuração refinada das 
+      A anotação <literal>@backupGlobals</literal> também pode ser usada a nível
+      de método de teste. Isso permite uma configuração refinada das
       operações de cópia de segurança e restauração: <programlisting>/**
  * @backupGlobals disabled
  */
@@ -142,8 +142,8 @@ class MyTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
 
-      A anotação <literal>@backupStaticAttributes</literal> pode ser usada para 
-      copiar todos valores de propriedades estáticas em todas classes declaradas antes de cada 
+      A anotação <literal>@backupStaticAttributes</literal> pode ser usada para
+      copiar todos valores de propriedades estáticas em todas classes declaradas antes de cada
       teste e restaurá-los depois. Pode ser usado em nível de classe de caso de teste ou
       método de teste:
 
@@ -166,23 +166,23 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        <literal>@backupStaticAttributes</literal> é limitada pela parte interna do PHP 
-        e pode causar valores estáticos não intencionais ao persistir e vazar para 
+        <literal>@backupStaticAttributes</literal> é limitada pela parte interna do PHP
+        e pode causar valores estáticos não intencionais ao persistir e vazar para
         testes subsequentes em algumas circunstâncias.
       </para>
       <para>
         Veja <xref linkend="fixtures.global-state"/> para detalhes.
       </para>
     </note>
-    
+
   </section>
-  
+
   <section id="appendixes.annotations.before">
     <title>@before</title>
 
     <para>
 
-      A anotação <literal>@before</literal> pode ser usada para especificar métodos 
+      A anotação <literal>@before</literal> pode ser usada para especificar métodos
       que devem ser chamados antes de cada método de teste em uma classe de caso de teste.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -204,14 +204,14 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.beforeClass">
     <title>@beforeClass</title>
 
     <para>
 
-      A anotação <literal>@beforeClass</literal> pode ser usada para especificar métodos 
-      estáticos que devem ser chamados antes de quaisquer métodos de teste em uma classe 
+      A anotação <literal>@beforeClass</literal> pode ser usada para especificar métodos
+      estáticos que devem ser chamados antes de quaisquer métodos de teste em uma classe
       de teste serem executados para criar ambientes compartilahdos.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -244,7 +244,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 
       As anotações <literal>@codeCoverageIgnore</literal>,
       <literal>@codeCoverageIgnoreStart</literal> e
-      <literal>@codeCoverageIgnoreEnd</literal> podem ser usadas 
+      <literal>@codeCoverageIgnoreEnd</literal> podem ser usadas
       para excluir linhas de código da análise de cobertura.
     </para>
 
@@ -261,23 +261,23 @@ class MyTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Cobertura de Código</primary></indexterm>
       <indexterm><primary>@covers</primary></indexterm>
 
-      A anotação <literal>@covers</literal> pode ser usada no código de teste para 
+      A anotação <literal>@covers</literal> pode ser usada no código de teste para
       especificar quais métodos um método de teste quer testar: <programlisting>/**
  * @covers BankAccount::getBalance
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
     <para>
-      Se fornecida, apenas a informação de cobertura de código para o(s) 
+      Se fornecida, apenas a informação de cobertura de código para o(s)
       método(s) especificado(s) será considerada.
     </para>
 
     <para>
-      <xref linkend="appendixes.annotations.covers.tables.annotations"/> mostra 
+      <xref linkend="appendixes.annotations.covers.tables.annotations"/> mostra
       a sintaxe da anotação <literal>@covers</literal>.
     </para>
 
@@ -336,7 +336,7 @@ public function testBalanceIsInitiallyZero()
       </tgroup>
     </table>
   </section>
-  
+
   <section id="appendixes.annotations.coversDefaultClass">
     <title>@coversDefaultClass</title>
 
@@ -376,8 +376,8 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@coversNothing</primary></indexterm>
 
-      A anotação <literal>@coversNothing</literal> pode ser usada no 
-      código de teste para especificar que nenhuma informação de cobertura de código será 
+      A anotação <literal>@coversNothing</literal> pode ser usada no
+      código de teste para especificar que nenhuma informação de cobertura de código será
       gravada para o caso de teste anotado.
     </para>
 
@@ -388,7 +388,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     </para>
 
     <para>
-        A anotação pode ser usada nos níveis de classe e de método e 
+        A anotação pode ser usada nos níveis de classe e de método e
         vão sobrescrever quaisquer tags <literal>@covers</literal>.
     </para>
   </section>
@@ -399,7 +399,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@dataProvider</primary></indexterm>
 
-      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser 
+      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser
       fornecidos por um método provedor  (<literal>provider()</literal> em
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
       O método provedor de dados a ser usado é especificado usando a anotação
@@ -407,7 +407,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.data-providers"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.data-providers"/> para mais
       detalhes.
     </para>
   </section>
@@ -418,17 +418,17 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@depends</primary></indexterm>
 
-      O PHPUnit suporta a declaração de dependências explícitas entre métodos 
-      de teste. Tais dependências não definem a ordem em que os métodos de teste 
-      devem ser executados, mas permitem o retorno de uma instância do 
+      O PHPUnit suporta a declaração de dependências explícitas entre métodos
+      de teste. Tais dependências não definem a ordem em que os métodos de teste
+      devem ser executados, mas permitem o retorno de uma instância do
       ambiente de teste por um produtor e passá-la aos consumidores dependentes.
-      O <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> mostra 
-      como usar a anotação <literal>@depends</literal> para expressar 
+      O <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> mostra
+      como usar a anotação <literal>@depends</literal> para expressar
       dependências entre métodos de teste.
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.test-dependencies"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.test-dependencies"/> para mais
       detalhes.
     </para>
   </section>
@@ -440,12 +440,12 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>@expectedException</primary></indexterm>
 
       O <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest.php" />
-      mostra como usar a anotação <literal>@expectedException</literal> para 
+      mostra como usar a anotação <literal>@expectedException</literal> para
       testar se uma exceção é lançada dentro do código testado.
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.exceptions"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.exceptions"/> para mais
       detalhes.
     </para>
   </section>
@@ -456,9 +456,9 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
-      A anotação <literal>@expectedExceptionCode</literal> em conjunção 
-      com a <literal>@expectedException</literal> permite fazer asserções no 
-      código de erro de uma exceção lançada, permitindo diminuir uma 
+      A anotação <literal>@expectedExceptionCode</literal> em conjunção
+      com a <literal>@expectedException</literal> permite fazer asserções no
+      código de erro de uma exceção lançada, permitindo diminuir uma
       exceção específica.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -473,7 +473,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     }
 }</programlisting>
 
-      Para facilitar o teste e reduzir a duplicação, um atalho pode ser usado para 
+      Para facilitar o teste e reduzir a duplicação, um atalho pode ser usado para
       especificar uma constante de classe como um
       <literal>@expectedExceptionCode</literal> usando a sintaxe
       "<literal>@expectedExceptionCode ClassName::CONST</literal>".
@@ -504,8 +504,8 @@ class MyClass
     <para>
       <indexterm><primary>@expectedExceptionMessage</primary></indexterm>
 
-      A anotação <literal>@expectedExceptionMessage</literal> trabalha de modo similar 
-      a <literal>@expectedExceptionCode</literal> já que lhe permite fazer uma 
+      A anotação <literal>@expectedExceptionMessage</literal> trabalha de modo similar
+      a <literal>@expectedExceptionCode</literal> já que lhe permite fazer uma
       asserção na mensagem de erro de uma exceção.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -520,9 +520,9 @@ class MyClass
     }
 }</programlisting>
 
-      A mensagem esperada pode ser uma substring de uma Mensagem de exceção. 
-      Isso pode ser útil para asseverar apenas que um certo nome ou parâmetro que 
-      foi passado é mostrado na exceção e não fixar toda a 
+      A mensagem esperada pode ser uma substring de uma Mensagem de exceção.
+      Isso pode ser útil para asseverar apenas que um certo nome ou parâmetro que
+      foi passado é mostrado na exceção e não fixar toda a
       mensagem de exceção no teste.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -538,7 +538,7 @@ class MyClass
      }
 }</programlisting>
 
-      Para facilitar o teste e reduzir duplicação um atalho pode ser usado para 
+      Para facilitar o teste e reduzir duplicação um atalho pode ser usado para
       especificar uma constante de classe como uma
       <literal>@expectedExceptionMessage</literal> usando a sintaxe
       "<literal>@expectedExceptionMessage ClassName::CONST</literal>".
@@ -547,7 +547,7 @@ class MyClass
     </para>
 
   </section>
-  
+
   <section id="appendixes.annotations.expectedExceptionMessageRegExp">
     <title>@expectedExceptionMessageRegExp</title>
 
@@ -556,7 +556,7 @@ class MyClass
 
       A mensagem experada também pode ser especificada como uma expressão regular usando
       a anotação <literal>@expectedExceptionMessageRegExp</literal>. Isso
-      é útil em situações aonde uma substring não é adequada para combinar 
+      é útil em situações aonde uma substring não é adequada para combinar
       uma determinada mensagem.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -580,7 +580,7 @@ class MyClass
     <para>
       <indexterm><primary>@group</primary></indexterm>
 
-      Um teste pode ser marcado como pertencente a um ou mais grupos usando a 
+      Um teste pode ser marcado como pertencente a um ou mais grupos usando a
       anotação <literal>@group</literal> desta forma <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -601,20 +601,20 @@ class MyClass
     </para>
 
     <para>
-      Testes podem ser selecionados para execução baseada em grupos usando as 
-      opções <literal>--group</literal> e <literal>--exclude-group</literal> 
-      do executor de teste em linha-de-comando ou usando as respectivas diretivas do 
+      Testes podem ser selecionados para execução baseada em grupos usando as
+      opções <literal>--group</literal> e <literal>--exclude-group</literal>
+      do executor de teste em linha-de-comando ou usando as respectivas diretivas do
       arquivo de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.large">
     <title>@large</title>
 
     <para>
       <indexterm><primary><literal>@large</literal></primary></indexterm>
 
-      A anotação <literal>@large</literal> é um apelido para 
+      A anotação <literal>@large</literal> é um apelido para
       <literal>@group large</literal>.
     </para>
 
@@ -622,14 +622,14 @@ class MyClass
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForLargeTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
-      estrito estiver habilitado, um teste grande irá falhar se ele demorar mais de 60 
-      segundos para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForLargeTests</literal> no arquivo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
+      estrito estiver habilitado, um teste grande irá falhar se ele demorar mais de 60
+      segundos para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForLargeTests</literal> no arquivo
       de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.medium">
     <title>@medium</title>
 
@@ -645,26 +645,26 @@ class MyClass
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForMediumTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
-      estrito estiver habilitado, um teste médio irá falhar se ele demorar mais de 10 
-      segundos para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForMediumTests</literal> no arquivo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
+      estrito estiver habilitado, um teste médio irá falhar se ele demorar mais de 10
+      segundos para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForMediumTests</literal> no arquivo
       de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.preserveGlobalState">
     <title>@preserveGlobalState</title>
 
     <para>
       <indexterm><primary>@preserveGlobalState</primary></indexterm>
 
-      Quando um teste é executado em um processo separado, o PHPUnit 
-      tentará preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
-      contém globais que não são serializáveis. Para corrigir isto, você pode prevenir o 
-      PHPUnit de preservar o estado global com a 
+      Quando um teste é executado em um processo separado, o PHPUnit
+      tentará preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
+      contém globais que não são serializáveis. Para corrigir isto, você pode prevenir o
+      PHPUnit de preservar o estado global com a
       anotação <literal>@preserveGlobalState</literal>.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -703,7 +703,7 @@ class MyClass
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indica que todos testes em uma classe de teste devem ser executados em um processo 
+      Indica que todos testes em uma classe de teste devem ser executados em um processo
       PHP separado. <programlisting>/**
  * @runTestsInSeparateProcesses
  */
@@ -713,11 +713,11 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
 
       <emphasis role="strong">Nota:</emphasis> Por padrão, o PHPUnit tentará
-      preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
+      preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
       contém globais que não são serializáveis. Veja <xref
-      linkend="appendixes.annotations.preserveGlobalState"/> para informações 
+      linkend="appendixes.annotations.preserveGlobalState"/> para informações
       de como corrigir isso.
     </para>
   </section>
@@ -741,15 +741,15 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
 
       <emphasis role="strong">Nota:</emphasis> Por padrão, o PHPUnit tentará
-      preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
+      preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
       contém globais que não são serializáveis. Veja <xref
-      linkend="appendixes.annotations.preserveGlobalState"/> para informações 
+      linkend="appendixes.annotations.preserveGlobalState"/> para informações
       de como corrigir isso.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.small">
     <title>@small</title>
 
@@ -765,19 +765,19 @@ class MyTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
       estrito estiver habilitado, um teste pequeno irá falhar se ele demorar mais de 1
-      segundo para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForLargeTests</literal> no arquivo 
+      segundo para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForLargeTests</literal> no arquivo
       de configuração XML.
     </para>
 
     <note>
       <para>
-        Pr padrão, todos testes são considerados pequenos se eles não são 
+        Pr padrão, todos testes são considerados pequenos se eles não são
         como <literal>@medium</literal> ou <literal>@large</literal>. Note, por favor,
-        no entanto, que <literal>--group</literal> e as opções relacionadas irão 
-        apenas considerarão um teste ser do grupo <literal>small</literal> se ele 
+        no entanto, que <literal>--group</literal> e as opções relacionadas irão
+        apenas considerarão um teste ser do grupo <literal>small</literal> se ele
         é marcado explicitamente com a anotação apropriada.
       </para>
     </note>
@@ -797,7 +797,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>
@@ -822,14 +822,14 @@ public function initialBalanceShouldBe0()
 
     <programlisting></programlisting>
   </section>
-  
+
   <section id="appendixes.annotations.uses">
     <title>@uses</title>
 
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      A anotação <literal>@uses</literal> especifica o código que irá 
+      A anotação <literal>@uses</literal> especifica o código que irá
       ser executado por um teste, mas não se destina a ser coberto pelo teste. Um bom
       exemplo é um objeto valor que é necessário para testar um unidade de código.
       <programlisting>/**
@@ -843,9 +843,9 @@ public function testMoneyCanBeDepositedInAccount()
     </para>
 
     <para>
-      Essa anotação é especialmente útil em modo de cobertura estrita aonde 
+      Essa anotação é especialmente útil em modo de cobertura estrita aonde
       código coberto involuntariamente fará um teste falhar. Veja
-      <xref linkend="risky-tests.unintentionally-covered-code"/> para mais 
+      <xref linkend="risky-tests.unintentionally-covered-code"/> para mais
       informação sobre modo de cobertura estrito.
     </para>
   </section>

--- a/src/4.6/pt_br/assertions.xml
+++ b/src/4.6/pt_br/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -84,7 +84,7 @@ FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </example>
   </section>
-  
+
   <section id="appendixes.assertions.assertClassHasAttribute">
     <title>assertClassHasAttribute()</title>
     <indexterm><primary>assertClassHasAttribute()</primary></indexterm>
@@ -99,7 +99,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1089,7 +1089,7 @@ Tests: 1, Assertions: 3, Failures: 1.</screen>
     <indexterm><primary>assertJsonStringNotEqualsJsonFile()</primary></indexterm>
     <para><literal>assertJsonStringEqualsJsonFile(mixed $expectedFile, mixed $actualJson[, string $message = ''])</literal></para>
     <para>
-      Reporta um erro identificado pela <literal>$message</literal> se o valor de <literal>$actualJson</literal> não combina com o valor de 
+      Reporta um erro identificado pela <literal>$message</literal> se o valor de <literal>$actualJson</literal> não combina com o valor de
       <literal>$expectedFile</literal>.
     </para>
     <example id="appendixes.assertions.assertJsonStringEqualsJsonFile.example">
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1640,10 +1640,10 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertThat()</primary></indexterm>
 
     <para>
-      Asserções mais complexas podem ser formuladas usando as 
-      classes <literal>PHPUnit_Framework_Constraint</literal>. Elas podem ser 
+      Asserções mais complexas podem ser formuladas usando as
+      classes <literal>PHPUnit_Framework_Constraint</literal>. Elas podem ser
       avaliadas usando o método <literal>assertThat()</literal>.
-      <xref linkend="appendixes.assertions.assertThat.example" /> mostra como as 
+      <xref linkend="appendixes.assertions.assertThat.example" /> mostra como as
       restrições <literal>logicalNot()</literal> e <literal>equalTo()</literal>
       podem ser usadas para expressar a mesma asserção como
       <literal>assertNotEquals()</literal>.
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.6/pt_br/code-coverage-analysis.xml
+++ b/src/4.6/pt_br/code-coverage-analysis.xml
@@ -8,7 +8,7 @@
     <para>
       Na ciência da computação, cobertura de código é um mensuração usada para descrever o
       grau em que um código fonte de um programa é testado por uma suíte
-      de testes particular. Um programa com cobertura de código alta foi mais exaustivamente 
+      de testes particular. Um programa com cobertura de código alta foi mais exaustivamente
       testado e tem uma menor chance de conter erros de software do que um programa
       com baixa cobertura de código.
     </para>
@@ -18,39 +18,39 @@
     <indexterm><primary>Cobertura de Código</primary></indexterm>
     <indexterm><primary>Xdebug</primary></indexterm>
 
-    Neste capítulo você aprenderá tudo sobre a funcionalidade de cobertura de código 
-    do PHPUnit que lhe dará uma perspicácia sobre quais partes do código de produção 
+    Neste capítulo você aprenderá tudo sobre a funcionalidade de cobertura de código
+    do PHPUnit que lhe dará uma perspicácia sobre quais partes do código de produção
     são executadas quando os testes são executados. Ele faz uso do componente
     <ulink url="https://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>,
-    que por sua vez utiliza a funcionalidade de cobertura de código fornecido 
+    que por sua vez utiliza a funcionalidade de cobertura de código fornecido
     pela extensão <ulink url="http://xdebug.org/">Xdebug</ulink> para PHP.
   </para>
-  
+
   <note>
     <para>
-      Xdebug não é distribuído como parte do PHPUnit. Se você Se você receber um aviso 
-      durante a execução de testes que a extensão Xdebug não está carregada, isso significa 
+      Xdebug não é distribuído como parte do PHPUnit. Se você Se você receber um aviso
+      durante a execução de testes que a extensão Xdebug não está carregada, isso significa
       que Xdebug ou não está instalada ou não está configurada corretamente. Antes
       que você possa usar as funcionalidades de análise de cobertura de código no PHPUnit, você deve
       ler <ulink url="http://xdebug.org/docs/install">o manual de instalação Xdebug</ulink>.
     </para>
   </note>
-  
+
   <para>
-    PHPUnit pode gerar um relatório de cobertura de código baseado em HTML, tal como 
+    PHPUnit pode gerar um relatório de cobertura de código baseado em HTML, tal como
     arquivos de registros baseado em XML com informações de cobertura de código em vários formatos
-    (Clover, Crap4J, PHPUnit). Informação de cobertura de código também pode ser relatado 
-    como texto (e impresso na STDOUT) e exportado como código PHP para futuro 
+    (Clover, Crap4J, PHPUnit). Informação de cobertura de código também pode ser relatado
+    como texto (e impresso na STDOUT) e exportado como código PHP para futuro
     processamento.
   </para>
-  
+
   <para>
     Por favor, consulte o <xref linkend="textui"/> para uma lista de opções de linha de comando
     que controlam a funcionalidade de cobertura de código, bem como em <xref
-    linkend="appendixes.configuration.logging"/> para as definições de 
+    linkend="appendixes.configuration.logging"/> para as definições de
     configurações relevantes.
   </para>
-  
+
   <section id="code-coverage-analysis.metrics">
     <title>Métricas de Software para  Cobertura de Código</title>
 
@@ -75,9 +75,9 @@
         <term><emphasis>Cobertura de Função e Método</emphasis></term>
         <listitem>
           <para>
-            A métrica de software <emphasis>Cobertura de Função e Método</emphasis> 
+            A métrica de software <emphasis>Cobertura de Função e Método</emphasis>
             mensura se cada função ou método foi invocado.
-            PHP_CodeCoverage só considera uma função ou método como coberto quando 
+            PHP_CodeCoverage só considera uma função ou método como coberto quando
             todas suas linhas executáveis são cobertas.
           </para>
         </listitem>
@@ -101,10 +101,10 @@
         <term><emphasis>Cobertura de Código de Operação</emphasis></term>
         <listitem>
           <para>
-            A métrica de software <emphasis>Cobertura de Código de Operação</emphasis> mensura 
-            se cada código de operação de uma função ou método foi  executado enquanto 
-            executa a suíte de teste. Uma linha de código geralmente compila em mais 
-            de um código de operação. Cobertura de Linha considera uma linha de código como coberta 
+            A métrica de software <emphasis>Cobertura de Código de Operação</emphasis> mensura
+            se cada código de operação de uma função ou método foi  executado enquanto
+            executa a suíte de teste. Uma linha de código geralmente compila em mais
+            de um código de operação. Cobertura de Linha considera uma linha de código como coberta
             logo que um dos seus códigos de operações é executado.
           </para>
         </listitem>
@@ -116,7 +116,7 @@
         <listitem>
           <para>
             A métrica de software <emphasis>Cobertura de Ramo</emphasis> mensura
-            se cada expressão booleana de cada estrutura de controle avaliada 
+            se cada expressão booleana de cada estrutura de controle avaliada
             a <literal>true</literal> e <literal>false</literal> enquanto
             executa a suíte de teste.
           </para>
@@ -129,9 +129,9 @@
         <listitem>
           <para>
             A métrica de software <emphasis>Cobertura de Caminho</emphasis> mensura
-            se cada um dos caminhos de execução possíveis em uma função ou método 
-            foi seguido durante a execução da suíte de teste. Um caminho de execução é 
-            uma sequência única de ramos a partir da entrada de uma função ou 
+            se cada um dos caminhos de execução possíveis em uma função ou método
+            foi seguido durante a execução da suíte de teste. Um caminho de execução é
+            uma sequência única de ramos a partir da entrada de uma função ou
             método para a sua saída.
           </para>
         </listitem>
@@ -142,11 +142,11 @@
         <term><emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis></term>
         <listitem>
           <para>
-            O <emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis> é 
-            calculado baseado na complexidade ciclomática e cobertura de código de uma 
-            unidade de código. Código que não é muito complexo e tem uma cobertura de teste 
+            O <emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis> é
+            calculado baseado na complexidade ciclomática e cobertura de código de uma
+            unidade de código. Código que não é muito complexo e tem uma cobertura de teste
             adequada terá um baixo índice CRAP. O índice CRAP pode ser reduzido
-            escrevendo testes e refatorando o código para reduzir sua 
+            escrevendo testes e refatorando o código para reduzir sua
             complexidade.
           </para>
         </listitem>
@@ -162,16 +162,16 @@
       </para>
     </note>
   </section>
-  
+
   <section id="code-coverage-analysis.including-excluding-files">
     <title>Incluindo e Excluindo Arquivos</title>
 
     <para>
-      Por padrão, todos os arquivos de código-fonte que contém pelo menos uma linha de código que 
-      tenha sido executada (e apenas esses arquivos) são incluídos no relatório 
+      Por padrão, todos os arquivos de código-fonte que contém pelo menos uma linha de código que
+      tenha sido executada (e apenas esses arquivos) são incluídos no relatório
       de cobertura de código.
     </para>
-    
+
     <para>
       <indexterm><primary>Cobertura de código</primary><secondary>Lista-negra</secondary></indexterm>
 
@@ -179,23 +179,23 @@
       relatório de cobertura de código. Essa lista-negra é previamente preenchida com os
       arquivos-fonte do PHPUnit e suas dependências.
     </para>
-    
+
     <para>
       <indexterm><primary>Cobertura de código</primary><secondary>Lista-branca</secondary></indexterm>
 
-      É uma boa prática usar um <emphasis>lista-branca</emphasis> ao invés da 
+      É uma boa prática usar um <emphasis>lista-branca</emphasis> ao invés da
       lista-negra mencionada acima.
     </para>
-    
+
     <para>
       Opcionalmente, todos arquivos da lista-branca pode ser adicionados ao relatório
       de cobertura de código pela definição <literal>addUncoveredFilesFromWhitelist="true"</literal>
       em suas configurações do PHPUnit (veja <xref
-      linkend="appendixes.configuration.blacklist-whitelist"/>). Isso permite a 
-      inclusão de arquivos que ainda não são testados em tudo. Se você quer obter 
+      linkend="appendixes.configuration.blacklist-whitelist"/>). Isso permite a
+      inclusão de arquivos que ainda não são testados em tudo. Se você quer obter
       informação sobre quais linhas de um tal arquivo descoberto são executadas,
-      por exemplo, você também precisa definir 
-      <literal>processUncoveredFilesFromWhitelist="true"</literal> em suas 
+      por exemplo, você também precisa definir
+      <literal>processUncoveredFilesFromWhitelist="true"</literal> em suas
       configurações do PHPUnit (veja <xref
       linkend="appendixes.configuration.blacklist-whitelist"/>).
     </para>
@@ -203,13 +203,13 @@
     <note>
       <para>
         Por favor, note que o carregamento de arquivos de código-fonte que é realizado, quando
-        <literal>processUncoveredFilesFromWhitelist="true"</literal> é definido, pode 
-        causar problemas quando um arquivo de código-fonte contém código fora do escopo de 
+        <literal>processUncoveredFilesFromWhitelist="true"</literal> é definido, pode
+        causar problemas quando um arquivo de código-fonte contém código fora do escopo de
         uma classe ou função, por exemplo.
       </para>
     </note>
   </section>
-  
+
   <section id="code-coverage-analysis.ignoring-code-blocks">
     <title>Ignorando Blocos de Código</title>
 
@@ -219,11 +219,11 @@
       <indexterm><primary>@codeCoverageIgnoreStart</primary></indexterm>
       <indexterm><primary>@codeCoverageIgnoreEnd</primary></indexterm>
 
-      Às vezes você tem blocos de código que não pode testar e que pode 
-      querer ignorar durante a análise de cobertura de código. O PHPUnit permite que você o faça 
+      Às vezes você tem blocos de código que não pode testar e que pode
+      querer ignorar durante a análise de cobertura de código. O PHPUnit permite que você o faça
       usando as anotações <literal>@codeCoverageIgnore</literal>,
       <literal>@codeCoverageIgnoreStart</literal> e
-      <literal>@codeCoverageIgnoreEnd</literal> como mostrado em 
+      <literal>@codeCoverageIgnoreEnd</literal> como mostrado em
       <xref linkend="code-coverage-analysis.ignoring-code-blocks.examples.Sample.php"/>.
     </para>
 
@@ -262,11 +262,11 @@ exit; // @codeCoverageIgnore
 
     <para>
       As linhas de código ignoradas (marcadas como ignoradas usando as anotações)
-      são contadas como executadas (se forem executáveis) e não serão 
+      são contadas como executadas (se forem executáveis) e não serão
       destacadas.
     </para>
   </section>
-  
+
   <section id="code-coverage-analysis.specifying-covered-methods">
     <title>Especificando métodos cobertos</title>
 
@@ -275,9 +275,9 @@ exit; // @codeCoverageIgnore
       <indexterm><primary>@covers</primary></indexterm>
 
       A anotação <literal>@covers</literal> (veja
-      <xref linkend="appendixes.annotations.covers.tables.annotations"/>) pode ser 
-      usada em um código de teste para especificar qual(is) método(s) um método de teste quer 
-      testar. Se fornecido, apenas a informação de cobertura de código para o(s) método(s) 
+      <xref linkend="appendixes.annotations.covers.tables.annotations"/>) pode ser
+      usada em um código de teste para especificar qual(is) método(s) um método de teste quer
+      testar. Se fornecido, apenas a informação de cobertura de código para o(s) método(s)
       especificado(s) será considerada.
       <xref linkend="code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php"/>
       mostra um exemplo.
@@ -300,7 +300,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -313,7 +313,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -331,7 +331,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -346,11 +346,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -363,8 +363,8 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       Também é possível especificar que um teste não deve cobrir
       <emphasis>qualquer</emphasis> método usando a anotação
       <literal>@coversNothing</literal> (veja
-      <xref linkend="appendixes.annotations.coversNothing"/>). Isso pode ser 
-      útil quando escrever testes de integração para certificar-se de que você só 
+      <xref linkend="appendixes.annotations.coversNothing"/>). Isso pode ser
+      útil quando escrever testes de integração para certificar-se de que você só
       gerará cobertura de código com testes unitários.
     </para>
 
@@ -388,14 +388,14 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
       </programlisting>
     </example>
   </section>
-  
+
   <section id="code-coverage-analysis.edge-cases">
     <title>Casos Extremos</title>
 

--- a/src/4.6/pt_br/database.xml
+++ b/src/4.6/pt_br/database.xml
@@ -3,59 +3,59 @@
 <chapter id="database">
   <title>Testando Bancos de Dados</title>
   <para>
-    Muitos exemplos de testes unitários iniciantes e intermediários em qualquer linguagem de 
-    programação sugerem que é perfeitamente fácil testar a lógica de sua aplicação 
-    com testes simples. Para aplicações centradas em bancos de dados isso está longe 
-    da realidade. Comece a usar Wordpress, TYPO3 ou Symfony com Doctrine ou Propel, 
-    por exemplo, e você vai experimentar facilmente problemas consideráveis com o 
+    Muitos exemplos de testes unitários iniciantes e intermediários em qualquer linguagem de
+    programação sugerem que é perfeitamente fácil testar a lógica de sua aplicação
+    com testes simples. Para aplicações centradas em bancos de dados isso está longe
+    da realidade. Comece a usar Wordpress, TYPO3 ou Symfony com Doctrine ou Propel,
+    por exemplo, e você vai experimentar facilmente problemas consideráveis com o
     PHPUnit: apenas porque o banco de dados é fortemente acoplado com essas bibliotecas.
   </para>
   <para>
-    Você provavelmente conhece esse cenário dos seus trabalhos e projetos diários, 
-    onde você quer colocar em prática suas habilidades (novas ou não) com PHPUnit 
+    Você provavelmente conhece esse cenário dos seus trabalhos e projetos diários,
+    onde você quer colocar em prática suas habilidades (novas ou não) com PHPUnit
     e acaba ficando preso por um dos seguintes problemas:
   </para>
   <orderedlist numeration="arabic">
     <listitem>
       <para>
-        O método que você quer testar executa uma operação JOIN muito grande e 
+        O método que você quer testar executa uma operação JOIN muito grande e
         usa os dados para calcular alguns resultados importantes.
       </para>
     </listitem>
     <listitem>
       <para>
-        Sua lógica de negócios faz uma mistura de declarações SELECT, INSERT, UPDATE 
+        Sua lógica de negócios faz uma mistura de declarações SELECT, INSERT, UPDATE
         e DELETE.
       </para>
     </listitem>
     <listitem>
       <para>
-        Você precisa definir os dados de teste em (provavelmente muito) mais de duas tabelas 
+        Você precisa definir os dados de teste em (provavelmente muito) mais de duas tabelas
         para conseguir dados iniciais razoáveis para os métodos que deseja testar.
       </para>
     </listitem>
   </orderedlist>
   <para>
-    A extensão DbUnit simplifica consideravelmente a configuração de um banco de dados 
-    para fins de teste e permite a você verificar os conteúdos de um banco de dados após 
+    A extensão DbUnit simplifica consideravelmente a configuração de um banco de dados
+    para fins de teste e permite a você verificar os conteúdos de um banco de dados após
     fazer uma série de operações.
   </para>
   <section id="database.supported-vendors-for-database-testing">
     <title>Fornecedores Suportados para Testes de Banco de Dados</title>
     <para>
-      DbUnit atualmente suporta MySQL, PostgreSQL, Oracle e SQLite. Através 
+      DbUnit atualmente suporta MySQL, PostgreSQL, Oracle e SQLite. Através
       das integrações <ulink url="http://framework.zend.com">Zend Framework</ulink> ou
       <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink>
-      ele tem acesso a outros sistemas como IBM DB2 ou 
+      ele tem acesso a outros sistemas como IBM DB2 ou
       Microsoft SQL Server.
     </para>
   </section>
   <section id="database.difficulties-in-database-testing">
     <title>Dificuldades em Testes de Bancos de Dados</title>
     <para>
-      Existe uma boa razão pela qual todos os exemplos de testes unitários não incluírem 
-      interações com bancos de dados: esses tipos de testes são complexos tanto em 
-      configuração quanto em manutenção. Enquanto testar contra seu banco de dados você 
+      Existe uma boa razão pela qual todos os exemplos de testes unitários não incluírem
+      interações com bancos de dados: esses tipos de testes são complexos tanto em
+      configuração quanto em manutenção. Enquanto testar contra seu banco de dados você
       precisará ter cuidado com as seguintes variáveis:
     </para>
     <itemizedlist>
@@ -81,8 +81,8 @@
       </listitem>
     </itemizedlist>
     <para>
-      Por causa de muitas APIs de bancos de dados como PDO, MySQLi ou OCI8 serem incômodos 
-      de usar e verbosas para escrever, fazer esses passos manualmente é um completo 
+      Por causa de muitas APIs de bancos de dados como PDO, MySQLi ou OCI8 serem incômodos
+      de usar e verbosas para escrever, fazer esses passos manualmente é um completo
       pesadelo.
     </para>
     <para>
@@ -91,24 +91,24 @@
     <itemizedlist>
       <listitem>
         <para>
-          Você não quer modificar uma considerável quantidade de código de teste por 
+          Você não quer modificar uma considerável quantidade de código de teste por
           pequenas mudanças em seu código de produção.
         </para>
       </listitem>
       <listitem>
         <para>
-          Você quer ser capaz de ler e entender o código de teste facilmente, 
+          Você quer ser capaz de ler e entender o código de teste facilmente,
           mesmo meses depois de tê-lo escrito.
         </para>
       </listitem>
     </itemizedlist>
     <para>
-      Adicionalmente você tem que perceber que o banco de dados é essencialmente 
-      uma variável global de entrada para seu código. Dois testes em sua suíte de testes 
-      podem executar contra o mesmo banco de dados, possivelmente reutilizando dados 
-      múltiplas vezes. Falhas em um teste podem facilmente afetar o resultado dos 
-      testes seguintes, fazendo sua experiência com os testes muito difícil. O 
-      passo de limpeza mencionado anteriormente é de maior importância 
+      Adicionalmente você tem que perceber que o banco de dados é essencialmente
+      uma variável global de entrada para seu código. Dois testes em sua suíte de testes
+      podem executar contra o mesmo banco de dados, possivelmente reutilizando dados
+      múltiplas vezes. Falhas em um teste podem facilmente afetar o resultado dos
+      testes seguintes, fazendo sua experiência com os testes muito difícil. O
+      passo de limpeza mencionado anteriormente é de maior importância
       para resolver o problema do <quote>banco de dados ser uma entrada global</quote>.
     </para>
     <para>
@@ -116,26 +116,26 @@
       forma elegante.
     </para>
     <para>
-      O PHPUnit só não pode ajudá-lo no fato de que testes de banco de dados 
-      são muito lentos comparados aos testes que não usam bancos de dados. Dependendo 
-      do tamanho das interações com seu banco de dados, seus testes 
-      podem levar um tempo considerável para executar. Porém se você mantiver pequena 
-      a quantidade de dados usados para cada teste e tentar testar o máximo possível 
-      sem usar testes com bancos de dados, você facilmente conseguirá tempos abaixo de um minuto, 
+      O PHPUnit só não pode ajudá-lo no fato de que testes de banco de dados
+      são muito lentos comparados aos testes que não usam bancos de dados. Dependendo
+      do tamanho das interações com seu banco de dados, seus testes
+      podem levar um tempo considerável para executar. Porém se você mantiver pequena
+      a quantidade de dados usados para cada teste e tentar testar o máximo possível
+      sem usar testes com bancos de dados, você facilmente conseguirá tempos abaixo de um minuto,
       mesmo para grandes suítes de teste.
     </para>
     <para>
-      A suíte de testes do <ulink url="http://www.doctrine-project.org">projeto 
-      Doctrine 2</ulink> por exemplo, atualmente tem uma suíte com 
-      cerca de 1000 testes onde aproximadamente a metade deles tem acesso ao banco 
-      de dados e ainda executa em 15 segundos contra um banco de dados MySQL em 
+      A suíte de testes do <ulink url="http://www.doctrine-project.org">projeto
+      Doctrine 2</ulink> por exemplo, atualmente tem uma suíte com
+      cerca de 1000 testes onde aproximadamente a metade deles tem acesso ao banco
+      de dados e ainda executa em 15 segundos contra um banco de dados MySQL em
       um computador desktop comum.
     </para>
   </section>
   <section id="database.the-four-stages-of-a-database-test">
     <title>Os quatro estágios dos testes com banco de dados</title>
     <para>
-      Em seu livro sobre Padrões de Teste xUnit, Gerard Meszaros lista os quatro 
+      Em seu livro sobre Padrões de Teste xUnit, Gerard Meszaros lista os quatro
       estágios de um teste unitário:
     </para>
     <orderedlist numeration="arabic">
@@ -165,45 +165,45 @@
         <emphasis role="strong">O que é um ambiente (fixture)?</emphasis>
       </para>
       <para>
-        Um ambiente (fixture) descreve o estado inicial em que sua aplicação e seu banco de dados 
+        Um ambiente (fixture) descreve o estado inicial em que sua aplicação e seu banco de dados
         estão ao executar um teste.
       </para>
     </blockquote>
     <para>
-      Testar o banco de dados exige que você utilize pelo menos o 
-      setup (configuração) e teardown (desmontagem) para limpar e escrever em suas tabelas 
-      os dados de ambiente exigidos. Porém a extensão do banco de dados tem uma boa razão para 
-      reverter esses quatro estágios em um teste de banco de dados para assemelhar o seguinte 
+      Testar o banco de dados exige que você utilize pelo menos o
+      setup (configuração) e teardown (desmontagem) para limpar e escrever em suas tabelas
+      os dados de ambiente exigidos. Porém a extensão do banco de dados tem uma boa razão para
+      reverter esses quatro estágios em um teste de banco de dados para assemelhar o seguinte
       fluxo de trabalho que é executado para cada teste:
     </para>
     <section id="database.clean-up-database">
       <title>1. Limpar o Banco de Dados</title>
       <para>
-        Já que sempre existe um primeiro teste que é executado contra o banco de dados, 
-        você não sabe exatamente se já existem dados nas tabelas. 
-        O PHPUnit vai executar um TRUNCATE contra todas as tabelas que 
+        Já que sempre existe um primeiro teste que é executado contra o banco de dados,
+        você não sabe exatamente se já existem dados nas tabelas.
+        O PHPUnit vai executar um TRUNCATE contra todas as tabelas que
         você especificou para redefinir seus estados para vazio.
       </para>
     </section>
     <section id="database.set-up-fixture">
       <title>2. Configurar o ambiente</title>
       <para>
-        O PHPUnit então vai iterar sobre todas as linhas do ambiente especificado e 
+        O PHPUnit então vai iterar sobre todas as linhas do ambiente especificado e
         inseri-las em suas respectivas tabelas.
       </para>
     </section>
     <section id="database.run-test-verify-outcome-and-teardown">
       <title>3–5. Executar Teste, Verificar resultado e Desmontar (Teardown)</title>
       <para>
-        Depois de redefinir o banco de dados e carregá-lo com seu estado inicial, 
-        o verdadeiro teste é executado pelo PHPUnit. Esta parte do código de teste 
-        não exige conhecimento sobre a Extensão do Banco de Dados, então você pode 
+        Depois de redefinir o banco de dados e carregá-lo com seu estado inicial,
+        o verdadeiro teste é executado pelo PHPUnit. Esta parte do código de teste
+        não exige conhecimento sobre a Extensão do Banco de Dados, então você pode
         prosseguir e testar o que quiser com seu código.
       </para>
       <para>
         Em seu teste use uma asserção especial chamada
-        <literal>assertDataSetsEqual()</literal> para fins de verificação, 
-        porém isso é totalmente opcional. Esta função será explicada 
+        <literal>assertDataSetsEqual()</literal> para fins de verificação,
+        porém isso é totalmente opcional. Esta função será explicada
         na seção <quote>Asserções em Bancos de Dados</quote>.
       </para>
     </section>
@@ -211,8 +211,8 @@
   <section id="database.configuration-of-a-phpunit-database-testcase">
     <title>Configuração de um Caso de Teste de Banco de Dados do PHPUnit</title>
     <para>
-      Ao usar o PHPUnit seus casos de teste vão estender a 
-      classe <literal>PHPUnit_Framework_TestCase</literal> da 
+      Ao usar o PHPUnit seus casos de teste vão estender a
+      classe <literal>PHPUnit_Framework_TestCase</literal> da
       seguinte forma:
     </para>
     <programlisting><![CDATA[<?php
@@ -220,13 +220,13 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
     <para>
-      Se você quer um código de teste que trabalha com a Extensão para Banco de Dados a 
-      configuração é um pouco mais complexa e você terá que estender um TestCase abstrato 
+      Se você quer um código de teste que trabalha com a Extensão para Banco de Dados a
+      configuração é um pouco mais complexa e você terá que estender um TestCase abstrato
       diferente, exigindo que você implemente dois métodos abstratos
       <literal>getConnection()</literal> e
       <literal>getDataSet()</literal>:
@@ -255,65 +255,65 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.implementing-getconnection">
       <title>Implementando getConnection()</title>
       <para>
-        Para permitir que a limpeza e o carregamento de funcionalidades do ambiente funcionem, 
-        a Extensão do Banco de Dados do PHPUnit exige acesso a uma conexão 
-        abstrata do banco de dados através dos fornecedores da biblioteca PDO. É 
-        importante notar que sua aplicação não precisa ser 
-        baseada em PDO para usar a Extensão para Banco de Dados do PHPUnit, pois a conexão é 
+        Para permitir que a limpeza e o carregamento de funcionalidades do ambiente funcionem,
+        a Extensão do Banco de Dados do PHPUnit exige acesso a uma conexão
+        abstrata do banco de dados através dos fornecedores da biblioteca PDO. É
+        importante notar que sua aplicação não precisa ser
+        baseada em PDO para usar a Extensão para Banco de Dados do PHPUnit, pois a conexão é
         meramente usada para limpeza e configuração de ambiente.
       </para>
       <para>
-        No exemplo anterior criamos uma conexão Sqlite na memória e 
+        No exemplo anterior criamos uma conexão Sqlite na memória e
         a passamos ao método <literal>createDefaultDBConnection</literal>
-        que embrulha a instância do PDO e o segundo parâmetro (o 
-        nome do banco de dados) em uma camada simples de abstração para conexões 
+        que embrulha a instância do PDO e o segundo parâmetro (o
+        nome do banco de dados) em uma camada simples de abstração para conexões
         do banco de dados do tipo
         <literal>PHPUnit_Extensions_Database_DB_IDatabaseConnection</literal>.
       </para>
       <para>
-        A seção <quote>Usando a Conexão de Banco de Dados</quote> explica 
+        A seção <quote>Usando a Conexão de Banco de Dados</quote> explica
         a API desta interface e como você pode usá-la da melhor forma possível.
       </para>
     </section>
     <section id="database.implementing-getdataset">
       <title>Implementando getDataSet()</title>
       <para>
-        O método <literal>getDataSet()</literal> define como deve ser o estado 
-        inicial do banco de dados antes de cada teste ser 
-        executado. O estado do banco de dados é abstraído através de 
-        conceitos DataSet (Conjunto de Dados) e DataTable (Tabela de Dados), ambos sendo representados 
+        O método <literal>getDataSet()</literal> define como deve ser o estado
+        inicial do banco de dados antes de cada teste ser
+        executado. O estado do banco de dados é abstraído através de
+        conceitos DataSet (Conjunto de Dados) e DataTable (Tabela de Dados), ambos sendo representados
         pelas interfaces
         <literal>PHPUnit_Extensions_Database_DataSet_IDataSet</literal> e
         <literal>PHPUnit_Extensions_Database_DataSet_IDataTable</literal>.
-        A próxima seção vai descrever em detalhes como esses conceitos trabalham 
+        A próxima seção vai descrever em detalhes como esses conceitos trabalham
         e quais os benefícios de usá-los nos testes com bancos de dados.
       </para>
       <para>
-        Para a implementação precisaremos apenas saber que o 
+        Para a implementação precisaremos apenas saber que o
         método <literal>getDataSet()</literal> é chamado uma vez durante o
-        <literal>setUp()</literal> para recuperar o conjunto de dados do ambiente e 
-        inseri-lo no banco de dados. No exemplo estamos usando um método de fábrica 
-        <literal>createFlatXMLDataSet($filename)</literal> que 
+        <literal>setUp()</literal> para recuperar o conjunto de dados do ambiente e
+        inseri-lo no banco de dados. No exemplo estamos usando um método de fábrica
+        <literal>createFlatXMLDataSet($filename)</literal> que
         representa um conjunto de dados através de uma representação XML.
       </para>
     </section>
     <section id="database.what-about-the-database-schema-ddl">
       <title>E quanto ao Esquema do Banco de Dados (DDL)?</title>
       <para>
-        O PHPUnit assume que o esquema do banco de dados com todas as suas tabelas, 
-        gatilhos, sequências e visualizações é criado antes que um teste seja executado. Isso 
-        quer dizer que você como desenvolvedor deve se certificar que o banco de dados está 
+        O PHPUnit assume que o esquema do banco de dados com todas as suas tabelas,
+        gatilhos, sequências e visualizações é criado antes que um teste seja executado. Isso
+        quer dizer que você como desenvolvedor deve se certificar que o banco de dados está
         corretamente configurado antes de executar a suíte.
       </para>
       <para>
-        Existem vários meios para realizar esta pré-condição para 
+        Existem vários meios para realizar esta pré-condição para
         testar bancos de dados.
       </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Se você está usando um banco de dados persistente (não Sqlite Memory) você pode 
-            facilmente configurar o banco de dados uma vez com ferramentas como phpMyAdmin para 
+            Se você está usando um banco de dados persistente (não Sqlite Memory) você pode
+            facilmente configurar o banco de dados uma vez com ferramentas como phpMyAdmin para
             MySQL e reutilizar o banco de dados para cada execução de teste.
           </para>
         </listitem>
@@ -322,8 +322,8 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
             Se você estiver usando bibliotecas como
             <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink> ou
             <ulink url="http://www.propelorm.org/">Propel</ulink>
-            você pode usar suas APIs para criar o esquema de banco de dados que 
-            precisa antes de rodar os testes. Você pode utilizar as capacidades de 
+            você pode usar suas APIs para criar o esquema de banco de dados que
+            precisa antes de rodar os testes. Você pode utilizar as capacidades de
             <ulink url="textui.html">Configuração e Bootstrap do PHPUnit</ulink>
             para executar esse código sempre que seus testes forem executados.
           </para>
@@ -333,12 +333,12 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.tip-use-your-own-abstract-database-testcase">
       <title>Dica: Use seu próprio Caso Abstrato de Teste de Banco de Dados</title>
       <para>
-        Do exemplo prévio de implementação você pode facilmente perceber que 
-        o método <literal>getConnection()</literal> é bastante estático e 
-        pode ser reutilizado em diferentes casos de teste de banco de dados. Adicionalmente para 
-        manter uma boa performance dos seus testes e pouca carga sobre seu banco de dados, você 
-        pode refatorar o código um pouco para obter um caso de teste abstrato genérico 
-        para sua aplicação, o que ainda permite a você especificar um 
+        Do exemplo prévio de implementação você pode facilmente perceber que
+        o método <literal>getConnection()</literal> é bastante estático e
+        pode ser reutilizado em diferentes casos de teste de banco de dados. Adicionalmente para
+        manter uma boa performance dos seus testes e pouca carga sobre seu banco de dados, você
+        pode refatorar o código um pouco para obter um caso de teste abstrato genérico
+        para sua aplicação, o que ainda permite a você especificar um
         ambiente de dados diferente para cada caso de teste:
       </para>
       <programlisting><![CDATA[<?php
@@ -364,12 +364,12 @@ abstract class MyApp_Tests_DatabaseTestCase extends PHPUnit_Extensions_Database_
 }
 ?>]]></programlisting>
       <para>
-        Entretanto, isso tem a conexão ao banco de dados codificada na conexão do PDO. 
-        O PHPUnit tem outra incrível característica que pode fazer este 
+        Entretanto, isso tem a conexão ao banco de dados codificada na conexão do PDO.
+        O PHPUnit tem outra incrível característica que pode fazer este
         caso de teste ainda mais genérico. Se você usar a
         <ulink url="appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">Configuração XML</ulink>
-        você pode tornar a conexão com o banco de dados configurável por execução de teste. 
-        Primeiro vamos criar um arquivo <quote>phpunit.xml</quote> em nosso diretório/de/teste 
+        você pode tornar a conexão com o banco de dados configurável por execução de teste.
+        Primeiro vamos criar um arquivo <quote>phpunit.xml</quote> em nosso diretório/de/teste
         da aplicação, de forma semelhante a isto:
       </para>
       <screen><![CDATA[
@@ -409,16 +409,16 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 }
 ?>]]></programlisting>
       <para>
-        Agora podemos executar a suíte de testes de banco de dados usando diferentes 
+        Agora podemos executar a suíte de testes de banco de dados usando diferentes
         configurações através da interface de linha-de-comando:
       </para>
       <screen><userinput>user@desktop> phpunit --configuration developer-a.xml MyTests/</userinput>
 <userinput>user@desktop> phpunit --configuration developer-b.xml MyTests/</userinput></screen>
       <para>
-        A possibilidade de executar facilmente os testes de banco de dados contra diferentes 
-        alvos é muito importante se você está desenvolvendo na 
-        máquina de desenvolvimento. Se vários desenvolvedores executarem os testes de banco 
-        de dados contra a mesma conexão de banco de dados você experimentará facilmente 
+        A possibilidade de executar facilmente os testes de banco de dados contra diferentes
+        alvos é muito importante se você está desenvolvendo na
+        máquina de desenvolvimento. Se vários desenvolvedores executarem os testes de banco
+        de dados contra a mesma conexão de banco de dados você experimentará facilmente
         falhas de testes devido à condição de execução.
       </para>
     </section>
@@ -426,36 +426,36 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
   <section id="database.understanding-datasets-and-datatables">
     <title>Entendendo Conjunto de Dados e Tabelas de Dados</title>
     <para>
-      Um conceito central da Extensão para Banco de Dados do PHPUnit são 
-      os Conjuntos de Dados e as Tabelas de Dados. Você deveria tentar entender este conceito simples para 
-      dominar os testes de banco de dados com PHPUnit. Conjunto de Dados e Tabela de Dados formam 
-      uma camada abstrata em torno das tabelas, linhas e 
-      colunas do seu banco de dados. Uma simples API esconde os conteúdos subjacentes do banco de dados em uma 
-      estrutura de objetos, que também podem ser implementada por outra 
+      Um conceito central da Extensão para Banco de Dados do PHPUnit são
+      os Conjuntos de Dados e as Tabelas de Dados. Você deveria tentar entender este conceito simples para
+      dominar os testes de banco de dados com PHPUnit. Conjunto de Dados e Tabela de Dados formam
+      uma camada abstrata em torno das tabelas, linhas e
+      colunas do seu banco de dados. Uma simples API esconde os conteúdos subjacentes do banco de dados em uma
+      estrutura de objetos, que também podem ser implementada por outra
       fonte que não seja um banco de dados.
     </para>
     <para>
-      Essa abstração é necessária para comparar os conteúdos reais de um 
-      banco de dados contra os conteúdos esperados. Expectativas podem ser 
-      representadas como arquivos XML, YAML, CSV ou vetores PHP, por exemplo. As 
-      interfaces DataSet (Conjunto de Dados) e DataTable (Tabela de Dados)  permitem a comparação dessas 
-      fontes conceitualmente diferentes, emulando o armazenamento de banco de dados 
+      Essa abstração é necessária para comparar os conteúdos reais de um
+      banco de dados contra os conteúdos esperados. Expectativas podem ser
+      representadas como arquivos XML, YAML, CSV ou vetores PHP, por exemplo. As
+      interfaces DataSet (Conjunto de Dados) e DataTable (Tabela de Dados)  permitem a comparação dessas
+      fontes conceitualmente diferentes, emulando o armazenamento de banco de dados
       relacional em uma abordagem semanticamente similar.
     </para>
     <para>
-      Um fluxo de trabalho para asserções em banco de dados em seus testes então consiste de 
+      Um fluxo de trabalho para asserções em banco de dados em seus testes então consiste de
       três passos simples:
     </para>
     <itemizedlist>
       <listitem>
         <para>
-          Especificar uma ou mais tabelas em seu banco de dados por nome de tabela (conjunto de dados 
+          Especificar uma ou mais tabelas em seu banco de dados por nome de tabela (conjunto de dados
           real)
         </para>
       </listitem>
       <listitem>
         <para>
-          Especificar o Conjunto de Dados esperado no seu formato preferido (YAML, XML, 
+          Especificar o Conjunto de Dados esperado no seu formato preferido (YAML, XML,
           ...)
         </para>
       </listitem>
@@ -466,10 +466,10 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
       </listitem>
     </itemizedlist>
     <para>
-      Asserções não são o único caso de uso para o Conjunto de Dados e a Tabela de Dados 
-      na Extensão para Banco de Dados do PHPUnit. Como mostrado na seção anterior, 
-      eles também descrevem os conteúdos iniciais de um banco de dados. Você é 
-      forçado a definir um conjunto de dados de ambiente pelo Caso de Teste de Banco de Dados, que 
+      Asserções não são o único caso de uso para o Conjunto de Dados e a Tabela de Dados
+      na Extensão para Banco de Dados do PHPUnit. Como mostrado na seção anterior,
+      eles também descrevem os conteúdos iniciais de um banco de dados. Você é
+      forçado a definir um conjunto de dados de ambiente pelo Caso de Teste de Banco de Dados, que
       então é usado para:
     </para>
     <itemizedlist>
@@ -507,17 +507,17 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
         </listitem>
       </itemizedlist>
       <para>
-        Os Conjuntos de Dados e Tabelas de Dados baseadas em arquivo são geralmente usados para o 
+        Os Conjuntos de Dados e Tabelas de Dados baseadas em arquivo são geralmente usados para o
         ambiente inicial e para descrever os estados esperados do banco de dados.
       </para>
       <section id="database.flat-xml-dataset">
         <title>Conjunto de Dados de XML Plano</title>
         <para>
-          O Conjunto de Dados mais comum é chamado XML Plano. É um formato xml simples 
+          O Conjunto de Dados mais comum é chamado XML Plano. É um formato xml simples
           onde uma tag dentro do nó-raiz
-          <literal><![CDATA[<dataset>]]></literal> representa exatamente uma linha no 
-          banco de dados. Os nomes das tags equivalem à tabela onde inserir a linha e 
-          um atributo representa a coluna. Um exemplo para uma simples aplicação de 
+          <literal><![CDATA[<dataset>]]></literal> representa exatamente uma linha no
+          banco de dados. Os nomes das tags equivalem à tabela onde inserir a linha e
+          um atributo representa a coluna. Um exemplo para uma simples aplicação de
           livro de visitas poderia se parecer com isto:
         </para>
         <screen><![CDATA[
@@ -529,7 +529,7 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 ]]></screen>
         <para>
           Isso é, obviamente, fácil de escrever. Aqui
-          <literal><![CDATA[<guestbook>]]></literal> é o nome da tabela onde duas linhas 
+          <literal><![CDATA[<guestbook>]]></literal> é o nome da tabela onde duas linhas
           são inseridas dentro de cada com quatro colunas <quote>id</quote>,
           <quote>content</quote>, <quote>user</quote> e
           <quote>created</quote> com seus respectivos valores.
@@ -538,9 +538,9 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
           Porém essa simplicidade tem um preço.
         </para>
         <para>
-          O exemplo anterior não deixa tão óbvio como você pode fazer para especificar uma 
-          tabela vazia. Você pode inserir uma tag sem atributos com o nome da 
-          tabela vazia. Um arquivo xml plano para uma tabela vazia do livro de visitas 
+          O exemplo anterior não deixa tão óbvio como você pode fazer para especificar uma
+          tabela vazia. Você pode inserir uma tag sem atributos com o nome da
+          tabela vazia. Um arquivo xml plano para uma tabela vazia do livro de visitas
           ficaria parecido com isso:
         </para>
         <screen><![CDATA[
@@ -550,13 +550,13 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 </dataset>
 ]]></screen>
         <para>
-          A manipulação de valores NULL com o xml plano é tedioso. Um 
-          valor NULL é diferente de uma string com valor vazio em quase todos 
-          os bancos de dados (Oracle é uma exceção), algo difícil 
-          de descrever no formato xml plano. Você pode representar um valor NULL 
-          omitindo o atributo da especificação da linha. Se nosso 
-          livro de visitas vai permitir entradas anônimas representadas por um valor NULL 
-          na coluna user, um estado hipotético para a tabela do livro de visitas 
+          A manipulação de valores NULL com o xml plano é tedioso. Um
+          valor NULL é diferente de uma string com valor vazio em quase todos
+          os bancos de dados (Oracle é uma exceção), algo difícil
+          de descrever no formato xml plano. Você pode representar um valor NULL
+          omitindo o atributo da especificação da linha. Se nosso
+          livro de visitas vai permitir entradas anônimas representadas por um valor NULL
+          na coluna user, um estado hipotético para a tabela do livro de visitas
           seria parecido com:
         </para>
         <screen><![CDATA[
@@ -567,47 +567,47 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 </dataset>
 ]]></screen>
         <para>
-          Nesse caso a segunda entrada é postada anonimamente. Porém isso 
-          acarreta um problema sério no reconhecimento de colunas. Durante as asserções de igualdade 
-          do conjunto de dados, cada conjunto de dados tem que especificar quais colunas uma 
-          tabela possui. Se um atributo for NULL para todas as linhas de uma 
-          tabela de dados, como a Extensão para Banco de Dados vai saber que a coluna 
+          Nesse caso a segunda entrada é postada anonimamente. Porém isso
+          acarreta um problema sério no reconhecimento de colunas. Durante as asserções de igualdade
+          do conjunto de dados, cada conjunto de dados tem que especificar quais colunas uma
+          tabela possui. Se um atributo for NULL para todas as linhas de uma
+          tabela de dados, como a Extensão para Banco de Dados vai saber que a coluna
           deve ser parte da tabela?
         </para>
         <para>
-          O conjunto de dados em xml plano faz uma presunção crucial agora, definindo que 
-          os atributos na primeira linha definida de uma tabela define as 
+          O conjunto de dados em xml plano faz uma presunção crucial agora, definindo que
+          os atributos na primeira linha definida de uma tabela define as
           colunas dessa tabela. No exemplo anterior isso significaria que
           <quote>id</quote>, <quote>content</quote>, <quote>user</quote> e
-          <quote>created</quote> são colunas da tabela guestbook. Para a 
-          segunda linha, onde <quote>user</quote> não está definido, um NULL seria 
+          <quote>created</quote> são colunas da tabela guestbook. Para a
+          segunda linha, onde <quote>user</quote> não está definido, um NULL seria
           inserido no banco de dados.
         </para>
         <para>
           Quando a primeira entrada do guestbook for apagada do conjunto de dados, apenas
           <quote>id</quote>, <quote>content</quote> e
-          <quote>created</quote> seriam colunas da tabela guestbook, 
+          <quote>created</quote> seriam colunas da tabela guestbook,
           já que <quote>user</quote> não é especificado.
         </para>
         <para>
-          Para usar o Conjunto de Dados em XML Plano efetivamente, quando valores NULL forem 
-          relevantes, a primeira linha de cada tabela não deve conter qualquer valor NULL 
-          e apenas as linhas seguintes poderão omitir atributos. Isso 
-          pode parecer estranho, já que a ordem das linhas é um fator relevante 
+          Para usar o Conjunto de Dados em XML Plano efetivamente, quando valores NULL forem
+          relevantes, a primeira linha de cada tabela não deve conter qualquer valor NULL
+          e apenas as linhas seguintes poderão omitir atributos. Isso
+          pode parecer estranho, já que a ordem das linhas é um fator relevante
           para as asserções com bancos de dados.
         </para>
         <para>
-          Em troca, se você especificar apenas um subconjunto das colunas da tabela no 
-          Conjunto de Dados do XML Plano, todos os valores omitidos serão definidos para seus valores 
-          padrão. Isso vai induzir a erros se uma das colunas omitidas estiver 
+          Em troca, se você especificar apenas um subconjunto das colunas da tabela no
+          Conjunto de Dados do XML Plano, todos os valores omitidos serão definidos para seus valores
+          padrão. Isso vai induzir a erros se uma das colunas omitidas estiver
           definida como <quote>NOT NULL DEFAULT NULL</quote>.
         </para>
         <para>
-          Para concluir eu posso dizer que os conjuntos de dados XML Plano só devem ser usadas se você 
+          Para concluir eu posso dizer que os conjuntos de dados XML Plano só devem ser usadas se você
           não precisar de valores NULL.
         </para>
         <para>
-          Você pode criar uma instância de conjunto de dados xml plano de dentro de seu 
+          Você pode criar uma instância de conjunto de dados xml plano de dentro de seu
           Caso de Teste de Banco de Dados chamando o método
           <literal>createFlatXmlDataSet($filename)</literal>:
         </para>
@@ -624,13 +624,13 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
       <section id="database.xml-dataset">
         <title>Conjunto de Dados XML</title>
         <para>
-          Existe um outro Conjunto de Dados em XML mais estruturado, que é um pouco mais 
-          verboso para escrever mas evita os problemas do NULL nos conjuntos de dados em 
-          XML Plano. Dentro do nó-raiz <literal><![CDATA[<dataset>]]></literal> você 
+          Existe um outro Conjunto de Dados em XML mais estruturado, que é um pouco mais
+          verboso para escrever mas evita os problemas do NULL nos conjuntos de dados em
+          XML Plano. Dentro do nó-raiz <literal><![CDATA[<dataset>]]></literal> você
           pode especificar as tags <literal><![CDATA[<table>]]></literal>,
           <literal><![CDATA[<column>]]></literal>, <literal><![CDATA[<row>]]></literal>,
           <literal><![CDATA[<value>]]></literal> e
-          <literal><![CDATA[<null />]]></literal>. Um Conjunto de Dados equivalente ao 
+          <literal><![CDATA[<null />]]></literal>. Um Conjunto de Dados equivalente ao
           definido anteriormente no Guestbook em XML Plano seria como:
         </para>
         <screen><![CDATA[
@@ -657,19 +657,19 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
 </dataset>
 ]]></screen>
         <para>
-          Qualquer <literal><![CDATA[<table>]]></literal> definida tem um nome e requer 
-          uma definição de todas as colunas com seus nomes. Pode conter zero 
-          ou qualquer número positivo de elementos <literal><![CDATA[<row>]]></literal> 
-          aninhados. Não definir nenhum elemento <literal><![CDATA[<row>]]></literal> significa 
+          Qualquer <literal><![CDATA[<table>]]></literal> definida tem um nome e requer
+          uma definição de todas as colunas com seus nomes. Pode conter zero
+          ou qualquer número positivo de elementos <literal><![CDATA[<row>]]></literal>
+          aninhados. Não definir nenhum elemento <literal><![CDATA[<row>]]></literal> significa
           que a tabela está vazia. As tags <literal><![CDATA[<value>]]></literal> e
-          <literal><![CDATA[<null />]]></literal> têm que ser especificadas na 
-          ordem dos elementos fornecidos previamente em 
-          <literal><![CDATA[<column>]]></literal>. A tag <literal><![CDATA[<null />]]></literal> obviamente significa 
+          <literal><![CDATA[<null />]]></literal> têm que ser especificadas na
+          ordem dos elementos fornecidos previamente em
+          <literal><![CDATA[<column>]]></literal>. A tag <literal><![CDATA[<null />]]></literal> obviamente significa
           que o valor é NULL.
         </para>
         <para>
-          Você pode criar uma instância de conjunto de dados xml de dentro de seu 
-          Caso de Teste de Banco de Dados chamando o método 
+          Você pode criar uma instância de conjunto de dados xml de dentro de seu
+          Caso de Teste de Banco de Dados chamando o método
           <literal>createXmlDataSet($filename)</literal>:
         </para>
         <programlisting><![CDATA[<?php
@@ -687,12 +687,12 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
         <para>
           Este novo formato XML é específico para o
           <ulink url="http://www.mysql.com">servidor de banco de dados MySQL</ulink>.
-          O suporte para ele foi adicionado no PHPUnit 3.5. Arquivos nesse formato podem 
-          ser gerados usando o utilitário 
-          <ulink url="http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html"><literal>mysqldump</literal></ulink>. 
+          O suporte para ele foi adicionado no PHPUnit 3.5. Arquivos nesse formato podem
+          ser gerados usando o utilitário
+          <ulink url="http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html"><literal>mysqldump</literal></ulink>.
           Diferente dos conjuntos de dados CSV, que o <literal>mysqldump</literal>
-          também suporta, um único arquivo neste formato XML pode conter dados 
-          para múltiplas tabelas. Você pode criar um arquivo nesse formato 
+          também suporta, um único arquivo neste formato XML pode conter dados
+          para múltiplas tabelas. Você pode criar um arquivo nesse formato
           invocando o <literal>mysqldump</literal> desta forma:
         </para>
         <screen><userinput>mysqldump --xml -t -u [username] --password=[password] [database] > /path/to/file.xml</userinput></screen>
@@ -729,13 +729,13 @@ guestbook:
     created: 2010-04-26 12:14:20
 ]]></screen>
         <para>
-          Isso é simples, conveniente E resolve o problema do NULL que o 
-          Conjunto de Dados similar do XML Plano tem. Um NULL em um YAML é apenas o nome 
+          Isso é simples, conveniente E resolve o problema do NULL que o
+          Conjunto de Dados similar do XML Plano tem. Um NULL em um YAML é apenas o nome
           da coluna sem nenhum valor especificado. Uma string vazia é especificada como
           <literal><![CDATA[column1: ""]]></literal>.
         </para>
         <para>
-          O Conjunto de Dados YAML atualmente não possui método fábrica no Caso de Teste 
+          O Conjunto de Dados YAML atualmente não possui método fábrica no Caso de Teste
           de Banco de Dados, então você tem que instanciar manualmente:
         </para>
         <programlisting><![CDATA[<?php
@@ -753,8 +753,8 @@ class YamlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.csv-dataset">
         <title>Conjunto de Dados CSV</title>
         <para>
-          Outro Conjunto de Dados baseado em arquivo, com arquivos CSV. Cada tabela do 
-          conjunto de dados é representada como um único arquivo CSV. Para nosso exemplo 
+          Outro Conjunto de Dados baseado em arquivo, com arquivos CSV. Cada tabela do
+          conjunto de dados é representada como um único arquivo CSV. Para nosso exemplo
           do guestbook, vamos definir um arquivo guestbook-table.csv:
         </para>
         <screen><![CDATA[
@@ -763,9 +763,9 @@ id,content,user,created
 2,"I like it!","nancy","2010-04-26 12:14:20"
 ]]></screen>
         <para>
-          Apesar disso ser muito conveniente para edição no Excel ou OpenOffice, 
-          você não pode especificar valores NULL em um Conjunto de Dados CSV. Uma coluna 
-          vazia levaria a um valor vazio padrão de banco de dados a ser inserido 
+          Apesar disso ser muito conveniente para edição no Excel ou OpenOffice,
+          você não pode especificar valores NULL em um Conjunto de Dados CSV. Uma coluna
+          vazia levaria a um valor vazio padrão de banco de dados a ser inserido
           na coluna.
         </para>
         <para>
@@ -786,8 +786,8 @@ class CsvGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.array-dataset">
         <title>Conjunto de Dados em Vetor</title>
         <para>
-          Não existe (ainda) Conjunto de Dados baseado em vetor na Extensão para Banco de Dados 
-          do PHPUnit, mas podemos implementar o nosso próprio facilmente. Nosso exemplo do guestbook 
+          Não existe (ainda) Conjunto de Dados baseado em vetor na Extensão para Banco de Dados
+          do PHPUnit, mas podemos implementar o nosso próprio facilmente. Nosso exemplo do guestbook
           deveria ficar parecido com:
         </para>
         <programlisting><![CDATA[<?php
@@ -805,7 +805,7 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
 }
 ?>]]></programlisting>
         <para>
-          Um Conjunto de Dados do PHP tem algumas vantagens óbvias sobre todas os outros 
+          Um Conjunto de Dados do PHP tem algumas vantagens óbvias sobre todas os outros
           conjuntos de dados baseados em arquivos:
         </para>
         <itemizedlist>
@@ -816,20 +816,20 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
           </listitem>
           <listitem>
             <para>
-              Você não precisa de arquivos adicionais para asserções e pode especificá-las diretamente 
+              Você não precisa de arquivos adicionais para asserções e pode especificá-las diretamente
               no Caso de Teste.
             </para>
           </listitem>
         </itemizedlist>
         <para>
-          Para este Conjunto de Dados, como nos Conjuntos de Dados em XML Plano, CSV e YAML, as chaves 
-          da primeira linha especificada definem os nomes das colunas das tabelas, que no 
+          Para este Conjunto de Dados, como nos Conjuntos de Dados em XML Plano, CSV e YAML, as chaves
+          da primeira linha especificada definem os nomes das colunas das tabelas, que no
           caso anterior seriam <quote>id</quote>,
           <quote>content</quote>, <quote>user</quote> e
           <quote>created</quote>.
         </para>
         <para>
-          A implementação para este Conjunto de Dados em Vetor é simples e 
+          A implementação para este Conjunto de Dados em Vetor é simples e
           direta:
         </para>
         <programlisting><![CDATA[<?php
@@ -880,8 +880,8 @@ class MyApp_DbUnit_ArrayDataSet extends PHPUnit_Extensions_Database_DataSet_Abst
       <section id="database.query-sql-dataset">
         <title>Conjunto de Dados Query (SQL)</title>
         <para>
-          Para asserções de banco de dados você não precisa somente de conjuntos de dados baseados em arquivos, 
-          mas também de conjuntos de dados baseados em Query/SQL que contenha os conteúdos 
+          Para asserções de banco de dados você não precisa somente de conjuntos de dados baseados em arquivos,
+          mas também de conjuntos de dados baseados em Query/SQL que contenha os conteúdos
           reais do banco de dados. É aí que entra o Query DataSet:
         </para>
         <programlisting><![CDATA[<?php
@@ -889,7 +889,7 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook');
 ?>]]></programlisting>
         <para>
-          Adicionar uma tabela apenas por nome é um modo implícito de definir a 
+          Adicionar uma tabela apenas por nome é um modo implícito de definir a
           tabela de dados com a seguinte query:
         </para>
         <programlisting><![CDATA[<?php
@@ -897,8 +897,8 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook', 'SELECT * FROM guestbook');
 ?>]]></programlisting>
         <para>
-          Você pode fazer uso disso especificando queries arbitrárias para suas 
-          tabelas, por exemplo restringindo linhas, colunas, ou adicionando 
+          Você pode fazer uso disso especificando queries arbitrárias para suas
+          tabelas, por exemplo restringindo linhas, colunas, ou adicionando
           cláusulas <literal>ORDER BY</literal>:
         </para>
         <programlisting><![CDATA[<?php
@@ -906,22 +906,22 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook', 'SELECT id, content FROM guestbook ORDER BY created DESC');
 ?>]]></programlisting>
         <para>
-          A seção nas Asserções de Banco de Dados mostrará mais alguns detalhes sobre 
+          A seção nas Asserções de Banco de Dados mostrará mais alguns detalhes sobre
           como fazer uso do Conjunto de Dados Query.
         </para>
       </section>
       <section id="database.database-db-dataset">
         <title>Conjunto de Dados de Banco de Dados (BD)</title>
         <para>
-          Acessando a Conexão de Teste você pode criar automaticamente um 
-          Conjunto de Dados que consiste de todas as tabelas com seus conteúdos no 
-          banco de dados especificado como segundo parâmetro ao método 
+          Acessando a Conexão de Teste você pode criar automaticamente um
+          Conjunto de Dados que consiste de todas as tabelas com seus conteúdos no
+          banco de dados especificado como segundo parâmetro ao método
           Fábrica de Conexões.
         </para>
         <para>
-          Você pode tanto criar um Conjunto de Dados para todo o banco de dados como mostrado 
-          em  <literal>testGuestbook()</literal>, ou restringi-lo a um conjunto de 
-          nomes específicos de tabelas com uma lista branca, como mostrado no 
+          Você pode tanto criar um Conjunto de Dados para todo o banco de dados como mostrado
+          em  <literal>testGuestbook()</literal>, ou restringi-lo a um conjunto de
+          nomes específicos de tabelas com uma lista branca, como mostrado no
           método <literal>testFilteredGuestbook()</literal>.
         </para>
         <programlisting><![CDATA[<?php
@@ -957,14 +957,14 @@ class MySqlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.replacement-dataset">
         <title>Conjunto de Dados de Reposição</title>
         <para>
-          Eu tenho falado sobre problemas com NULL nos Conjunto de Dados XML Plano e 
-          CSV, mas existe uma alternativa um pouco complicada para fazer ambos 
+          Eu tenho falado sobre problemas com NULL nos Conjunto de Dados XML Plano e
+          CSV, mas existe uma alternativa um pouco complicada para fazer ambos
           funcionarem com NULLs.
         </para>
         <para>
-          O Conjunto de Dados de Reposição é um decorador para um Conjunto de Dados existente e 
-          permite que você substitua valores em qualquer coluna do conjunto de dados por outro 
-          valor de reposição. Para fazer nosso exemplo do guestbook funcionar com valores NULL 
+          O Conjunto de Dados de Reposição é um decorador para um Conjunto de Dados existente e
+          permite que você substitua valores em qualquer coluna do conjunto de dados por outro
+          valor de reposição. Para fazer nosso exemplo do guestbook funcionar com valores NULL
           devemos especificar o arquivo como:
         </para>
         <screen><![CDATA[
@@ -993,9 +993,9 @@ class ReplacementTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.dataset-filter">
         <title>Filtro de Conjunto de Dados</title>
         <para>
-          Se você tiver um arquivo grande de ambiente você pode usar o Filtro de Conjunto de Dados para 
-          as listas branca e negra das tabelas e colunas que deveriam estar 
-          contidas em um sub-conjunto de dados. Isso ajuda especialmente em combinação 
+          Se você tiver um arquivo grande de ambiente você pode usar o Filtro de Conjunto de Dados para
+          as listas branca e negra das tabelas e colunas que deveriam estar
+          contidas em um sub-conjunto de dados. Isso ajuda especialmente em combinação
           com o DB DataSet para filtrar as colunas dos conjuntos de dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1026,9 +1026,9 @@ class DataSetFilterTest extends PHPUnit_Extensions_Database_TestCase
 ?>]]></programlisting>
         <blockquote>
           <para>
-            <emphasis role="strong">NOTA</emphasis> Você não pode usar ambos os 
-            filtros de coluna excluir e incluir na mesma tabela, apenas em tabelas 
-            diferentes. E mais: só é possível para a lista branca ou negra, 
+            <emphasis role="strong">NOTA</emphasis> Você não pode usar ambos os
+            filtros de coluna excluir e incluir na mesma tabela, apenas em tabelas
+            diferentes. E mais: só é possível para a lista branca ou negra,
             mas não para ambas.
           </para>
         </blockquote>
@@ -1036,9 +1036,9 @@ class DataSetFilterTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.composite-dataset">
         <title>Conjunto de Dados Composto</title>
         <para>
-          O Conjunto de Dados composto é muito útil para agregar vários 
-          conjuntos de dados já existentes em um único Conjunto de Dados. Quando vários 
-          conjuntos de dados contém as mesmas tabelas, as linhas são anexadas na 
+          O Conjunto de Dados composto é muito útil para agregar vários
+          conjuntos de dados já existentes em um único Conjunto de Dados. Quando vários
+          conjuntos de dados contém as mesmas tabelas, as linhas são anexadas na
           ordem especificada. Por exemplo se tivermos dois conjuntos de dados
           <emphasis>fixture1.xml</emphasis>:
         </para>
@@ -1081,18 +1081,18 @@ class CompositeTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.beware-of-foreign-keys">
       <title>Cuidado com Chaves Estrangeiras</title>
       <para>
-        Durante a Configuração do Ambiente a Extensão para Banco de Dados do PHPUnit insere as linhas 
-        no banco de dados na ordem que são especificadas em seu ambiente. 
-        Se seu esquema de banco de dados usa chaves estrangeiras isso significa que você tem que 
-        especificar as tabelas em uma ordem que não faça as restrições das chaves estrangeiras 
+        Durante a Configuração do Ambiente a Extensão para Banco de Dados do PHPUnit insere as linhas
+        no banco de dados na ordem que são especificadas em seu ambiente.
+        Se seu esquema de banco de dados usa chaves estrangeiras isso significa que você tem que
+        especificar as tabelas em uma ordem que não faça as restrições das chaves estrangeiras
         falharem.
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
       <title>Implementando seus próprios Conjuntos de Dados/ Tabelas de Dados</title>
       <para>
-        Para entender os interiores dos Conjuntos de Dados e Tabelas de Dados, vamos dar uma 
-        olhada na interface de um Conjunto de Dados. Você pode pular esta parte se você 
+        Para entender os interiores dos Conjuntos de Dados e Tabelas de Dados, vamos dar uma
+        olhada na interface de um Conjunto de Dados. Você pode pular esta parte se você
         não planeja implementar seu próprio Conjunto de Dados ou Tabela de Dados.
       </para>
       <programlisting><![CDATA[<?php
@@ -1108,18 +1108,18 @@ interface PHPUnit_Extensions_Database_DataSet_IDataSet extends IteratorAggregate
 ?>]]></programlisting>
       <para>
         A interface pública é usada internamente pela asserção
-        <literal>assertDataSetsEqual()</literal> no Caso de Teste de 
+        <literal>assertDataSetsEqual()</literal> no Caso de Teste de
         Banco de Dados para verificar a qualidade do conjunto de dados. Da interface
-        <literal>IteratorAggregate</literal> o IDataSet 
-        herda o método <literal>getIterator()</literal> para iterar 
-        sobre todas as tabelas do conjunto de dados. O iterador reverso permite o PHPUnit 
-        truncar corretamente as tabelas em ordem reversa à que foi criada para satisfazer 
+        <literal>IteratorAggregate</literal> o IDataSet
+        herda o método <literal>getIterator()</literal> para iterar
+        sobre todas as tabelas do conjunto de dados. O iterador reverso permite o PHPUnit
+        truncar corretamente as tabelas em ordem reversa à que foi criada para satisfazer
         as restrições de chaves estrangeiras.
       </para>
       <para>
-        Dependendo da implementação, diferentes abordagens são usadas para 
-        adicionar instâncias de tabela a um Conjunto de Dados. Por exemplo, tabelas são adicionadas 
-        internamente durante a construção a partir de um arquivo fonte em todos 
+        Dependendo da implementação, diferentes abordagens são usadas para
+        adicionar instâncias de tabela a um Conjunto de Dados. Por exemplo, tabelas são adicionadas
+        internamente durante a construção a partir de um arquivo fonte em todos
         os conjuntos de dados baseados em arquivo como <literal>YamlDataSet</literal>,
         <literal>XmlDataSet</literal> ou <literal>FlatXmlDataSet</literal>.
       </para>
@@ -1137,14 +1137,14 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
 }
 ?>]]></programlisting>
       <para>
-        Com exceção do método <literal>getTableMetaData()</literal> isso é 
-        bastante auto-explicativo. Os métodos usados são todos requeridos para 
-        as diferentes asserções da Extensão para Banco de Dados que são 
+        Com exceção do método <literal>getTableMetaData()</literal> isso é
+        bastante auto-explicativo. Os métodos usados são todos requeridos para
+        as diferentes asserções da Extensão para Banco de Dados que são
         explicados no próximo capítulo. O método
-        <literal>getTableMetaData()</literal> deve retornar uma 
+        <literal>getTableMetaData()</literal> deve retornar uma
         implementação da interface
         <literal>PHPUnit_Extensions_Database_DataSet_ITableMetaData</literal>
-        que descreve a estrutura da tabela. Possui informações 
+        que descreve a estrutura da tabela. Possui informações
         sobre:
       </para>
       <itemizedlist>
@@ -1155,7 +1155,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
         </listitem>
         <listitem>
           <para>
-            Um vetor de nomes de coluna da tabela, ordenado por suas aparições 
+            Um vetor de nomes de coluna da tabela, ordenado por suas aparições
             nos conjuntos de resultados.
           </para>
         </listitem>
@@ -1166,8 +1166,8 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
         </listitem>
       </itemizedlist>
       <para>
-        Essa interface também tem uma asserção que verifica se duas instâncias 
-        de Metadados de Tabela se equivalem, o que é usado pela asserção de igualdade 
+        Essa interface também tem uma asserção que verifica se duas instâncias
+        de Metadados de Tabela se equivalem, o que é usado pela asserção de igualdade
         do conjunto de dados.
       </para>
     </section>
@@ -1175,7 +1175,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
   <section id="database.the-connection-api">
     <title>A API de Conexão</title>
     <para>
-      Existem três métodos interessantes na interface Connection 
+      Existem três métodos interessantes na interface Connection
       que devem ser retornados do método
       <literal>getConnection()</literal> no Caso de Teste de Banco de Dados:
     </para>
@@ -1192,7 +1192,7 @@ interface PHPUnit_Extensions_Database_DB_IDatabaseConnection
     <orderedlist numeration="arabic">
       <listitem>
         <para>
-          O método <literal>createDataSet()</literal> cria um Conjunto de Dados 
+          O método <literal>createDataSet()</literal> cria um Conjunto de Dados
           de Banco de Dados (BD) como descrito na seção de implementações de Conjunto de Dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1208,10 +1208,10 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
       </listitem>
       <listitem>
         <para>
-          O método <literal>createQueryTable()</literal> pode ser usado para 
-          criar instâncias de uma QueryTable, dado um nome de resultado e uma query 
+          O método <literal>createQueryTable()</literal> pode ser usado para
+          criar instâncias de uma QueryTable, dado um nome de resultado e uma query
           SQL. Este é um método conveniente quando se fala sobre asserções de resultado/tabela
-          como será mostrado na próxima seção de API de Asserções 
+          como será mostrado na próxima seção de API de Asserções
           de Banco de Dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1227,9 +1227,9 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
       </listitem>
       <listitem>
         <para>
-          O método <literal>getRowCount()</literal> é uma forma conveniente de 
-          acessar o número de linhas em uma tabela, opcionalmente filtradas por uma 
-          cláusula where adicional. Isso pode ser usado com uma simples asserção 
+          O método <literal>getRowCount()</literal> é uma forma conveniente de
+          acessar o número de linhas em uma tabela, opcionalmente filtradas por uma
+          cláusula where adicional. Isso pode ser usado com uma simples asserção
           de igualdade:
         </para>
         <programlisting><![CDATA[<?php
@@ -1237,7 +1237,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1247,19 +1247,19 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
   <section id="database.database-assertions-api">
     <title>API de Asserções de Banco de Dados</title>
     <para>
-      Para uma ferramenta de testes, a Extensão para Banco de Dados certamente fornece algumas 
-      asserções que você pode usar para verificar o estado atual do banco de dados, 
-      tabelas e a contagem de linhas de tabelas. Esta seção 
+      Para uma ferramenta de testes, a Extensão para Banco de Dados certamente fornece algumas
+      asserções que você pode usar para verificar o estado atual do banco de dados,
+      tabelas e a contagem de linhas de tabelas. Esta seção
       descreve essa funcionalidade em detalhes:
     </para>
     <section id="database.asserting-the-row-count-of-a-table">
       <title>Asseverado a contagem de linhas de uma Tabela</title>
       <para>
-        Às vezes ajuda verificar se uma tabela contém uma quantidade específica 
-        de linhas. Você pode conseguir isso facilmente sem colar códigos adicionais 
-        usando a API de Conexão. Suponha que queiramos verificar se após a 
-        inserção de uma linha em nosso guestbook não apenas temos as duas entradas 
-        iniciais que nos acompanharam em todos os exemplos 
+        Às vezes ajuda verificar se uma tabela contém uma quantidade específica
+        de linhas. Você pode conseguir isso facilmente sem colar códigos adicionais
+        usando a API de Conexão. Suponha que queiramos verificar se após a
+        inserção de uma linha em nosso guestbook não apenas temos as duas entradas
+        iniciais que nos acompanharam em todos os exemplos
         anteriores, mas uma terceira:
       </para>
       <programlisting><![CDATA[<?php
@@ -1267,12 +1267,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1280,14 +1280,14 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Asseverando o Estado de uma Tabela</title>
       <para>
-       A asserção anterior ajuda, mas certamente queremos verificar os 
-        conteúdos reais da tabela para verificar se todos os valores foram 
-        escritos nas colunas corretas. Isso pode ser conseguido com uma 
+       A asserção anterior ajuda, mas certamente queremos verificar os
+        conteúdos reais da tabela para verificar se todos os valores foram
+        escritos nas colunas corretas. Isso pode ser conseguido com uma
         asserção de tabela.
       </para>
       <para>
-        Para isso vamos definir uma instância de Tabela Query que deriva seu 
-        conteúdo de um nome de tabela e de uma query SQL e compara isso a um 
+        Para isso vamos definir uma instância de Tabela Query que deriva seu
+        conteúdo de um nome de tabela e de uma query SQL e compara isso a um
         Conjunto de Dados baseado em Arquivo/Vetor:
       </para>
       <programlisting><![CDATA[<?php
@@ -1303,12 +1303,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
       <para>
-        Agora temos que escrever o arquivo XML Plano <emphasis>expectedBook.xml</emphasis> 
+        Agora temos que escrever o arquivo XML Plano <emphasis>expectedBook.xml</emphasis>
         para esta asserção:
       </para>
       <screen><![CDATA[
@@ -1320,15 +1320,15 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 </dataset>
 ]]></screen>
       <para>
-        Apesar disso, esta asserção só vai passar em exatamente um segundo 
-        do universo, em <emphasis>2010–05–01 21:47:08</emphasis>. Datas 
-        possuem um problema especial nos testes de bancos de dados e podemos circundar 
-        a falha omitindo a coluna <quote>created</quote> 
+        Apesar disso, esta asserção só vai passar em exatamente um segundo
+        do universo, em <emphasis>2010–05–01 21:47:08</emphasis>. Datas
+        possuem um problema especial nos testes de bancos de dados e podemos circundar
+        a falha omitindo a coluna <quote>created</quote>
         da asserção.
       </para>
       <para>
-        O arquivo ajustado <emphasis>expectedBook.xml</emphasis> em XML Plano 
-        provavelmente vai ficar parecido com o seguinte para fazer a 
+        O arquivo ajustado <emphasis>expectedBook.xml</emphasis> em XML Plano
+        provavelmente vai ficar parecido com o seguinte para fazer a
         asserção passar:
       </para>
       <screen><![CDATA[
@@ -1351,8 +1351,8 @@ $queryTable = $this->getConnection()->createQueryTable(
     <section id="database.asserting-the-result-of-a-query">
       <title>Asseverando o Resultado de uma Query</title>
       <para>
-        Você também pode asseverar o resultado de querys complexas com a abordagem 
-        da Tabela Query, apenas especificando um nome de resultado com uma query e 
+        Você também pode asseverar o resultado de querys complexas com a abordagem
+        da Tabela Query, apenas especificando um nome de resultado com uma query e
         comparando isso a um conjunto de dados:
       </para>
       <programlisting><![CDATA[<?php
@@ -1365,7 +1365,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1373,14 +1373,14 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-multiple-tables">
       <title>Asseverando o Estado de Múltiplas Tabelas</title>
       <para>
-        Certamente você pode asseverar o estado de múltiplas tabelas de uma vez e 
-        comparar um conjunto de dados de query contra um conjunto de dados baseado em arquivo. Existem duas 
+        Certamente você pode asseverar o estado de múltiplas tabelas de uma vez e
+        comparar um conjunto de dados de query contra um conjunto de dados baseado em arquivo. Existem duas
         formas diferentes de asserções de Conjuntos de Dados.
       </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Você pode usar o Database (Banco de Dados - DB) e o DataSet (Conjunto de Dados) da Connection (Conexão) e 
+            Você pode usar o Database (Banco de Dados - DB) e o DataSet (Conjunto de Dados) da Connection (Conexão) e
             compará-lo com um Conjunto de Dados Baseado em Arquivo.
           </para>
           <programlisting><![CDATA[<?php
@@ -1390,7 +1390,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1408,7 +1408,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1419,33 +1419,33 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
   <section id="database.frequently-asked-questions">
     <title>Perguntas Mais Frequentes</title>
     <section id="database.will-phpunit-re-create-the-database-schema-for-each-test">
-      <title>O PHPUnit vai (re)criar o esquema do banco de dados para cada 
+      <title>O PHPUnit vai (re)criar o esquema do banco de dados para cada
              teste?</title>
       <para>
-        Não, o PHPUnit exige que todos os objetos do banco de dados estejam disponíveis quando a 
-        suíte começar os testes. O Banco de Dados, tabelas, sequências, gatilhos e 
+        Não, o PHPUnit exige que todos os objetos do banco de dados estejam disponíveis quando a
+        suíte começar os testes. O Banco de Dados, tabelas, sequências, gatilhos e
         visualizações devem ser criadas antes que você execute a suíte de testes.
       </para>
       <para>
         <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink> ou
-        <ulink url="http://www.ezcomponents.org">eZ Components</ulink> possuem 
-        ferramentas poderosas que permitem a você criar o esquema de banco de dados através 
-        de estruturas de dados pré-definidas, porém devem ser ligados à 
-        extensão do PHPUnit para permitir a recriação automática de banco de dados 
+        <ulink url="http://www.ezcomponents.org">eZ Components</ulink> possuem
+        ferramentas poderosas que permitem a você criar o esquema de banco de dados através
+        de estruturas de dados pré-definidas, porém devem ser ligados à
+        extensão do PHPUnit para permitir a recriação automática de banco de dados
         antes que a suíte de testes completa seja executada.
       </para>
       <para>
-        Já que cada teste limpa completamente o banco de dados, você nem sequer é 
-        forçado a recriar o banco de dados para cada execução de teste. Um banco de dados 
+        Já que cada teste limpa completamente o banco de dados, você nem sequer é
+        forçado a recriar o banco de dados para cada execução de teste. Um banco de dados
         permanentemente disponível funciona perfeitamente.
       </para>
     </section>
     <section id="database.am-i-required-to-use-pdo-in-my-application-for-the-database-extension-to-work">
-      <title>Sou forçado a usar PDO em minha aplicação para que a Extensão para 
+      <title>Sou forçado a usar PDO em minha aplicação para que a Extensão para
              Banco de Dados funcione?</title>
       <para>
-        Não, PDO só é exigido para limpeza e configuração do ambiente e para 
-        asserções. Você pode usar qualquer abstração de banco de dados que quiser 
+        Não, PDO só é exigido para limpeza e configuração do ambiente e para
+        asserções. Você pode usar qualquer abstração de banco de dados que quiser
         dentro de seu próprio código.
       </para>
     </section>
@@ -1453,24 +1453,24 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
       <title>O que posso fazer quando recebo um Erro
              <quote>Too much Connections</quote>?</title>
       <para>
-        Se você não armazena em cache a instância de PDO que é criada a partir do 
-        método do Caso de Teste <literal>getConnection()</literal> o número de 
-        conexões ao banco de dados é aumentado em um ou mais com cada 
-        teste do banco de dados. Com a configuração padrão o MySQL só permite 100 
-        conexões concorrentes e outros fornecedores também têm um limite máximo 
+        Se você não armazena em cache a instância de PDO que é criada a partir do
+        método do Caso de Teste <literal>getConnection()</literal> o número de
+        conexões ao banco de dados é aumentado em um ou mais com cada
+        teste do banco de dados. Com a configuração padrão o MySQL só permite 100
+        conexões concorrentes e outros fornecedores também têm um limite máximo
         de conexões.
       </para>
       <para>
         A Sub-seção
-        <quote>Use seu próprio Caso Abstrato de Teste de Banco de Dados</quote> mostra como 
-        você pode prevenir o acontecimento desse erro usando uma instância única armazenada 
+        <quote>Use seu próprio Caso Abstrato de Teste de Banco de Dados</quote> mostra como
+        você pode prevenir o acontecimento desse erro usando uma instância única armazenada
         em cache do PDO em todos os seus testes.
       </para>
     </section>
     <section id="database.how-to-handle-null-with-flat-xml-csv-datasets">
       <title>Como lidar com NULL usando Conjuntos de Dados XML Plano / CSV?</title>
       <para>
-        Não faça isso. Em vez disso, você deveria usar Conjuntos de Dados ou 
+        Não faça isso. Em vez disso, você deveria usar Conjuntos de Dados ou
         XML ou YAML.
       </para>
     </section>

--- a/src/4.6/pt_br/fixtures.xml
+++ b/src/4.6/pt_br/fixtures.xml
@@ -6,21 +6,21 @@
   <para>
     <indexterm><primary>Ambientes</primary></indexterm>
 
-    Uma das partes que mais consomem tempo ao se escrever testes é escrever o 
-    código para ajustar o ambiente para um estado conhecido e então retorná-lo ao seu 
-    estado original quando o teste está completo. Esse estado conhecido é chamado 
+    Uma das partes que mais consomem tempo ao se escrever testes é escrever o
+    código para ajustar o ambiente para um estado conhecido e então retorná-lo ao seu
+    estado original quando o teste está completo. Esse estado conhecido é chamado
     de <emphasis>ambiente</emphasis> do teste.
   </para>
 
   <para>
-    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" />, o 
+    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" />, o
     ambiente era simplesmente o vetor que está guardado na variável <literal>$stack</literal>.
-    Na maior parte do tempo, porém, o ambiente será mais complexo 
-    que um simples vetor, e a quantidade de código necessária para defini-lo aumentará 
-    na mesma proporção. O conteúdo real do teste se perde na bagunça 
-    da configuração do ambiente. Esse problema piora ainda mais quando você escreve 
-    vários testes com ambientes similares. Sem alguma ajuda do framework de teste, 
-    teríamos que duplicar o código que define o ambiente 
+    Na maior parte do tempo, porém, o ambiente será mais complexo
+    que um simples vetor, e a quantidade de código necessária para defini-lo aumentará
+    na mesma proporção. O conteúdo real do teste se perde na bagunça
+    da configuração do ambiente. Esse problema piora ainda mais quando você escreve
+    vários testes com ambientes similares. Sem alguma ajuda do framework de teste,
+    teríamos que duplicar o código que define o ambiente
     para cada teste que escrevermos.
   </para>
 
@@ -29,25 +29,25 @@
     <indexterm><primary>setUp()</primary></indexterm>
     <indexterm><primary>tearDown()</primary></indexterm>
 
-    O PHPUnit suporta compartilhamento do código de configuração. Antes que um método seja executado, um 
+    O PHPUnit suporta compartilhamento do código de configuração. Antes que um método seja executado, um
     método modelo chamado <literal>setUp()</literal> é invocado.
-    <literal>setUp()</literal> é onde você cria os objetos que serão 
-    alvo dos testes. Uma vez que o método de teste tenha terminado sua execução, seja 
+    <literal>setUp()</literal> é onde você cria os objetos que serão
+    alvo dos testes. Uma vez que o método de teste tenha terminado sua execução, seja
     bem-sucedido ou falho, outro método modelo chamado
     <literal>tearDown()</literal> é invocado. <literal>tearDown()</literal>
     é onde você limpa os objetos que foram alvo dos testes.
   </para>
 
   <para>
-    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> usamos 
-    a relação produtor-consumidor entre testes para compartilhar ambientes. Isso 
+    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> usamos
+    a relação produtor-consumidor entre testes para compartilhar ambientes. Isso
     nem sempre é desejável, ou mesmo possível. <xref linkend="fixtures.examples.StackTest.php"/>
-    mostra como podemos escrever os testes do <literal>StackTest</literal> de forma 
-    que o próprio ambiente não é reutilizado, mas o código que o cria. 
-    Primeiro declaramos a variável de instância <literal>$stack</literal>, que 
-    usaremos no lugar de uma variável do método local. Então colocamos a 
+    mostra como podemos escrever os testes do <literal>StackTest</literal> de forma
+    que o próprio ambiente não é reutilizado, mas o código que o cria.
+    Primeiro declaramos a variável de instância <literal>$stack</literal>, que
+    usaremos no lugar de uma variável do método local. Então colocamos a
     criação do ambiente <literal>vetor</literal> dentro do método
-    <literal>setUp()</literal>. Finalmente, removemos o código redundante 
+    <literal>setUp()</literal>. Finalmente, removemos o código redundante
     dos métodos de teste e usamos a nova variável de instância,
     <literal>$this->stack</literal>, em vez da variável de método local
     <literal>$stack</literal> com o método de asserção <literal>assertEquals()</literal>.
@@ -67,21 +67,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -94,8 +94,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>tearDown()</primary></indexterm>
     <indexterm><primary>tearDownAfterClass()</primary></indexterm>
 
-    Os métodos-modelo <literal>setUp()</literal> e <literal>tearDown()</literal> 
-    são executados uma vez para cada método de teste (e em novas instâncias) da 
+    Os métodos-modelo <literal>setUp()</literal> e <literal>tearDown()</literal>
+    são executados uma vez para cada método de teste (e em novas instâncias) da
     classe do caso de teste.
   </para>
 
@@ -110,15 +110,15 @@ class StackTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>onNotSuccessfulTest()</primary></indexterm>
 
     Além disso, os métodos-modelo <literal>setUpBeforeClass()</literal> e
-    <literal>tearDownAfterClass()</literal> são chamados antes 
-    do primeiro teste da classe do caso de teste ser executado e após o último teste da 
+    <literal>tearDownAfterClass()</literal> são chamados antes
+    do primeiro teste da classe do caso de teste ser executado e após o último teste da
     classe do caso de teste ser executado, respectivamente.
   </para>
 
   <para>
     <indexterm><primary>Método Modelo</primary></indexterm>
 
-    O exemplo abaixo mostra todos os métodos-modelo que estão disponíveis em uma classe 
+    O exemplo abaixo mostra todos os métodos-modelo que estão disponíveis em uma classe
     de casos de teste.
   </para>
 
@@ -145,13 +145,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()
@@ -209,15 +209,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Mais setUp() que tearDown()</title>
 
     <para>
-      <literal>setUp()</literal> e <literal>tearDown()</literal> são bastante 
-      simétricos em teoria, mas não na prática. Na prática, você só precisa 
-      implementar <literal>tearDown()</literal> se você tiver alocado 
+      <literal>setUp()</literal> e <literal>tearDown()</literal> são bastante
+      simétricos em teoria, mas não na prática. Na prática, você só precisa
+      implementar <literal>tearDown()</literal> se você tiver alocado
       recursos externos como arquivos ou sockets no <literal>setUp()</literal>.
-      Se seu <literal>setUp()</literal> apenas cria objetos planos do PHP, você 
-      pode geralmente ignorar o <literal>tearDown()</literal>. Porém, se você 
-      criar muitos objetos em seu <literal>setUp()</literal>, você pode querer 
+      Se seu <literal>setUp()</literal> apenas cria objetos planos do PHP, você
+      pode geralmente ignorar o <literal>tearDown()</literal>. Porém, se você
+      criar muitos objetos em seu <literal>setUp()</literal>, você pode querer
       <literal>unset()</literal> as variáveis que apontam para aqueles objetos
-      em seu <literal>tearDown()</literal> para que eles possam ser coletados como lixo. 
+      em seu <literal>tearDown()</literal> para que eles possam ser coletados como lixo.
       A coleta de lixo dos objetos dos casos de teste não é previsível.
     </para>
   </section>
@@ -226,23 +226,23 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variações</title>
 
     <para>
-      O que acontece quando você tem dois testes com definições (setups) ligeiramente diferentes? 
+      O que acontece quando você tem dois testes com definições (setups) ligeiramente diferentes?
       Existem duas possibilidades:
     </para>
 
     <itemizedlist>
       <listitem>
         <para>
-          Se o código <literal>setUp()</literal> diferir só um pouco, mova 
-          o código que difere do código do <literal>setUp()</literal> para 
+          Se o código <literal>setUp()</literal> diferir só um pouco, mova
+          o código que difere do código do <literal>setUp()</literal> para
           o método de teste.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          Se você tiver um <literal>setUp()</literal> realmente diferente, você precisará 
-          de uma classe de caso de teste diferente. Nomeie a classe após a diferença 
+          Se você tiver um <literal>setUp()</literal> realmente diferente, você precisará
+          de uma classe de caso de teste diferente. Nomeie a classe após a diferença
           na configuração.
         </para>
       </listitem>
@@ -253,15 +253,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Compartilhando Ambientes</title>
 
     <para>
-      Existem algumas boas razões para compartilhar ambientes entre testes, mas na maioria 
-        dos casos a necessidade de compartilhar um ambiente entre testes deriva de um problema 
+      Existem algumas boas razões para compartilhar ambientes entre testes, mas na maioria
+        dos casos a necessidade de compartilhar um ambiente entre testes deriva de um problema
         de design não resolvido.
     </para>
 
     <para>
-      Um bom exemplo de um ambiente que faz sentido compartilhar através de vários 
-        testes é a conexão ao banco de dados: você loga no banco de dados uma vez e 
-        reutiliza essa conexão em vez de criar uma nova conexão para cada 
+      Um bom exemplo de um ambiente que faz sentido compartilhar através de vários
+        testes é a conexão ao banco de dados: você loga no banco de dados uma vez e
+        reutiliza essa conexão em vez de criar uma nova conexão para cada
         teste. Isso faz seus testes serem executados mais rápido.
     </para>
 
@@ -271,8 +271,8 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
       <xref linkend="fixtures.sharing-fixture.examples.DatabaseTest.php" />
       usa os métodos-modelo <literal>setUpBeforeClass()</literal> e
-      <literal>tearDownAfterClass()</literal> para conectar ao 
-      banco de dados antes do primeiro teste da classe de casos de teste e para desconectar do 
+      <literal>tearDownAfterClass()</literal> para conectar ao
+      banco de dados antes do primeiro teste da classe de casos de teste e para desconectar do
       banco de dados após o último teste dos casos de teste, respectivamente.
     </para>
 
@@ -297,12 +297,12 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Não dá pra enfatizar o suficiente o quanto o compartilhamento de ambientes entre testes 
-      reduz o custo dos testes. O problema de design subjacente é 
-      que objetos não são de baixo acoplamento. Você vai conseguir 
-      melhores resultados resolvendo o problema de design subjacente e então escrevendo testes 
-      usando pontas (veja <xref linkend="test-doubles" />), do que criando 
-      dependências entre os testes em tempo de execução e ignorando a oportunidade 
+      Não dá pra enfatizar o suficiente o quanto o compartilhamento de ambientes entre testes
+      reduz o custo dos testes. O problema de design subjacente é
+      que objetos não são de baixo acoplamento. Você vai conseguir
+      melhores resultados resolvendo o problema de design subjacente e então escrevendo testes
+      usando pontas (veja <xref linkend="test-doubles" />), do que criando
+      dependências entre os testes em tempo de execução e ignorando a oportunidade
       de melhorar seu design.
     </para>
   </section>
@@ -312,8 +312,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     <para>
       <ulink url="http://googletesting.blogspot.com/2008/05/tott-using-dependancy-injection-to.html">É difícil testar um código que usa singletons (instâncias únicas de objetos).</ulink>
-      Isso também vale para os códigos que usam variáveis globais. Tipicamente, o código 
-      que você quer testar é fortemente acoplado com uma variável global e você não pode 
+      Isso também vale para os códigos que usam variáveis globais. Tipicamente, o código
+      que você quer testar é fortemente acoplado com uma variável global e você não pode
       controlar sua criação. Um problema adicional é o fato de que uma alteração em uma
       variável global para um teste pode quebrar um outro teste.
     </para>
@@ -330,7 +330,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </itemizedlist>
 
     <para>
-      Além das variáveis globais, atributos estáticos de classes também são parte do 
+      Além das variáveis globais, atributos estáticos de classes também são parte do
       estado global.
     </para>
 
@@ -338,24 +338,24 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary>Isolamento de Testes</primary></indexterm>
 
-      Por padrão, o PHPUnit executa seus testes de forma que mudanças às 
+      Por padrão, o PHPUnit executa seus testes de forma que mudanças às
       variáveis globais ou super-globais (<literal>$GLOBALS</literal>,
       <literal>$_ENV</literal>, <literal>$_POST</literal>,
       <literal>$_GET</literal>, <literal>$_COOKIE</literal>,
       <literal>$_SERVER</literal>, <literal>$_FILES</literal>,
-      <literal>$_REQUEST</literal>) não afetem outros testes. Opcionalmente, este 
+      <literal>$_REQUEST</literal>) não afetem outros testes. Opcionalmente, este
       isolamento pode ser estendido a atributos estáticos de classes.
     </para>
 
     <note>
       <para>
-        A operações de cópia de segurança e restauração para variáveis globais e atributos 
+        A operações de cópia de segurança e restauração para variáveis globais e atributos
         estáticos de classes usa <literal>serialize()</literal> e
         <literal>unserialize()</literal>.
       </para>
       <para>
-        Objetos de algumas classes (e.g., <literal>PDO</literal>) não podem ser 
-        serializadas e a operação de cópia de segurança vai quebrar quando esse tipo de objeto 
+        Objetos de algumas classes (e.g., <literal>PDO</literal>) não podem ser
+        serializadas e a operação de cópia de segurança vai quebrar quando esse tipo de objeto
         for guardado no vetor <literal>$GLOBALS</literal>, por exemplo.
       </para>
     </note>
@@ -365,9 +365,9 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>$backupGlobalsBlacklist</literal></primary></indexterm>
 
       A anotação <literal>@backupGlobals</literal> que é discutida na
-      <xref linkend="appendixes.annotations.backupGlobals"/> pode ser usada para 
-      controlar as operações de cópia de segurança e restauração para variáveis globais. 
-      Alternativamente, você pode fornecer uma lista-negra de variáveis globais que deverão 
+      <xref linkend="appendixes.annotations.backupGlobals"/> pode ser usada para
+      controlar as operações de cópia de segurança e restauração para variáveis globais.
+      Alternativamente, você pode fornecer uma lista-negra de variáveis globais que deverão
       ser excluídas das operações de backup e restauração como esta:
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -379,7 +379,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        Definir a propriedade <literal>$backupGlobalsBlacklist</literal> dentro 
+        Definir a propriedade <literal>$backupGlobalsBlacklist</literal> dentro
         do método <literal>setUp()</literal>, por exemplo, não tem efeito.
       </para>
     </note>
@@ -387,39 +387,39 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
       <indexterm><primary><literal>$backupStaticAttributesBlacklist</literal></primary></indexterm>
-      
+
       A anotação <literal>@backupStaticAttributes</literal> que é discutida na
-      <xref linkend="appendixes.annotations.backupStaticAttributes"/> 
-      pode ser usado para fazer backup de todos os valores de propriedades estáticas em todas as classes declaradas 
+      <xref linkend="appendixes.annotations.backupStaticAttributes"/>
+      pode ser usado para fazer backup de todos os valores de propriedades estáticas em todas as classes declaradas
       antes de cada teste e restaurá-los depois.
     </para>
-    
+
     <para>
-      Ele processa todas as classes que são declaradas no momento que um teste começa, 
-      não só a classe de teste. Ele só se aplica a propriedades da classe estática, 
+      Ele processa todas as classes que são declaradas no momento que um teste começa,
+      não só a classe de teste. Ele só se aplica a propriedades da classe estática,
       e não variáveis estáticas dentro de funções.
     </para>
 
     <note>
       <para>
-        A operação <literal>@backupStaticAttributes</literal> é executada 
-        antes de um método de teste, mas somente se ele está habilitado. Se um valor estático foi 
-        alterado por um teste executado anteriormente que não 
-        tinha ativado <literal>@backupStaticAttributes</literal>, esse valor então será 
-        feito o backup e restaurado - não o valor padrão originalmente declarado. 
-        O PHP não registra o valor padrão originalmente declarado de nenhuma variável 
+        A operação <literal>@backupStaticAttributes</literal> é executada
+        antes de um método de teste, mas somente se ele está habilitado. Se um valor estático foi
+        alterado por um teste executado anteriormente que não
+        tinha ativado <literal>@backupStaticAttributes</literal>, esse valor então será
+        feito o backup e restaurado - não o valor padrão originalmente declarado.
+        O PHP não registra o valor padrão originalmente declarado de nenhuma variável
         estática.
       </para>
       <para>
-        O mesmo se aplica a propriedades estáticas de classes que foram 
-        recém-carregadas/declaradas dentro de um teste. Elas não podem ser redefinidas para o seu valor 
-        padrão originalmente declarado após o teste, uma vez que esse valor é desconhecido. 
+        O mesmo se aplica a propriedades estáticas de classes que foram
+        recém-carregadas/declaradas dentro de um teste. Elas não podem ser redefinidas para o seu valor
+        padrão originalmente declarado após o teste, uma vez que esse valor é desconhecido.
         Qualquer que seja o valor definido irá vazar para testes subsequentes.
       </para>
       <para>
-        Para testes de unidade, recomenda-se redefinir explicitamente os valores das 
-        propriedades estáticas em teste em seu código <literal>setUp()</literal> 
-        ao invés (e, idealmente, também <literal>tearDown()</literal>, de modo a não 
+        Para testes de unidade, recomenda-se redefinir explicitamente os valores das
+        propriedades estáticas em teste em seu código <literal>setUp()</literal>
+        ao invés (e, idealmente, também <literal>tearDown()</literal>, de modo a não
         afetar os testes posteriormente executados).
       </para>
     </note>

--- a/src/4.6/pt_br/incomplete-and-skipped-tests.xml
+++ b/src/4.6/pt_br/incomplete-and-skipped-tests.xml
@@ -7,17 +7,17 @@
     <title>Testes Incompletos</title>
 
     <para>
-      Quando você está trabalhando em uma nova classe de caso de teste, você pode querer começar 
+      Quando você está trabalhando em uma nova classe de caso de teste, você pode querer começar
       a escrever métodos de teste vazios, como: <programlisting>public function testSomething()
 {
-}</programlisting> para manter o controle sobre os testes que você já escreveu. O 
-      problema com os métodos de teste vazios é que eles são interpretados como 
-      bem-sucedidos pelo framework do PHPUnit. Esse erro de interpretação leva à 
-      inutilização dos relatórios de testes -- você não pode ver se um teste foi 
-      realmente bem-sucedido ou simplesmente ainda não foi implementado. Chamar 
-      <literal>$this->fail()</literal> no teste não implementado 
-      não ajuda em nada, já que o teste será interpretado como uma 
-      falha. Isso seria tão errado quanto interpretar um teste não implementado 
+}</programlisting> para manter o controle sobre os testes que você já escreveu. O
+      problema com os métodos de teste vazios é que eles são interpretados como
+      bem-sucedidos pelo framework do PHPUnit. Esse erro de interpretação leva à
+      inutilização dos relatórios de testes -- você não pode ver se um teste foi
+      realmente bem-sucedido ou simplesmente ainda não foi implementado. Chamar
+      <literal>$this->fail()</literal> no teste não implementado
+      não ajuda em nada, já que o teste será interpretado como uma
+      falha. Isso seria tão errado quanto interpretar um teste não implementado
       como bem-sucedido.
     </para>
 
@@ -26,22 +26,22 @@
       <indexterm><primary>PHPUnit_Framework_IncompleteTest</primary></indexterm>
       <indexterm><primary>PHPUnit_Framework_IncompleteTestError</primary></indexterm>
 
-      Se imaginarmos que um teste bem-sucedido é uma luz verde e um teste mal-sucedido (falho) 
-      é uma luz vermelha, precisaremos de uma luz amarela adicional para marcar um teste 
-      como incompleto ou ainda não implementado. 
-      O <literal>PHPUnit_Framework_IncompleteTest</literal> é uma interface 
-      marcadora para marcar uma exceção que surge de um método de teste como 
-      resultado do teste ser incompleto ou atualmente não implementado. 
-      O <literal>PHPUnit_Framework_IncompleteTestError</literal> é a 
+      Se imaginarmos que um teste bem-sucedido é uma luz verde e um teste mal-sucedido (falho)
+      é uma luz vermelha, precisaremos de uma luz amarela adicional para marcar um teste
+      como incompleto ou ainda não implementado.
+      O <literal>PHPUnit_Framework_IncompleteTest</literal> é uma interface
+      marcadora para marcar uma exceção que surge de um método de teste como
+      resultado do teste ser incompleto ou atualmente não implementado.
+      O <literal>PHPUnit_Framework_IncompleteTestError</literal> é a
       implementação padrão dessa interface.
     </para>
 
     <para>
       O <xref linkend="incomplete-and-skipped-tests.incomplete-tests.examples.SampleTest.php" />
-      mostra uma classe de caso de teste, <literal>SampleTest</literal>, que contém um método 
-      de teste, <literal>testSomething()</literal>. Chamando o método de conveniência 
-      <literal>markTestIncomplete()</literal> (que automaticamente 
-      traz uma exceção <literal>PHPUnit_Framework_IncompleteTestError</literal>) 
+      mostra uma classe de caso de teste, <literal>SampleTest</literal>, que contém um método
+      de teste, <literal>testSomething()</literal>. Chamando o método de conveniência
+      <literal>markTestIncomplete()</literal> (que automaticamente
+      traz uma exceção <literal>PHPUnit_Framework_IncompleteTestError</literal>)
       no método de teste, marcamos o teste como sendo incompleto.
     </para>
 
@@ -53,7 +53,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // Opcional: Teste alguma coisa aqui, se quiser
-        $this->assertTrue(TRUE, 'This should already work.');
+        self::assertTrue(TRUE, 'This should already work.');
 
         // Pare aqui e marque este teste como incompleto.
         $this->markTestIncomplete(
@@ -65,8 +65,8 @@ class SampleTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Um teste incompleto é denotado por um <literal>I</literal> na saída 
-      do executor de testes em linha-de-comando do PHPUnit, como mostrado no exemplo 
+      Um teste incompleto é denotado por um <literal>I</literal> na saída
+      do executor de testes em linha-de-comando do PHPUnit, como mostrado no exemplo
       abaixo:
     </para>
 
@@ -119,18 +119,18 @@ Tests: 1, Assertions: 1, Incomplete: 1.</screen>
     <title>Pulando Testes</title>
 
     <para>
-      Nem todos os testes podem ser executados em qualquer ambiente. Considere, por exemplo, 
+      Nem todos os testes podem ser executados em qualquer ambiente. Considere, por exemplo,
       uma camada de abstração de banco de dados contendo vários drivers para os diversos
-      sistemas de banco de dados que suporta. Os testes para o driver MySQL podem ser 
+      sistemas de banco de dados que suporta. Os testes para o driver MySQL podem ser
       executados apenas, é claro, se um servidor MySQL estiver disponível.
     </para>
 
     <para>
       O <xref linkend="incomplete-and-skipped-tests.skipping-tests.examples.DatabaseTest.php" />
-      mostra uma classe de caso de teste, <literal>DatabaseTest</literal>, que contém um método 
-      de teste, <literal>testConnection()</literal>. No método-modelo <literal>setUp()</literal> 
-      da classe de caso de teste, verificamos se a extensão MySQLi 
-      está disponível e usamos o método <literal>markTestSkipped()</literal> 
+      mostra uma classe de caso de teste, <literal>DatabaseTest</literal>, que contém um método
+      de teste, <literal>testConnection()</literal>. No método-modelo <literal>setUp()</literal>
+      da classe de caso de teste, verificamos se a extensão MySQLi
+      está disponível e usamos o método <literal>markTestSkipped()</literal>
       para pular o teste caso contrário.
     </para>
 
@@ -157,8 +157,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Um teste que tenha sido pulado é denotado por um <literal>S</literal> na 
-      saída do executor de testes em linha-de-comando do PHPUnit, como mostrado 
+      Um teste que tenha sido pulado é denotado por um <literal>S</literal> na
+      saída do executor de testes em linha-de-comando do PHPUnit, como mostrado
       no seguinte exemplo:
     </para>
 
@@ -211,7 +211,7 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
     <title>Pulando Testes usando @requires</title>
 
     <para>
-      Além do método acima também é possível usar a 
+      Além do método acima também é possível usar a
       anotação <literal>@requires</literal> para expressar pré-condições comuns para um caso de teste.
     </para>
 
@@ -283,7 +283,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Se você está usando uma sintaxe que não compila com uma certa versão do PHP, procure dentro da configuração 
+      Se você está usando uma sintaxe que não compila com uma certa versão do PHP, procure dentro da configuração
       xml por includes dependentes de versão na <xref linkend="appendixes.configuration.testsuites" />.
     </para>
   </section>

--- a/src/4.6/pt_br/selenium.xml
+++ b/src/4.6/pt_br/selenium.xml
@@ -9,21 +9,21 @@
     <para>
       <indexterm><primary>Servidor Selenium</primary></indexterm>
 
-      <ulink url="http://seleniumhq.org/">Servidor Selenium</ulink> é uma 
-      ferramenta de testes que permite a você escrever testes automatizados de interface de usuário para 
-      aplicações web em qualquer linguagem de programação contra qualquer website HTTP 
-      usando um dos principais navegadores. Ele realiza tarefas automatizadas no navegador 
-      guiando seu processo através do sistema operacional. 
-      O Selenium executa os testes diretamente em um navegador, exatamente como os usuários reais fazem. Esses 
+      <ulink url="http://seleniumhq.org/">Servidor Selenium</ulink> é uma
+      ferramenta de testes que permite a você escrever testes automatizados de interface de usuário para
+      aplicações web em qualquer linguagem de programação contra qualquer website HTTP
+      usando um dos principais navegadores. Ele realiza tarefas automatizadas no navegador
+      guiando seu processo através do sistema operacional.
+      O Selenium executa os testes diretamente em um navegador, exatamente como os usuários reais fazem. Esses
       testes podem ser usados para ambos <emphasis>testes de aceitação</emphasis>
-      (realizando testes de alto-nível no sistema integrado em vez de 
-      apenas testar cada unidade do sistema independentemente) e 
-      <emphasis>testes de compatibilidade de navegador</emphasis> (testando a aplicação web em 
+      (realizando testes de alto-nível no sistema integrado em vez de
+      apenas testar cada unidade do sistema independentemente) e
+      <emphasis>testes de compatibilidade de navegador</emphasis> (testando a aplicação web em
       diferentes sistemas operacionais e navegadores).
     </para>
-    
+
     <para>
-      O único cenário suportado do PHPUnit_Selenium é o do servidor Selenium 2.x. 
+      O único cenário suportado do PHPUnit_Selenium é o do servidor Selenium 2.x.
       O servidor pode ser acessado através da Api clássica Selenium RC, já presente no 1.x, ou com a API WebDriver (parcialmente implementada) do PHPUnit_Selenium 1.2.
     </para>
     <para>
@@ -44,17 +44,17 @@
       <listitem>Descompacte o arquivo de distribuição e copie o <filename>selenium-server-standalone-2.9.0.jar</filename> (verifique o sufixo da versão) para <filename>/usr/local/bin</filename>, por exemplo.</listitem>
       <listitem>Inicie o Servidor Selenium executando <userinput>java -jar /usr/local/bin/selenium-server-standalone-2.9.0.jar</userinput>.</listitem>
     </orderedlist>
-    
+
     <para>
-      O pacote PHPUnit_Selenium está incluso na distribuição PHAR 
+      O pacote PHPUnit_Selenium está incluso na distribuição PHAR
       do PHPUnit. Ele pode ser instalado através do Composer, adicionando a seguinte
       dependência <literal>"require-dev"</literal>:
     </para>
-    
+
     <screen><userinput>"phpunit/phpunit-selenium": ">=1.2"</userinput></screen>
 
     <para>
-      Agora podemos enviar comandos para o Servidor Selenium usando seu protocolo 
+      Agora podemos enviar comandos para o Servidor Selenium usando seu protocolo
       cliente/servidor.
     </para>
   </section>
@@ -69,9 +69,9 @@
     </para>
 
     <para>
-      <xref linkend="selenium.selenium2testcase.examples.WebTest.php" /> mostra 
+      <xref linkend="selenium.selenium2testcase.examples.WebTest.php" /> mostra
       como testar os conteúdos do elemento <literal><![CDATA[<title>]]></literal>
-      do site 
+      do site
       <systemitem role="URL">http://www.example.com/</systemitem>.
     </para>
     <example id="selenium.selenium2testcase.examples.WebTest.php">
@@ -88,7 +88,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -126,15 +126,15 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
     <para>
       <indexterm><primary><literal>PHPUnit_Extensions_SeleniumTestCase</literal></primary></indexterm>
 
-      A extensão de caso de teste <literal>PHPUnit_Extensions_SeleniumTestCase</literal> 
-      implementa o protocolo cliente/servidor para conversar com o Servidor Selenium assim como 
+      A extensão de caso de teste <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
+      implementa o protocolo cliente/servidor para conversar com o Servidor Selenium assim como
       métodos de asserção especializados para testes web.
     </para>
 
     <para>
-      O <xref linkend="selenium.seleniumtestcase.examples.WebTest.php" /> mostra 
+      O <xref linkend="selenium.seleniumtestcase.examples.WebTest.php" /> mostra
       como testar os conteúdos do elemento <literal><![CDATA[<title>]]></literal>
-      para o site 
+      para o site
       <systemitem role="URL">http://www.exemplo.com/</systemitem>.
     </para>
 
@@ -154,7 +154,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -180,8 +180,8 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 
     <para>
       Diferente da classe <literal>PHPUnit_Framework_TestCase</literal>,
-      classes de caso de teste que estendem o <literal>PHPUnit_Extensions_SeleniumTestCase</literal> 
-      têm que fornecer um método <literal>setUp()</literal>. Esse método é usado 
+      classes de caso de teste que estendem o <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
+      têm que fornecer um método <literal>setUp()</literal>. Esse método é usado
       para configurar a sessão do Servidor Selenium. Veja
       <xref linkend="selenium.seleniumtestcase.tables.seleniumrc-api.setup" />
       para uma lista de métodos que estão disponíveis para isso.
@@ -227,7 +227,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </table>
 
     <para>
-      O PHPUnit pode opcionalmente capturar a tela quando um teste do Selenium falha. Para 
+      O PHPUnit pode opcionalmente capturar a tela quando um teste do Selenium falha. Para
       habilitar isso, configure <literal>$captureScreenshotOnFailure</literal>,
       <literal>$screenshotPath</literal> e <literal>$screenshotUrl</literal>
       em sua classe de caso de teste como mostrado em
@@ -254,7 +254,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -280,12 +280,12 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 
     <para>
       Você pode executar cada teste usando um conjunto de navegadores: Em vez de usar
-      <literal>setBrowser()</literal> para configurar um navegador, você pode declarar um 
+      <literal>setBrowser()</literal> para configurar um navegador, você pode declarar um
       vetor <literal>public static</literal> chamado <literal>$browsers</literal>
-      em sua classe de caso de testes. Cada item nesse vetor descreve uma configuração 
-      de navegador. Cada um desses navegadores pode ser hospedado em diferentes 
+      em sua classe de caso de testes. Cada item nesse vetor descreve uma configuração
+      de navegador. Cada um desses navegadores pode ser hospedado em diferentes
       Servidores Selenium.
-      O <xref linkend="selenium.seleniumtestcase.examples.WebTest3.php" /> mostra 
+      O <xref linkend="selenium.seleniumtestcase.examples.WebTest3.php" /> mostra
       um exemplo.
     </para>
 
@@ -335,14 +335,14 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      <literal>PHPUnit_Extensions_SeleniumTestCase</literal> pode coletar a 
+      <literal>PHPUnit_Extensions_SeleniumTestCase</literal> pode coletar a
       informação de cobertura de código para execução de testes através do Selenium:
     </para>
 
@@ -353,7 +353,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </orderedlist>
 
     <para>
-      <xref linkend="selenium.seleniumtestcase.tables.assertions" /> lista os 
+      <xref linkend="selenium.seleniumtestcase.tables.assertions" /> lista os
       vários métodos de asserção que o <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
       fornece.
     </para>
@@ -422,7 +422,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      <xref linkend="selenium.seleniumtestcase.tables.template-methods" /> mostra 
+      <xref linkend="selenium.seleniumtestcase.tables.template-methods" /> mostra
       o método modelo de <literal>PHPUnit_Extensions_SeleniumTestCase</literal>:
     </para>
 
@@ -446,7 +446,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Por favor, verifique a <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentação dos comandos do Selenium</ulink> 
+      Por favor, verifique a <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentação dos comandos do Selenium</ulink>
       para uma referência de todos os comandos disponíveis e como eles são utilizados.
     </para>
     <para>
@@ -454,13 +454,13 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </para>
 
     <para>
-      Usando o método <literal>runSelenese($filename)</literal> você também pode 
-      executar um teste Selenium a partir de sua especificação Selenese/HTML. Além disso, 
-      usando o atributo estático <literal>$seleneseDirectory</literal>, você pode 
-      criar automaticamente objetos de teste a partir de um diretório que contenha 
-      arquivos Selenese/HTML. O diretório especificado é pesquisado recursivamente por 
+      Usando o método <literal>runSelenese($filename)</literal> você também pode
+      executar um teste Selenium a partir de sua especificação Selenese/HTML. Além disso,
+      usando o atributo estático <literal>$seleneseDirectory</literal>, você pode
+      criar automaticamente objetos de teste a partir de um diretório que contenha
+      arquivos Selenese/HTML. O diretório especificado é pesquisado recursivamente por
       arquivos <literal>.htm</literal> que possam conter Selenese/HTML.
-     O <xref linkend="selenium.seleniumtestcase.examples.WebTest4.php" /> mostra um 
+     O <xref linkend="selenium.seleniumtestcase.examples.WebTest4.php" /> mostra um
      exemplo.
     </para>
 
@@ -477,8 +477,8 @@ class SeleneseTests extends PHPUnit_Extensions_SeleniumTestCase
     </example>
 
     <para>
-    Desde o Selenium 1.1.1, um recurso experimental foi incluído para permitir ao usuário compartilhar a sessão entre testes. O único caso suportado é compartilhar a sessão entre todos os testes quando um único navegador é usado. 
-    Chame <literal>PHPUnit_Extensions_SeleniumTestCase::shareSession(true)</literal> em seu arquivo bootstrap para habilitar o compartilhamento de sessão. 
+    Desde o Selenium 1.1.1, um recurso experimental foi incluído para permitir ao usuário compartilhar a sessão entre testes. O único caso suportado é compartilhar a sessão entre todos os testes quando um único navegador é usado.
+    Chame <literal>PHPUnit_Extensions_SeleniumTestCase::shareSession(true)</literal> em seu arquivo bootstrap para habilitar o compartilhamento de sessão.
     A sessão será reiniciada no caso de testes mal-sucedidos (falhos ou incompletos); cabe ao usuário evitar interações entre testes seja resetando cookies ou deslogando da aplicação sob teste (com um método tearDown()).
     </para>
   </section>

--- a/src/4.6/pt_br/test-doubles.xml
+++ b/src/4.6/pt_br/test-doubles.xml
@@ -13,11 +13,11 @@
     <para>
       <indexterm><primary>Sistema Sob Teste</primary></indexterm>
 
-      Às vezes é muito difícil testar o sistema sob teste (SST - em inglês: system under test - SUT) 
-      porque isso depende de outros ambientes que não podem ser usados no ambiente 
-      de testes. Isso pode ser porque não estão disponíveis, não retornarão 
-      os resultados necessários para o teste, ou porque executá-los 
-      causaria efeitos colaterais indesejáveis. Em outros casos, nossa estratégia de testes requer 
+      Às vezes é muito difícil testar o sistema sob teste (SST - em inglês: system under test - SUT)
+      porque isso depende de outros ambientes que não podem ser usados no ambiente
+      de testes. Isso pode ser porque não estão disponíveis, não retornarão
+      os resultados necessários para o teste, ou porque executá-los
+      causaria efeitos colaterais indesejáveis. Em outros casos, nossa estratégia de testes requer
       que tenhamos mais controle ou visibilidade do comportamento interno do SST.
     </para>
 
@@ -25,27 +25,27 @@
       <indexterm><primary>Componente Dependente</primary></indexterm>
       <indexterm><primary>Dublê de Teste</primary></indexterm>
 
-      Quando estamos escrevendo um teste no qual não podemos (ou decidimos não) usar um componente 
-      dependente (depended-on component - DOC) real, podemos substitui-lo por um Dublê de Teste. O 
-      Dublê de Teste não precisa se comportar exatamente como o DOC real; apenas precisa 
-      fornecer a mesma API como o real, de forma que o SST pense que é 
+      Quando estamos escrevendo um teste no qual não podemos (ou decidimos não) usar um componente
+      dependente (depended-on component - DOC) real, podemos substitui-lo por um Dublê de Teste. O
+      Dublê de Teste não precisa se comportar exatamente como o DOC real; apenas precisa
+      fornecer a mesma API como o real, de forma que o SST pense que é
       o real!
     </para>
   </blockquote>
 
   <para>
-    O método <literal>getMockBuilder($type)</literal> fornecido pelo PHPUnit pode 
-    ser usado em um teste para gerar automaticamente um objeto que possa atuar como um dublê 
-    de teste para a classe original especificada. Esse objeto de 
-    dublê de teste pode ser usado em cada contexto onde um objeto da classe original 
+    O método <literal>getMockBuilder($type)</literal> fornecido pelo PHPUnit pode
+    ser usado em um teste para gerar automaticamente um objeto que possa atuar como um dublê
+    de teste para a classe original especificada. Esse objeto de
+    dublê de teste pode ser usado em cada contexto onde um objeto da classe original
     é esperado ou requerido.
   </para>
 
   <para>
-    Por padrão, todos os métodos da classe original são substituídos com uma implementação 
-    simulada que apenas retorna <literal>null</literal> (sem chamar 
-    o método original). Usando o método <literal>will($this->returnValue())</literal>, 
-    por exemplo, você pode configurar essas implementações simuladas para 
+    Por padrão, todos os métodos da classe original são substituídos com uma implementação
+    simulada que apenas retorna <literal>null</literal> (sem chamar
+    o método original). Usando o método <literal>will($this->returnValue())</literal>,
+    por exemplo, você pode configurar essas implementações simuladas para
     retornar um valor quando chamadas.
   </para>
 
@@ -54,8 +54,8 @@
 
     <para>
       Por favor, note que os métodos <literal>final</literal>, <literal>private</literal>
-      e <literal>static</literal> não podem ser esboçados (stubbed) ou falsificados (mocked). Eles 
-      são ignorados pela funcionalidade de dublê de teste do PHPUnit e mantêm seus 
+      e <literal>static</literal> não podem ser esboçados (stubbed) ou falsificados (mocked). Eles
+      são ignorados pela funcionalidade de dublê de teste do PHPUnit e mantêm seus
       comportamentos originais.
     </para>
   </note>
@@ -64,7 +64,7 @@
     <title>Aviso</title>
 
     <para>
-        Por favor atente para o fato de que a gestão de parâmetros foi mudada. 
+        Por favor atente para o fato de que a gestão de parâmetros foi mudada.
         A implementação anterior clona todos os parâmetros de objetos. Isso não permite verificar se o mesmo objeto foi passado para um método ou não.
         <xref linkend="test-doubles.mock-objects.examples.clone-object-parameters-usecase.php" /> mostra onde a nova implementação pode ser útil.
         <xref linkend="test-doubles.mock-objects.examples.enable-clone-object-parameters.php" /> mostra como voltar para o comportamento anterior.
@@ -77,27 +77,27 @@
     <para>
       <indexterm><primary>Esboço</primary></indexterm>
 
-      A prática de substituir um objeto por um dublê de teste que (opcionalmente) 
+      A prática de substituir um objeto por um dublê de teste que (opcionalmente)
       retorna valores de retorno configurados é chamada de
-      <emphasis>delineamento</emphasis>. Você pode usar um <emphasis>esboço</emphasis> para 
-      "substituir um componente real do qual o SST depende de modo que o teste tenha um 
-      ponto de controle para as entradas indiretas do SST. Isso permite ao teste 
+      <emphasis>delineamento</emphasis>. Você pode usar um <emphasis>esboço</emphasis> para
+      "substituir um componente real do qual o SST depende de modo que o teste tenha um
+      ponto de controle para as entradas indiretas do SST. Isso permite ao teste
       forçar o SST através de caminhos que não seriam executáveis de outra forma".
     </para>
 
     <para>
       <indexterm><primary>Interface Fluente</primary></indexterm>
 
-      <xref linkend="test-doubles.stubs.examples.StubTest.php" /> mostra como 
-      esboçar chamadas de método e configurar valores de retorno. Primeiro usamos o 
-      método <literal>getMockBuilder()</literal> que é fornecido pela 
-      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um esboço 
+      <xref linkend="test-doubles.stubs.examples.StubTest.php" /> mostra como
+      esboçar chamadas de método e configurar valores de retorno. Primeiro usamos o
+      método <literal>getMockBuilder()</literal> que é fornecido pela
+      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um esboço
       de objeto que parece com um objeto de <literal>SomeClass</literal>
-      (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). Então 
+      (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). Então
       usamos a <ulink url="http://martinfowler.com/bliki/FluentInterface.html">Interface Fluente</ulink>
-      que o PHPUnit fornece para especificar o comportamento para o esboço. Essencialmente, 
-      isso significa que você não precisa criar vários objetos temporários e 
-      uni-los depois. Em vez disso, você encadeia chamadas de método como mostrado no 
+      que o PHPUnit fornece para especificar o comportamento para o esboço. Essencialmente,
+      isso significa que você não precisa criar vários objetos temporários e
+      uni-los depois. Em vez disso, você encadeia chamadas de método como mostrado no
       exemplo. Isso leva a códigos mais legíveis e "fluentes".
     </para>
 
@@ -134,22 +134,22 @@ class StubTest extends PHPUnit_Framework_TestCase
         $stub->method('doSomething')
              ->willReturn('foo');
 
-        // Chamando $esboco->fazAlgumaCoisa() agora vai retornar 
+        // Chamando $esboco->fazAlgumaCoisa() agora vai retornar
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      "Atrás dos bastidores" o PHPUnit automaticamente gera uma nova classe PHP que 
+      "Atrás dos bastidores" o PHPUnit automaticamente gera uma nova classe PHP que
       implementa o comportamento desejado quando o método <literal>getMock()</literal>
       é usado.
     </para>
 
     <para>
-      <xref linkend="test-doubles.stubs.examples.StubTest2.php"/> mostra um 
+      <xref linkend="test-doubles.stubs.examples.StubTest2.php"/> mostra um
       exemplo de como usar a interface fluente do Mock Builder para configurar a
       criação do dublê de teste.
     </para>
@@ -177,7 +177,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Chamar $stub->doSomething() agora vai retornar
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -195,18 +195,18 @@ class StubTest extends PHPUnit_Framework_TestCase
       <listitem><para><literal>disableOriginalClone()</literal> pode ser usado para desabilitar a chamada ao construtor do clone da classe original.</para></listitem>
       <listitem><para><literal>disableAutoload()</literal> pode ser usado para desabilitar o <literal>__autoload()</literal> durante a geração da classe de dublê de teste.</para></listitem>
     </itemizedlist>
-    
+
     <para>
       Nos exemplos até agora temos retornado valores simples usando
-      <literal>willReturn($value)</literal>. Essa sintaxe curta é o mesmo que 
-      <literal>will($this->returnValue($value))</literal>. Podemos usar variações 
+      <literal>willReturn($value)</literal>. Essa sintaxe curta é o mesmo que
+      <literal>will($this->returnValue($value))</literal>. Podemos usar variações
       desta sintaxe longa para alcançar mais comportamento de esboço complexo.
     </para>
 
     <para>
-      Às vezes você quer retornar um dos argumentos de uma chamada de método 
+      Às vezes você quer retornar um dos argumentos de uma chamada de método
       (inalterada) como o resultado de uma chamada ao método esboçado.
-      <xref linkend="test-doubles.stubs.examples.StubTest3.php"/> mostra como você 
+      <xref linkend="test-doubles.stubs.examples.StubTest3.php"/> mostra como você
       pode conseguir isso usando <literal>returnArgument()</literal> em vez de
       <literal>returnValue()</literal>.
     </para>
@@ -233,19 +233,19 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') retorna 'foo'.
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') retorna 'bar'.
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Ao testar uma interface fluente, às vezes é útil fazer um método 
+      Ao testar uma interface fluente, às vezes é útil fazer um método
       esboçado retornar uma referência ao objeto esboçado.
-      <xref linkend="test-doubles.stubs.examples.StubTest4.php"/> mostra como você 
+      <xref linkend="test-doubles.stubs.examples.StubTest4.php"/> mostra como você
       pode usar <literal>returnSelf()</literal> para conseguir isso.
     </para>
 
@@ -271,18 +271,18 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() retorna $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Algumas vezes um método esboçado deveria retornar valores diferentes dependendo de 
+      Algumas vezes um método esboçado deveria retornar valores diferentes dependendo de
       uma lista predefinida de argumentos. Você pode usar
-      <literal>returnValueMap()</literal> para criar um mapa que associa 
+      <literal>returnValueMap()</literal> para criar um mapa que associa
       argumentos com valores de retorno correspondentes. Veja
-      <xref linkend="test-doubles.stubs.examples.StubTest5.php"/> para 
+      <xref linkend="test-doubles.stubs.examples.StubTest5.php"/> para
       ter um exemplo.
     </para>
 
@@ -313,20 +313,20 @@ class StubTest extends PHPUnit_Framework_TestCase
         $stub->method('doSomething')
              ->will($this->returnValueMap($map));
 
-        // $stub->doSomething() retorna diferentes valores dependendo do 
+        // $stub->doSomething() retorna diferentes valores dependendo do
         // argumento fornecido.
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Quando a chamada ao método esboçado deve retornar um valor calculado em vez de 
-      um fixo (veja <literal>returnValue()</literal>) ou um argumento (inalterado) 
+      Quando a chamada ao método esboçado deve retornar um valor calculado em vez de
+      um fixo (veja <literal>returnValue()</literal>) ou um argumento (inalterado)
       (veja <literal>returnArgument()</literal>), você pode usar
-      <literal>returnCallback()</literal> para que o método esboçado retorne o 
+      <literal>returnCallback()</literal> para que o método esboçado retorne o
       resultado da função ou método callback. Veja
       <xref linkend="test-doubles.stubs.examples.StubTest6.php"/> para ter um exemplo.
     </para>
@@ -353,17 +353,17 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) retorna str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Uma alternativa mais simples para configurar um método callback pode ser 
-      especificar uma lista de valores de retorno desejados. Você pode fazer isso com 
+      Uma alternativa mais simples para configurar um método callback pode ser
+      especificar uma lista de valores de retorno desejados. Você pode fazer isso com
       o método <literal>onConsecutiveCalls()</literal>. Veja
-      <xref linkend="test-doubles.stubs.examples.StubTest7.php"/> para 
+      <xref linkend="test-doubles.stubs.examples.StubTest7.php"/> para
       ter um exemplo.
     </para>
 
@@ -372,7 +372,7 @@ class StubTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>will()</primary></indexterm>
       <indexterm><primary>onConsecutiveCalls()</primary></indexterm>
-      <title>Esboçando uma chamada de método para retornar uma lista de valores na 
+      <title>Esboçando uma chamada de método para retornar uma lista de valores na
       ordem especificada</title>
       <programlisting><![CDATA[<?php
 require_once 'SomeClass.php';
@@ -390,9 +390,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() retorna um valor diferente em cada vez
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -400,7 +400,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
 
     <para>
-      Em vez de retornar um valor, um método esboçado também pode causar uma 
+      Em vez de retornar um valor, um método esboçado também pode causar uma
       exceção. <xref linkend="test-doubles.stubs.examples.StubTest8.php"/>
       mostra como usar <literal>throwException()</literal> para fazer isso.
     </para>
@@ -434,23 +434,23 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Alternativamente, você mesmo pode escrever um esboço enquanto melhora 
-      o design. Recursos amplamente utilizados são acessados através de uma única fachada, 
-      então você pode substituir facilmente o recurso pelo esboço. Por exemplo, 
-      em vez de ter chamadas diretas ao banco de dados espalhadas pelo código, 
-      você tem um único objeto <literal>Database</literal> que implementa a interface 
-      <literal>IDatabase</literal>. Então, você pode criar um esboço 
-      de implementação da <literal>IDatabase</literal> e usá-la em seus 
-      testes. Você pode até criar uma opção para executar os testes com o 
-      esboço do banco de dados ou com o banco de dados real, então você pode usar seus testes tanto 
-      para testes locais durante o desenvolvimento quanto para integração dos testes com o 
+      Alternativamente, você mesmo pode escrever um esboço enquanto melhora
+      o design. Recursos amplamente utilizados são acessados através de uma única fachada,
+      então você pode substituir facilmente o recurso pelo esboço. Por exemplo,
+      em vez de ter chamadas diretas ao banco de dados espalhadas pelo código,
+      você tem um único objeto <literal>Database</literal> que implementa a interface
+      <literal>IDatabase</literal>. Então, você pode criar um esboço
+      de implementação da <literal>IDatabase</literal> e usá-la em seus
+      testes. Você pode até criar uma opção para executar os testes com o
+      esboço do banco de dados ou com o banco de dados real, então você pode usar seus testes tanto
+      para testes locais durante o desenvolvimento quanto para integração dos testes com o
       banco de dados real.
     </para>
 
     <para>
-      Funcionalidades que precisam ser esboçadas tendem a se agrupar no mesmo 
-      objeto, aumentando a coesão. Por apresentar a funcionalidade com uma 
-      interface única e coerente, você reduz o acoplamento com o resto do 
+      Funcionalidades que precisam ser esboçadas tendem a se agrupar no mesmo
+      objeto, aumentando a coesão. Por apresentar a funcionalidade com uma
+      interface única e coerente, você reduz o acoplamento com o resto do
       sistema.
     </para>
   </section>
@@ -459,20 +459,20 @@ class StubTest extends PHPUnit_Framework_TestCase
     <title>Objetos Falsos</title>
 
     <para>
-      A prática de substituir um objeto por um dublê de teste que verifica 
-      expectativas, por exemplo asseverando que um método foi chamado, é 
+      A prática de substituir um objeto por um dublê de teste que verifica
+      expectativas, por exemplo asseverando que um método foi chamado, é
       conhecido como <emphasis>falsificação (mocking)</emphasis>.
     </para>
 
     <para>
       <indexterm><primary>Objeto Falso</primary></indexterm>
 
-      Você pode usar um <emphasis>objeto falso</emphasis> "como um ponto de observação 
-      que é usado para verificar as saídas indiretas do SST durante seu exercício. 
-      Tipicamente, o objeto falso também inclui a funcionalidade de um esboço de teste 
-      que deve retornar valores para o SST se ainda não tiver falhado 
-      nos testes, mas a ênfase está na verificação das saídas indiretas. 
-      Portanto, um objeto falso é muito mais que apenas um esboço de testes mais 
+      Você pode usar um <emphasis>objeto falso</emphasis> "como um ponto de observação
+      que é usado para verificar as saídas indiretas do SST durante seu exercício.
+      Tipicamente, o objeto falso também inclui a funcionalidade de um esboço de teste
+      que deve retornar valores para o SST se ainda não tiver falhado
+      nos testes, mas a ênfase está na verificação das saídas indiretas.
+      Portanto, um objeto falso é muito mais que apenas um esboço de testes mais
       asserções; é utilizado de uma forma fundamentalmente diferente".
     </para>
 
@@ -481,15 +481,15 @@ class StubTest extends PHPUnit_Framework_TestCase
 
       <para>
         Somente objetos falsos gerados no escopo de um teste irá ser verificado
-        automaticamente pelo PHPUnit. Objetos falsos gerados em provedores de dados, por 
+        automaticamente pelo PHPUnit. Objetos falsos gerados em provedores de dados, por
         exemplo, não serão verificados pelo PHPUnit.
       </para>
     </note>
-    
+
     <para>
       Aqui está um exemplo: suponha que queiramos testar se o método correto,
-      <literal>update()</literal> em nosso exemplo, é chamado em um objeto que 
-      observa outro objeto. <xref linkend="test-doubles.mock-objects.examples.SUT.php"/> 
+      <literal>update()</literal> em nosso exemplo, é chamado em um objeto que
+      observa outro objeto. <xref linkend="test-doubles.mock-objects.examples.SUT.php"/>
       mostra o código para as classes <literal>Subject</literal> e <literal>Observer</literal>
       que são parte do Sistema Sob Teste (SST).
     </para>
@@ -565,21 +565,21 @@ class Observer
       <indexterm><primary>Objeto Falso</primary></indexterm>
 
       <xref linkend="test-doubles.mock-objects.examples.SubjectTest.php" />
-      mostra como usar um objeto falso para testar a interação entre 
+      mostra como usar um objeto falso para testar a interação entre
       os objetos <literal>Subject</literal> e <literal>Observer</literal>.
     </para>
 
     <para>
-      Primeiro usamos o método <literal>getMock()</literal> que é fornecido pela 
-      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um objeto 
-      falso para ser o <literal>Observer</literal>. Já que fornecemos um vetor como 
-      segundo parâmetro (opcional) para o método <literal>getMock()</literal>, 
-      apenas o método <literal>update()</literal> da classe 
+      Primeiro usamos o método <literal>getMock()</literal> que é fornecido pela
+      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um objeto
+      falso para ser o <literal>Observer</literal>. Já que fornecemos um vetor como
+      segundo parâmetro (opcional) para o método <literal>getMock()</literal>,
+      apenas o método <literal>update()</literal> da classe
       <literal>Observer</literal> é substituído por uma implementação falsificada.
     </para>
 
     <para>
-      Porque estamos interessados em verificar se um método foi chamado, e com quais 
+      Porque estamos interessados em verificar se um método foi chamado, e com quais
       argumentos ele foi chamado, introduzimos os métodos <literal>expects()</literal> e
       <literal>with()</literal> para especificar como essa interação deve considerar.
     </para>
@@ -619,14 +619,14 @@ class SubjectTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      O método <literal>with()</literal> pode receber qualquer número de 
-      argumentos, correspondendo ao número de argumentos 
-      sendo falsos. Você pode especificar restrições mais avançadas 
+      O método <literal>with()</literal> pode receber qualquer número de
+      argumentos, correspondendo ao número de argumentos
+      sendo falsos. Você pode especificar restrições mais avançadas
       do que uma simples igualdade no argumento do método.
     </para>
 
     <example id="test-doubles.mock-objects.examples.MultiParameterTest.php">
-      <title>Testando se um método é chamado com um número de 
+      <title>Testando se um método é chamado com um número de
       argumentos restringidos de formas diferentes</title>
       <programlisting><![CDATA[<?php
 class SubjectTest extends PHPUnit_Framework_TestCase
@@ -657,11 +657,11 @@ class SubjectTest extends PHPUnit_Framework_TestCase
 }
 ?>]]></programlisting>
     </example>
-    
+
     <para>
-      O método <literal>withConsecutive()</literal> pode receber qualquer número de 
+      O método <literal>withConsecutive()</literal> pode receber qualquer número de
       vetores de argumentos, dependendo das chamados que você quer testar contra.
-      Cada vetor é uma lista de restrições correspondentes para os argumentos do 
+      Cada vetor é uma lista de restrições correspondentes para os argumentos do
       método falsificado, como em <literal>with()</literal>.
     </para>
 
@@ -692,9 +692,9 @@ class FooTest extends PHPUnit_Framework_TestCase
 
     <para>
       A restrição <literal>callback()</literal> pode ser usada para verificação de argumento
-      mais complexa. Essa restrição recebe um callback PHP como seu único 
-      argumento. O callback PHP receberá o argumento a ser verificado como 
-      seu único argumento e deverá retornar <literal>TRUE</literal> se o 
+      mais complexa. Essa restrição recebe um callback PHP como seu único
+      argumento. O callback PHP receberá o argumento a ser verificado como
+      seu único argumento e deverá retornar <literal>TRUE</literal> se o
       argumento passou a verificação e <literal>FALSE</literal> caso contrário.
     </para>
 
@@ -778,7 +778,7 @@ class FooTest extends PHPUnit_Framework_TestCase
       <xref linkend="appendixes.assertions.assertThat.tables.constraints"/>
       mostra as restrições que podem ser aplicadas aos argumentos do método e
       <xref linkend="test-doubles.mock-objects.tables.matchers"/>
-      mostra os comparados que estão disponíveis para especificar o número de 
+      mostra os comparados que estão disponíveis para especificar o número de
       invocações.
     </para>
 
@@ -824,22 +824,22 @@ class FooTest extends PHPUnit_Framework_TestCase
     <note>
       <para>
         O parâmetro <literal>$index</literal> para o comparador <literal>at()</literal>
-        se refere ao índice, iniciando em zero, em <emphasis>todas invocações 
-        de métodos</emphasis> para um objeto falsificado fornecido. Tenha cuidado ao 
-        usar este comparador, pois pode levar a testes frágeis que são muito 
+        se refere ao índice, iniciando em zero, em <emphasis>todas invocações
+        de métodos</emphasis> para um objeto falsificado fornecido. Tenha cuidado ao
+        usar este comparador, pois pode levar a testes frágeis que são muito
         intimamente ligados a detalhes de implementação específicos.
       </para>
     </note>
   </section>
-  
+
   <section id="test-doubles.prophecy">
     <title>Profecia</title>
 
     <para>
       <ulink url="https://github.com/phpspec/prophecy">Prophecy</ulink> é um
-      "framework PHP de falsificação de objetos muito poderoso e flexível, porém 
-      altamente opcional. Embora inicialmente criado para atender as necessidades do phpspec2, ele é 
-      flexível o suficiente para ser usado dentro de qualquer framework de teste por aí, com 
+      "framework PHP de falsificação de objetos muito poderoso e flexível, porém
+      altamente opcional. Embora inicialmente criado para atender as necessidades do phpspec2, ele é
+      flexível o suficiente para ser usado dentro de qualquer framework de teste por aí, com
       o mínimo de esforço".
     </para>
 
@@ -847,7 +847,7 @@ class FooTest extends PHPUnit_Framework_TestCase
       O PHPUnit tem suporte nativo para uso do Prophecy para criar dublês de testes
       desde a versão 4.5. <xref linkend="test-doubles.prophecy.examples.SubjectTest.php"/>
       mostra como o mesmo teste mostrado no <xref linkend="test-doubles.mock-objects.examples.SubjectTest.php"/>
-      pode ser expressado usando a filosofia do Prophecy de profecias e 
+      pode ser expressado usando a filosofia do Prophecy de profecias e
       revelações:
     </para>
 
@@ -895,7 +895,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>getMockForTrait()</primary></indexterm>
 
       O método <literal>getMockForTrait()</literal> retorna um objeto falsificado
-      que usa uma trait especificada. Todos métodos abstratos de uma dada trait 
+      que usa uma trait especificada. Todos métodos abstratos de uma dada trait
       são falsificados. Isto permite testar os métodos concretos de uma trait.
     </para>
 
@@ -922,18 +922,18 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
     </example>
-    
+
     <para>
       <indexterm><primary>getMockForAbstractClass()</primary></indexterm>
 
-      O método <literal>getMockForAbstractClass()</literal> retorna um objeto 
-      falso para uma classe abstrata. Todos os métodos abstratos da classe abstrata fornecida 
-      são falsificados. Isto permite testar os métodos concretos de uma 
+      O método <literal>getMockForAbstractClass()</literal> retorna um objeto
+      falso para uma classe abstrata. Todos os métodos abstratos da classe abstrata fornecida
+      são falsificados. Isto permite testar os métodos concretos de uma
       classe abstrata.
     </para>
 
@@ -960,7 +960,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -973,18 +973,18 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>getMockFromWsdl()</primary></indexterm>
 
-      Quando sua aplicação interage com um serviço web você quer testá-lo 
-      sem realmente interagir com o serviço web. Para tornar mais fáceis o esboço 
+      Quando sua aplicação interage com um serviço web você quer testá-lo
+      sem realmente interagir com o serviço web. Para tornar mais fáceis o esboço
       e falsificação dos serviços web, o <literal>getMockFromWsdl()</literal>
-      pode ser usado da mesma forma que o <literal>getMock()</literal> (veja acima). A única 
-      diferença é que <literal>getMockFromWsdl()</literal> retorna um esboço ou 
+      pode ser usado da mesma forma que o <literal>getMock()</literal> (veja acima). A única
+      diferença é que <literal>getMockFromWsdl()</literal> retorna um esboço ou
       falsificação baseado em uma descrição de um serviço web em WSDL e <literal>getMock()</literal>
       retorna um esboço ou falsificação baseado em uma classe ou interface PHP.
     </para>
 
     <para>
       <xref linkend="test-doubles.stubbing-and-mocking-web-services.examples.GoogleTest.php"/>
-      mostra como <literal>getMockFromWsdl()</literal> pode ser usado para esboçar, por 
+      mostra como <literal>getMockFromWsdl()</literal> pode ser usado para esboçar, por
       exemplo, o serviço web descrito em <filename>GoogleSearch.wsdl</filename>.
     </para>
 
@@ -1035,7 +1035,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() will now return a stubbed result and
          * the web service's doGoogleSearch() method will not be invoked.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1063,15 +1063,15 @@ class GoogleTest extends PHPUnit_Framework_TestCase
       <ulink url="https://github.com/mikey179/vfsStream">vfsStream</ulink>
       é um <ulink url="http://www.php.net/streams">stream wrapper</ulink> para um
       <ulink url="http://en.wikipedia.org/wiki/Virtual_file_system">sistema de arquivos virtual
-      </ulink> que pode ser útil em testes unitários para falsificar um sistema 
+      </ulink> que pode ser útil em testes unitários para falsificar um sistema
       de arquivos real.
     </para>
 
     <para>
-      Simplesmente adicione a dependência <literal>mikey179/vfsStream</literal> ao seu 
+      Simplesmente adicione a dependência <literal>mikey179/vfsStream</literal> ao seu
       arquivo <literal>composer.json</literal> do projeto se você usa o
-      <ulink url="https://getcomposer.org/">Composer</ulink> para gerenciar as 
-      dependências do seu projeto. Aqui é um exemplo simplório de um arquivo 
+      <ulink url="https://getcomposer.org/">Composer</ulink> para gerenciar as
+      dependências do seu projeto. Aqui é um exemplo simplório de um arquivo
       <literal>composer.json</literal> que apenas define uma dependência em ambiente de
       desenvolvimento para o PHPUnit 4.6 e vfsStream:
     </para>
@@ -1113,8 +1113,8 @@ class Example
     </example>
 
     <para>
-      Sem um sistema de arquivos virtual tal como o vfsStream não poderíamos testar o 
-      método <literal>setDirectory()</literal> isolado de influências 
+      Sem um sistema de arquivos virtual tal como o vfsStream não poderíamos testar o
+      método <literal>setDirectory()</literal> isolado de influências
       externas (veja <xref
       linkend="test-doubles.mocking-the-filesystem.examples.ExampleTest.php"/>).
     </para>
@@ -1136,10 +1136,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1164,7 +1164,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
 
     <para>
       <xref linkend="test-doubles.mocking-the-filesystem.examples.ExampleTest2.php"/>
-      mostra como o vfsStream pode ser usado para falsificar o sistema de arquivos em um teste para uma 
+      mostra como o vfsStream pode ser usado para falsificar o sistema de arquivos em um teste para uma
       classe que interage com o sistema de arquivos.
     </para>
 
@@ -1185,10 +1185,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/pt_br/textui.xml
+++ b/src/4.6/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -401,7 +401,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict</literal></term>
         <listitem>
@@ -601,7 +601,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -612,7 +612,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -623,18 +623,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -644,7 +644,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -672,7 +672,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -681,7 +681,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -704,17 +704,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -730,16 +730,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -798,14 +798,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -817,7 +817,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -842,7 +842,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/4.6/pt_br/writing-tests-for-phpunit.xml
+++ b/src/4.6/pt_br/writing-tests-for-phpunit.xml
@@ -6,9 +6,9 @@
   <para>
     <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
-    <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" /> mostra 
-    como podemos escrever testes usando o PHPUnit que exercita operações de vetor do PHP. 
-    O exemplo introduz as convenções básicas e passos para escrever testes 
+    <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" /> mostra
+    como podemos escrever testes usando o PHPUnit que exercita operações de vetor do PHP.
+    O exemplo introduz as convenções básicas e passos para escrever testes
     com o PHPUnit:
   </para>
 
@@ -27,14 +27,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -43,8 +43,8 @@ class StackTest extends PHPUnit_Framework_TestCase
   <blockquote>
     <attribution>Martin Fowler</attribution>
     <para>
-      Sempre que você estiver tentado a escrever algo em uma 
-      declaração <literal>print</literal> ou uma expressão depuradora, escreva 
+      Sempre que você estiver tentado a escrever algo em uma
+      declaração <literal>print</literal> ou uma expressão depuradora, escreva
       como um teste em vez disso.
     </para>
   </blockquote>
@@ -55,13 +55,13 @@ class StackTest extends PHPUnit_Framework_TestCase
     <blockquote>
       <attribution>Adrian Kuhn et. al.</attribution>
       <para>
-        Testes Unitários são primeiramente escritos como uma boa prática para ajudar desenvolvedores 
-        a identificar e corrigir defeitos, refatorar o código e servir como documentação 
-        para uma unidade de programa sob teste. Para conseguir esses benefícios, testes unitários 
-        idealmente deveriam cobrir todos os caminhos possíveis em um programa. Um teste unitário 
-        geralmente cobre um caminho específico em uma função ou método. Porém um 
-        método de teste não é necessariamente uma entidade encapsulada e independente. Às vezes 
-        existem dependências implícitas entre métodos de teste, escondidas no 
+        Testes Unitários são primeiramente escritos como uma boa prática para ajudar desenvolvedores
+        a identificar e corrigir defeitos, refatorar o código e servir como documentação
+        para uma unidade de programa sob teste. Para conseguir esses benefícios, testes unitários
+        idealmente deveriam cobrir todos os caminhos possíveis em um programa. Um teste unitário
+        geralmente cobre um caminho específico em uma função ou método. Porém um
+        método de teste não é necessariamente uma entidade encapsulada e independente. Às vezes
+        existem dependências implícitas entre métodos de teste, escondidas no
         cenário de implementação de um teste.
       </para>
     </blockquote>
@@ -69,9 +69,9 @@ class StackTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>Dependências de Testes</primary></indexterm>
 
-      O PHPUnit suporta a declaração explícita de dependências entre métodos de teste. 
-      Tais dependências não definem a ordem em que os métodos de teste 
-      devem ser executados, mas permitem o retorno de uma instância do 
+      O PHPUnit suporta a declaração explícita de dependências entre métodos de teste.
+      Tais dependências não definem a ordem em que os métodos de teste
+      devem ser executados, mas permitem o retorno de uma instância do
       ambiente do teste por um produtor e a passagem dele para os consumidores dependentes.
     </para>
 
@@ -84,8 +84,8 @@ class StackTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Anotação</primary></indexterm>
       <indexterm><primary>@depends</primary></indexterm>
 
-      <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> mostra 
-      como usar a anotação <literal>@depends</literal> para expressar 
+      <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> mostra
+      como usar a anotação <literal>@depends</literal> para expressar
       dependências entre métodos de teste.
     </para>
 
@@ -97,7 +97,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -108,8 +108,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -119,16 +119,16 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      No exemplo acima, o primeiro teste, <literal>testEmpty()</literal>, 
-      cria um novo vetor e assegura que o mesmo é vazio. O teste então retorna 
+      No exemplo acima, o primeiro teste, <literal>testEmpty()</literal>,
+      cria um novo vetor e assegura que o mesmo é vazio. O teste então retorna
       o ambiente como resultado. O segundo teste, <literal>testPush()</literal>,
       depende de <literal>testEmpty()</literal> e lhe é passado o resultado do qual
       ele depende como um argumento. Finalmente, <literal>testPop()</literal>
@@ -138,9 +138,9 @@ class StackTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>Localização de Defeitos</primary></indexterm>
 
-      Para localizar defeitos rapidamente, queremos nossa atenção focada nas 
-      falhas relevantes dos testes. É por isso que o PHPUnit pula a execução de um teste 
-      quando um teste do qual ele depende falha. Isso melhora a localização de defeitos por 
+      Para localizar defeitos rapidamente, queremos nossa atenção focada nas
+      falhas relevantes dos testes. É por isso que o PHPUnit pula a execução de um teste
+      quando um teste do qual ele depende falha. Isso melhora a localização de defeitos por
       explorar as dependências entre os testes como mostrado em
       <xref linkend="writing-tests-for-phpunit.examples.DependencyFailureTest.php" />.
     </para>
@@ -152,7 +152,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -163,7 +163,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
     }
 }
 ?>]]></programlisting>
-    
+
       <screen><userinput>phpunit --verbose DependencyFailureTest</userinput><![CDATA[
 PHPUnit 4.6.0 by Sebastian Bergmann and contributors.
 
@@ -189,19 +189,19 @@ Tests: 1, Assertions: 1, Failures: 1, Skipped: 1.]]></screen>
     </example>
 
     <para>
-      Um teste pode ter mais de uma anotação <literal>@depends</literal>. 
-      O PHPUnit não muda a ordem em que os testes são executados, portanto você deve 
-      se certificar de que as dependências de um teste podem realmente ser encontradas antes de 
+      Um teste pode ter mais de uma anotação <literal>@depends</literal>.
+      O PHPUnit não muda a ordem em que os testes são executados, portanto você deve
+      se certificar de que as dependências de um teste podem realmente ser encontradas antes de
       executar o teste.
     </para>
-    
+
     <para>
       Um teste que tem mais de uma anotação <literal>@depends</literal>
-      vai obter um ambiente a partir do primeiro produtor como o primeiro argumento, um ambiente 
+      vai obter um ambiente a partir do primeiro produtor como o primeiro argumento, um ambiente
       a partir do segundo produtor como o segundo argumento, e assim por diante.
       Veja <xref linkend="writing-tests-for-phpunit.examples.MultipleDependencies.php" />
     </para>
-    
+
     <example id="writing-tests-for-phpunit.examples.MultipleDependencies.php">
       <title>Teste com múltiplas dependências</title>
       <programlisting><![CDATA[<?php
@@ -209,13 +209,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -225,7 +225,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -250,18 +250,18 @@ OK (3 tests, 3 assertions)]]></screen>
     <para>
       <indexterm><primary>Anotação</primary></indexterm>
       <indexterm><primary>@dataProvider</primary></indexterm>
-      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser 
+      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser
       fornecidos por um método provedor de dados (<literal>additionProvider()</literal> em
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
-      O método provedor de dados a ser usado é especificado usando a 
+      O método provedor de dados a ser usado é especificado usando a
       anotação <literal>@dataProvider</literal>.
     </para>
 
     <para>
-      Um método provedor de dados deve ser <literal>public</literal> e ou retornar 
-      um vetor de vetores ou um objeto que implementa a interface <literal>Iterator</literal> 
-      e produz um vetor para cada passo da iteração. Para cada vetor que 
-      é parte da coleção o método de teste será chamado com os conteúdos 
+      Um método provedor de dados deve ser <literal>public</literal> e ou retornar
+      um vetor de vetores ou um objeto que implementa a interface <literal>Iterator</literal>
+      e produz um vetor para cada passo da iteração. Para cada vetor que
+      é parte da coleção o método de teste será chamado com os conteúdos
       do vetor como seus argumentos.
     </para>
 
@@ -275,7 +275,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -320,7 +320,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -396,13 +396,13 @@ class CsvFileIterator implements Iterator {
       <indexterm><primary>@depends</primary></indexterm>
 
       Quando um teste recebe uma entrada tanto de um método <literal>@dataProvider</literal>
-      quanto de um ou mais testes dos quais ele <literal>@depends</literal>, os 
-      argumentos do provedor de dados virão antes daqueles dos quais ele 
-      é dependente. Os argumentos dos quais o teste depende serão os 
+      quanto de um ou mais testes dos quais ele <literal>@depends</literal>, os
+      argumentos do provedor de dados virão antes daqueles dos quais ele
+      é dependente. Os argumentos dos quais o teste depende serão os
       mesmos para cada conjunto de dados.
       Veja <xref linkend="writing-tests-for-phpunit.data-providers.examples.DependencyAndDataProviderCombo.php"/>
     </para>
-    
+
     <example id="writing-tests-for-phpunit.data-providers.examples.DependencyAndDataProviderCombo.php">
       <title>Combinação de @depends e @dataProvider no mesmo teste</title>
       <programlisting><![CDATA[<?php
@@ -415,13 +415,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -432,7 +432,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -473,9 +473,9 @@ Tests: 4, Assertions: 4, Failures: 1.
         <indexterm><primary>@dataProvider</primary></indexterm>
         <indexterm><primary>@depends</primary></indexterm>
 
-        Quando um teste depende de um teste que usa provedores de dados, o teste dependente 
-        será executado quando o teste do qual ele depende for bem sucedido em pelo 
-        menos um conjunto de dados. O resultado de um teste que usa provedores de dados não pode 
+        Quando um teste depende de um teste que usa provedores de dados, o teste dependente
+        será executado quando o teste do qual ele depende for bem sucedido em pelo
+        menos um conjunto de dados. O resultado de um teste que usa provedores de dados não pode
         ser injetado dentro de um teste dependente.
       </para>
     </note>
@@ -488,8 +488,8 @@ Tests: 4, Assertions: 4, Failures: 1.
 
         Todos provedores de dados são executados antes da chamada ao método estático <literal>setUpBeforeClass</literal>
         e a primeira chamada ao método <literal>setUp</literal>.
-        Por isso você não pode acessar quaisquer variáveis que criar 
-        ali de dentro de um provedor de dados. Isto é necessário para que o PHPUnit seja capaz 
+        Por isso você não pode acessar quaisquer variáveis que criar
+        ali de dentro de um provedor de dados. Isto é necessário para que o PHPUnit seja capaz
         de calcular o número total de testes.
       </para>
     </note>
@@ -503,7 +503,7 @@ Tests: 4, Assertions: 4, Failures: 1.
       <indexterm><primary>@expectedException</primary></indexterm>
 
       <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest.php" />
-      mostra como usar a anotação <literal>@expectedException</literal> para 
+      mostra como usar a anotação <literal>@expectedException</literal> para
       testar se uma exceção é lançada dentro do código de teste.
     </para>
 
@@ -547,7 +547,7 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       Adicionalmente, você pode usar <literal>@expectedExceptionMessage</literal>,
       <literal>@expectedExceptionMessageRegExp</literal> e
       <literal>@expectedExceptionCode</literal> em combinação com
-      <literal>@expectedException</literal> para testar a mensagem de exceção e 
+      <literal>@expectedException</literal> para testar a mensagem de exceção e
       o código de exceção como mostrado em
       <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest2.php" />.
     </para>
@@ -615,16 +615,16 @@ Tests: 3, Assertions: 6, Failures: 3.]]></screen>
     <para>
       Mais exemplos de <literal>@expectedExceptionMessage</literal>,
       <literal>@expectedExceptionMessageRegExp</literal> e
-      <literal>@expectedExceptionCode</literal> são mostrados em 
+      <literal>@expectedExceptionCode</literal> são mostrados em
       <xref linkend="appendixes.annotations.expectedExceptionMessage"/>,
       <xref linkend="appendixes.annotations.expectedExceptionMessageRegExp"/> e
       <xref linkend="appendixes.annotations.expectedExceptionCode"/> respectivamente.
     </para>
-    
+
 
     <para>
       Alternativamente, você pode usar o método <literal>setExpectedException()</literal> ou
-      <literal>setExpectedExceptionRegExp()</literal> para definir a exceção esperada 
+      <literal>setExpectedExceptionRegExp()</literal> para definir a exceção esperada
       como mostrado em <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest3.php" />.
     </para>
 
@@ -750,8 +750,8 @@ class ExceptionTest extends PHPUnit_Framework_TestCase {
       Se o código que deve lançar uma exceção no <xref
       linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest4.php" />
       não lançá-la, a chamada subsequente ao
-      <literal>fail()</literal> vai parar o teste e sinalizar um problema com o 
-      teste. Se a exceção esperada é lançada, o bloco <literal>catch</literal> 
+      <literal>fail()</literal> vai parar o teste e sinalizar um problema com o
+      teste. Se a exceção esperada é lançada, o bloco <literal>catch</literal>
       será executado, e o teste terminará com sucesso.
     </para>
   </section>
@@ -765,21 +765,21 @@ class ExceptionTest extends PHPUnit_Framework_TestCase {
       <indexterm><primary>PHP Warning</primary></indexterm>
       <indexterm><primary>PHPUnit_Framework_Error</primary></indexterm>
 
-      Por padrão, o PHPUnit converte os erros, avisos e notificações do PHP que são 
-      disparados durante a execução de um teste para uma exceção. Usando essas 
-      exceções, você pode, por exemplo, esperar que um teste dispare um erro PHP como 
+      Por padrão, o PHPUnit converte os erros, avisos e notificações do PHP que são
+      disparados durante a execução de um teste para uma exceção. Usando essas
+      exceções, você pode, por exemplo, esperar que um teste dispare um erro PHP como
       mostrado no <xref linkend="writing-tests-for-phpunit.exceptions.examples.ErrorTest.php" />.
     </para>
 
     <note>
       <para>
         A configuração em tempo de execução <literal>error_reporting</literal> do PHP pode
-        limitar quais erros o PHPUnit irá converter para exceções. Se você 
+        limitar quais erros o PHPUnit irá converter para exceções. Se você
         está tendo problemas com essa funcionalidade, certifique-se que o PHP não está configurado para
         suprimir os tipos de erros que você esta testando.
       </para>
     </note>
-    
+
     <example id="writing-tests-for-phpunit.exceptions.examples.ErrorTest.php">
       <title>Esperando um erro PHP usando @expectedException</title>
       <programlisting><![CDATA[<?php
@@ -809,14 +809,14 @@ OK (1 test, 1 assertion)</screen>
       <indexterm><primary>PHPUnit_Framework_Error_Warning</primary></indexterm>
 
       <literal>PHPUnit_Framework_Error_Notice</literal> e
-      <literal>PHPUnit_Framework_Error_Warning</literal> representam notificações 
+      <literal>PHPUnit_Framework_Error_Warning</literal> representam notificações
       e avisos do PHP, respectivamente.
     </para>
 
     <note>
       <para>
-        Você deve ser o mais específico possível quando testar exceções. Testar 
-        por classes que são muito genéricas pode causar efeitos colaterais 
+        Você deve ser o mais específico possível quando testar exceções. Testar
+        por classes que são muito genéricas pode causar efeitos colaterais
         indesejáveis. Da mesma forma, testar para a classe <literal>Exception</literal>
         com <literal>@expectedException</literal> ou
         <literal>setExpectedException()</literal> não é mais permitido.
@@ -825,8 +825,8 @@ OK (1 test, 1 assertion)</screen>
 
     <para>
         Ao testar com funções que dependem de funções php que disparam erros como
-        <literal>fopen</literal> pode ser útil algumas vezes usar a supressão de 
-        erros enquanto testa. Isso permite a você verificar os valores retornados por 
+        <literal>fopen</literal> pode ser útil algumas vezes usar a supressão de
+        erros enquanto testa. Isso permite a você verificar os valores retornados por
         suprimir notificações que levariam a uma
         <literal>PHPUnit_Framework_Error_Notice</literal> phpunit.
         <example id="writing-tests-for-phpunit.exceptions.examples.TriggerErrorReturnValue.php">
@@ -837,7 +837,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -872,19 +872,19 @@ OK (1 test, 1 assertion)</screen>
     <title>Testando Saídas</title>
 
     <para>
-      Às vezes você quer assegurar que a execução de um método, por 
-      exemplo, gere uma saída esperada (via <literal>echo</literal> ou 
-      <literal>print</literal>, por exemplo). A 
+      Às vezes você quer assegurar que a execução de um método, por
+      exemplo, gere uma saída esperada (via <literal>echo</literal> ou
+      <literal>print</literal>, por exemplo). A
       classe <literal>PHPUnit_Framework_TestCase</literal> usa a funcionalidade
       <ulink url="http://www.php.net/manual/en/ref.outcontrol.php">Output
-      Buffering</ulink> do PHP para fornecer a funcionalidade que é 
+      Buffering</ulink> do PHP para fornecer a funcionalidade que é
       necessária para isso.
     </para>
 
     <para>
       <xref linkend="writing-tests-for-phpunit.output.examples.OutputTest.php" />
-      mostra como usar o método <literal>expectOutputString()</literal> para 
-      definir a saída esperada. Se essa saída esperada não for gerada, o 
+      mostra como usar o método <literal>expectOutputString()</literal> para
+      definir a saída esperada. Se essa saída esperada não for gerada, o
       teste será contado como uma falha.
     </para>
 
@@ -971,7 +971,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     <title>Saída de Erro</title>
 
     <para>
-      Sempre que um teste falha o PHPUnit faz o melhor para fornecer a você o 
+      Sempre que um teste falha o PHPUnit faz o melhor para fornecer a você o
       máximo possível de conteúdo que possa ajudar a identificar o problema.
     </para>
 
@@ -981,7 +981,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1018,12 +1018,12 @@ FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </example>
     <para>
-      Neste exemplo apenas um dos valores dos vetores diferem e os outros valores 
+      Neste exemplo apenas um dos valores dos vetores diferem e os outros valores
       são exibidos para fornecer o contexto onde o erro ocorreu.
     </para>
 
     <para>
-      Quando a saída gerada for longa demais para ler o PHPUnit vai quebrá-la 
+      Quando a saída gerada for longa demais para ler o PHPUnit vai quebrá-la
       e fornecer algumas linhas de contexto ao redor de cada diferença.
     </para>
     <example id="writing-tests-for-phpunit.error-output.examples.LongArrayDiffTest.php">
@@ -1032,7 +1032,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1071,8 +1071,8 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Casos Extremos</title>
 
       <para>
-        Quando uma comparação falha o PHPUnit cria uma representação textual da 
-        entrada de valores e as compara. Devido a essa implementação uma diferenciação 
+        Quando uma comparação falha o PHPUnit cria uma representação textual da
+        entrada de valores e as compara. Devido a essa implementação uma diferenciação
         pode mostrar mais problemas do que realmente existem.
       </para>
 
@@ -1087,7 +1087,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );
@@ -1128,7 +1128,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       </example>
       <para>
         Neste exemplo a diferença no primeiro índice entre
-        <literal>1</literal> e <literal>'1'</literal> é 
+        <literal>1</literal> e <literal>'1'</literal> é
         relatada ainda que o assertEquals considere os valores como uma combinação.
       </para>
 

--- a/src/4.6/zh_cn/assertions.xml
+++ b/src/4.6/zh_cn/assertions.xml
@@ -19,7 +19,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -56,7 +56,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -93,7 +93,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -133,7 +133,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -165,7 +165,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -194,12 +194,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -240,7 +240,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -278,7 +278,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -314,7 +314,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -354,7 +354,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -392,7 +392,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -403,7 +403,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -416,7 +416,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -429,7 +429,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -498,17 +498,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -565,12 +565,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -607,7 +607,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -656,7 +656,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -697,7 +697,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -743,7 +743,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -780,7 +780,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -860,7 +860,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -897,7 +897,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -937,7 +937,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -977,7 +977,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1013,7 +1013,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1050,7 +1050,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1088,7 +1088,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1134,7 +1134,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1171,7 +1171,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1208,7 +1208,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1245,7 +1245,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1282,7 +1282,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1319,7 +1319,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1370,7 +1370,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1411,7 +1411,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1443,7 +1443,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1480,7 +1480,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1517,7 +1517,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1560,7 +1560,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1601,7 +1601,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1794,7 +1794,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1831,7 +1831,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1877,7 +1877,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1923,7 +1923,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.6/zh_cn/code-coverage-analysis.xml
+++ b/src/4.6/zh_cn/code-coverage-analysis.xml
@@ -175,7 +175,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -188,7 +188,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -206,7 +206,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -221,11 +221,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -255,7 +255,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -286,6 +286,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.6/zh_cn/database.xml
+++ b/src/4.6/zh_cn/database.xml
@@ -98,7 +98,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -716,7 +716,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -734,12 +734,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -761,7 +761,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -804,7 +804,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -822,7 +822,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -838,7 +838,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/zh_cn/fixtures.xml
+++ b/src/4.6/zh_cn/fixtures.xml
@@ -29,21 +29,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -92,13 +92,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.6/zh_cn/incomplete-and-skipped-tests.xml
+++ b/src/4.6/zh_cn/incomplete-and-skipped-tests.xml
@@ -26,7 +26,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // 可选：如果愿意，在这里随便测试点什么。
-        $this->assertTrue(TRUE, '这应该已经是能正常工作的。');
+        self::assertTrue(TRUE, '这应该已经是能正常工作的。');
 
         // 在这里停止，并将此测试标记为未完成。
         $this->markTestIncomplete(

--- a/src/4.6/zh_cn/selenium.xml
+++ b/src/4.6/zh_cn/selenium.xml
@@ -10,12 +10,12 @@
       <indexterm><primary>Selenium Server</primary></indexterm>
 
       <ulink url="http://seleniumhq.org/">Selenium Server</ulink>是一个测试工具，它允许用任意主流浏览器为任意 HTTP 网站上的用任意编程语言开发的 web 应用程序编写自动用户界面测试。它通过操作系统来驱动浏览器进程来执行自动测试。Selenium 测试直接运行于某个浏览器中，就和真实用户一样。这些测试既可以用于 <emphasis>验收测试</emphasis>（通过在集成好的系统中执行较高层面的测试而非仅对系统的各个单元分别单独测试。）也可以用于<emphasis>浏览器兼容性测试</emphasis>（通过在不同的操作系统与浏览器上对 web 应用程序进行测试）。</para>
-    
+
     <para>PHPUnit_Selenium 只支持 Selenium 2.x 服务器的脚本。服务器可以通过从 1.x 就提供的传统 Selenium RC API 访问，也可以从 PHPUnit_Selenium 1.2 用 WebDriver API（部分实现）访问。</para>
     <para>这个决定的原因是 Selenium 2 是向后兼容的，而 Selenium RC 已经不再维护了。</para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>安装</title>
 
@@ -56,7 +56,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -111,7 +111,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -198,7 +198,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -270,7 +270,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/zh_cn/test-doubles.xml
+++ b/src/4.6/zh_cn/test-doubles.xml
@@ -76,7 +76,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->willReturn('foo');
 
         // 现在调用 $stub->doSomething() 将返回 'foo'。
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -109,7 +109,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->willReturn('foo');
 
         // 现在调用 $stub->doSomething() 将返回 'foo'。
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -152,10 +152,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // stub->doSomething('foo') 返回 'foo'
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') 返回 'bar'
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -185,7 +185,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() 返回 $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -221,8 +221,8 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnValueMap($map));
 
         // $stub->doSomething() 根据提供的参数返回不同的值。
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -252,7 +252,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) 返回 str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -282,9 +282,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() 每次返回值都不同
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -440,7 +440,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
         $subject->attach($observer);
 
         // 在 $subject 对象上调用 doSomething() 方法，
-        // 预期将以字符串 'something' 为参数调用 
+        // 预期将以字符串 'something' 为参数调用
         // Observer 仿件对象的 update() 方法。
         $subject->doSomething();
     }
@@ -659,7 +659,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
         $subject->attach($observer->reveal());
 
         // 在 $subject 对象上调用 doSomething() 方法，
-        // 预期将以字符串 'something' 为参数调用 
+        // 预期将以字符串 'something' 为参数调用
         // Observer 仿件对象的 update() 方法。
         $subject->doSomething();
     }
@@ -699,7 +699,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -731,7 +731,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -794,7 +794,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() 将会返回上桩的结果，
          * web 服务的 doGoogleSearch() 方法不会被调用。
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -876,10 +876,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -920,10 +920,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.6/zh_cn/textui.xml
+++ b/src/4.6/zh_cn/textui.xml
@@ -285,7 +285,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.6/zh_cn/writing-tests-for-phpunit.xml
+++ b/src/4.6/zh_cn/writing-tests-for-phpunit.xml
@@ -23,14 +23,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -71,7 +71,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -82,8 +82,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -93,8 +93,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -112,7 +112,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -160,13 +160,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -176,7 +176,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -214,7 +214,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -259,7 +259,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -347,13 +347,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -364,7 +364,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -691,7 +691,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -811,7 +811,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -856,7 +856,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -904,7 +904,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.7/en/annotations.xml
+++ b/src/4.7/en/annotations.xml
@@ -267,7 +267,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
@@ -797,7 +797,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.7/en/assertions.xml
+++ b/src/4.7/en/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -99,7 +99,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.7/en/code-coverage-analysis.xml
+++ b/src/4.7/en/code-coverage-analysis.xml
@@ -300,7 +300,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -313,7 +313,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -331,7 +331,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -346,11 +346,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -360,11 +360,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@coversNothing</primary></indexterm>
 
-      It is also possible to specify that a test should not cover 
-      <emphasis>any</emphasis> method by using the 
+      It is also possible to specify that a test should not cover
+      <emphasis>any</emphasis> method by using the
       <literal>@coversNothing</literal> annotation (see
       <xref linkend="appendixes.annotations.coversNothing"/>). This can be
-      helpful when writing integration tests to make sure you only 
+      helpful when writing integration tests to make sure you only
       generate code coverage with unit tests.
     </para>
 
@@ -388,7 +388,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -413,7 +413,7 @@ if (false) this_function_call_shows_up_as_covered();
 // Due to how code coverage works internally these two lines are special.
 // This line will show up as non executable
 if (false)
-    // This line will show up as covered because it is actually the 
+    // This line will show up as covered because it is actually the
     // coverage of the if statement in the line above that gets shown here!
     will_also_show_up_as_coveraged();
 
@@ -422,6 +422,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.7/en/database.xml
+++ b/src/4.7/en/database.xml
@@ -220,7 +220,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -1064,8 +1064,8 @@ interface PHPUnit_Extensions_Database_DataSet_IDataSet extends IteratorAggregate
         TestCase to check for dataset quality. From the
         <literal>IteratorAggregate</literal> interface the IDataSet
         inherits the <literal>getIterator()</literal> method to iterate
-        over all tables of the dataset. The reverse iterator allows PHPUnit to 
-        truncate tables opposite the order they were created to satisfy foreign 
+        over all tables of the dataset. The reverse iterator allows PHPUnit to
+        truncate tables opposite the order they were created to satisfy foreign
         key constraints.
       </para>
       <para>
@@ -1189,7 +1189,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1219,12 +1219,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1255,7 +1255,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1317,7 +1317,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1342,7 +1342,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1360,7 +1360,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/en/fixtures.xml
+++ b/src/4.7/en/fixtures.xml
@@ -68,21 +68,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -146,13 +146,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.7/en/incomplete-and-skipped-tests.xml
+++ b/src/4.7/en/incomplete-and-skipped-tests.xml
@@ -53,7 +53,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // Optional: Test anything here, if you want.
-        $this->assertTrue(TRUE, 'This should already work.');
+        self::assertTrue(TRUE, 'This should already work.');
 
         // Stop here and mark this test as incomplete.
         $this->markTestIncomplete(

--- a/src/4.7/en/selenium.xml
+++ b/src/4.7/en/selenium.xml
@@ -12,16 +12,16 @@
       <ulink url="http://seleniumhq.org/">Selenium Server</ulink> is a
       test tool that allows you to write automated user-interface tests for
       web applications in any programming language against any HTTP website
-      using any mainstream browser. It performs automated browser tasks 
+      using any mainstream browser. It performs automated browser tasks
       by driving the browser's process through the operating system.
-      Selenium tests run directly in a browser, just as real users do. These 
-      tests can be used for both <emphasis>acceptance testing</emphasis> 
+      Selenium tests run directly in a browser, just as real users do. These
+      tests can be used for both <emphasis>acceptance testing</emphasis>
       (by performing higher-level tests on the integrated system instead of
-      just testing each unit of the system independently) and <emphasis>browser 
+      just testing each unit of the system independently) and <emphasis>browser
       compatibility testing</emphasis> (by testing the web application on
       different operating systems and browsers).
     </para>
-    
+
     <para>
       The only supported scenario of PHPUnit_Selenium is that of a Selenium 2.x
       server. The server can be accessed through the classic Selenium RC Api, already present in 1.x, or with the WebDriver API (partially implemented) from PHPUnit_Selenium 1.2.
@@ -31,7 +31,7 @@
     </para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>Installation</title>
 
@@ -88,7 +88,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -115,7 +115,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     The commands of Selenium2TestCase are implemented via __call(). Please refer to <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">the end-to-end test for PHPUnit_Extensions_Selenium2TestCase</ulink> for a list of every supported feature.
   </para>
   </section>
@@ -154,7 +154,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -254,7 +254,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -335,7 +335,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/en/test-doubles.xml
+++ b/src/4.7/en/test-doubles.xml
@@ -136,7 +136,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Calling $stub->doSomething() will now return
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -177,7 +177,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Calling $stub->doSomething() will now return
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -233,10 +233,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') returns 'foo'
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') returns 'bar'
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -271,7 +271,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() returns $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -315,8 +315,8 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() returns different values depending on
         // the provided arguments.
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -353,7 +353,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) returns str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -390,9 +390,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() returns a different value each time
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -921,7 +921,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -959,7 +959,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -1034,7 +1034,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() will now return a stubbed result and
          * the web service's doGoogleSearch() method will not be invoked.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1135,10 +1135,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1184,10 +1184,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/en/textui.xml
+++ b/src/4.7/en/textui.xml
@@ -273,7 +273,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -405,7 +405,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.7/en/writing-tests-for-phpunit.xml
+++ b/src/4.7/en/writing-tests-for-phpunit.xml
@@ -27,14 +27,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -97,7 +97,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -108,8 +108,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -119,8 +119,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -152,7 +152,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -209,13 +209,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -225,7 +225,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -275,7 +275,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -320,7 +320,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -415,13 +415,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -432,7 +432,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -837,7 +837,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -981,7 +981,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1032,7 +1032,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1087,7 +1087,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.7/fr/annotations.xml
+++ b/src/4.7/fr/annotations.xml
@@ -9,7 +9,7 @@
     Une annotation est une forme spéciale de méta donnée syntaxique qui peut
     être ajoutée au code source de certains langages de programmation. Bien que
     PHP n'ait pas de fonctionnalité dédiée à l'annotation du code source, l'utilisation
-    d'étiquettes telles que <literal>@annotation paramètres</literal> dans les blocs de documentation 
+    d'étiquettes telles que <literal>@annotation paramètres</literal> dans les blocs de documentation
     s'est établi dans la communauté PHP pour annoter le code source. En PHP, les blocs de
     documentation sont réflexifs: ils peuvent être accédés via la méthode de l'API de réflexivité
     <literal>getDocComment()</literal> au niveau des fonctions, classes, méthodes et attributs.
@@ -92,7 +92,7 @@ class MonTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
 
-      L'annotation <literal>@backupStaticAttributes</literal> peut également être utilisée au 
+      L'annotation <literal>@backupStaticAttributes</literal> peut également être utilisée au
       niveau d'une méthode de test. Ceci permet une configuration plus fine des opérations
       de sauvegarde et de restauration: <programlisting>/**
  * @backupStaticAttributes disabled
@@ -118,8 +118,8 @@ class MonTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>@codeCoverageIgnoreStart</primary></indexterm>
       <indexterm><primary>@codeCoverageIgnoreEnd</primary></indexterm>
 
-      Les annotations <literal>@codeCoverageIgnore</literal>, 
-      <literal>@codeCoverageIgnoreStart</literal> et 
+      Les annotations <literal>@codeCoverageIgnore</literal>,
+      <literal>@codeCoverageIgnoreStart</literal> et
       <literal>@codeCoverageIgnoreEnd</literal> peuvent être utilisées pour
       exclure des lignes de code de l'analyse de couverture.
     </para>
@@ -137,18 +137,18 @@ class MonTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Code Coverage</primary></indexterm>
       <indexterm><primary>@covers</primary></indexterm>
 
-      L'annotation <literal>@covers</literal> peut être utilisée dans le code de test pour 
+      L'annotation <literal>@covers</literal> peut être utilisée dans le code de test pour
       indique quelle(s) méthode(s) un test veut tester:<programlisting>/**
  * @covers CompteBancaire::getBalance
  */
 public function testBalanceEstInitiallementAZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
     <para>
-      Si elle est fournie, seule l'information de couverture de code pour 
+      Si elle est fournie, seule l'information de couverture de code pour
       la(les) méthode(s) sera prise en considération.
     </para>
 
@@ -216,7 +216,7 @@ public function testBalanceEstInitiallementAZero()
       <indexterm><primary>@coversNothing</primary></indexterm>
 
       L'annotation <literal>@coversNothing</literal> peut être utilisée dans le code de test
-      pour indiquer qu'aucune information de couverture de code ne sera enregistrée pour le 
+      pour indiquer qu'aucune information de couverture de code ne sera enregistrée pour le
       cas de test annoté.
     </para>
 
@@ -226,7 +226,7 @@ public function testBalanceEstInitiallementAZero()
         pour un exemple.
     </para>
 
-    <para>    
+    <para>
         L'annotation peut être utilisée au niveau de la classe et de la méthode
         et sera surchargée par toute étiquette <literal>@covers</literal>.
     </para>
@@ -247,7 +247,7 @@ public function testBalanceEstInitiallementAZero()
     </para>
 
     <para>
-      Voir <xref linkend="writing-tests-for-phpunit.data-providers"/> pour plus de 
+      Voir <xref linkend="writing-tests-for-phpunit.data-providers"/> pour plus de
       détails.
     </para>
   </section>
@@ -297,7 +297,7 @@ public function testBalanceEstInitiallementAZero()
     <para>
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
-      L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec 
+      L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
       <literal>@expectedException</literal> permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
@@ -315,25 +315,25 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
 	Pour faciliter les tests et réduire la duplication, un raccourci peut être utilisé pour
-    indiquer une constante de classe comme un 
+    indiquer une constante de classe comme un
     <literal>@expectedExceptionCode</literal> en utilisant la syntaxe
     "<literal>@expectedExceptionCode ClassName::CONST</literal>".
-                                                                        
-    <programlisting>class MonTest extends PHPUnit_Framework_TestCase 
-  {                                                                      
-      /**                                                                
-        * @expectedException     MonException                             
-        * @expectedExceptionCode MaClasse::CODE_ERREUR                      
-        */                                                               
-      public function testExceptionAUnCodeErreur20()                      
-      {                                                                  
+
+    <programlisting>class MonTest extends PHPUnit_Framework_TestCase
+  {
+      /**
+        * @expectedException     MonException
+        * @expectedExceptionCode MaClasse::CODE_ERREUR
+        */
+      public function testExceptionAUnCodeErreur20()
+      {
         throw new MonException('Un message', 20);
-      }                                                                  
-  }                                                                      
-  class MaClasse                                                          
-  {                                                                      
-      const CODE_ERREUR = 20;                                              
-  }</programlisting>     
+      }
+  }
+  class MaClasse
+  {
+      const CODE_ERREUR = 20;
+  }</programlisting>
     </para>
 
   </section>
@@ -345,7 +345,7 @@ public function testBalanceEstInitiallementAZero()
       <indexterm><primary>@expectedExceptionMessage</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionMessage</literal> fonctionne de manière
-      similaire à <literal>@expectedExceptionCode</literal> en ce qu'il vous permet de 
+      similaire à <literal>@expectedExceptionCode</literal> en ce qu'il vous permet de
       faire une assertion sur le message d'erreur d'une exception.
 
       <programlisting>class MonTest extends PHPUnit_Framework_TestCase
@@ -361,7 +361,7 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
       Le message attendu peut être une partie d'une chaîne d'un message d'exception.
-      Ceci peut être utile pour faire une assertion sur le fait qu'un nom ou un 
+      Ceci peut être utile pour faire une assertion sur le fait qu'un nom ou un
       paramètre qui est passé s'affiche dans une exception sans fixer la totalité
       du message d'exception dans le test.
 
@@ -379,7 +379,7 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
 	Pour faciliter les tests et réduire la duplication, un raccourci peut être utilisé pour
-    indiquer une constante de classe comme un 
+    indiquer une constante de classe comme un
     <literal>@expectedExceptionCode</literal> en utilisant la syntaxe
     "<literal>@expectedExceptionCode ClassName::CONST</literal>".
 
@@ -414,10 +414,10 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
     </para>
 
-    <para> 
+    <para>
       Des tests peuvent être sélectionnés pour l'exécution en se basant sur les groupes
       en utilisant les options <literal>--group</literal> et <literal>--exclude-group</literal>
-      du lanceur de test en ligne de commandes ou en utilisant les directives respectives du 
+      du lanceur de test en ligne de commandes ou en utilisant les directives respectives du
       fichier de configuration XML.
     </para>
   </section>
@@ -474,7 +474,7 @@ public function testBalanceEstInitiallementAZero()
  */
 public function balanceInitialeDoitEtre0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.7/fr/code-coverage-analysis.xml
+++ b/src/4.7/fr/code-coverage-analysis.xml
@@ -18,7 +18,7 @@
     <indexterm><primary>Couverture de code</primary></indexterm>
 
     Dans ce chapitre, vous apprendrez tout sur la fonctionnalité de couverture
-    de code de PHPUnit qui fournit une vision interne des parties du code de 
+    de code de PHPUnit qui fournit une vision interne des parties du code de
     production qui sont exécutées quand les tests sont exécutés. Cela aide à
     répondre à des questions comme :
   </para>
@@ -36,7 +36,7 @@
   </itemizedlist>
 
   <para>
-    Un exemple de ce que peuvent signifier des statistiques de couverture de code est, 
+    Un exemple de ce que peuvent signifier des statistiques de couverture de code est,
     s'il y a une méthode avec 100 lignes de code, et seulement 75 de ces lignes sont réellement
     exécutées quand les tests sont lancés, alors la méthode est considérée comme ayant une couverture
     de code de 75 pour cent.
@@ -45,7 +45,7 @@
   <para>
     <indexterm><primary>Xdebug</primary></indexterm>
 
-    La fonctionnalité de couverture de code de PHPUnit fait usage du composant 
+    La fonctionnalité de couverture de code de PHPUnit fait usage du composant
     <ulink url="http://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
     qui, à son tour, tire partie de la fonctionnalité de couverture d'instructions
     fournie par l'extension <ulink url="http://www.xdebug.org/">Xdebug</ulink>
@@ -96,9 +96,9 @@ Generating report, this may take a moment.</screen>
   </figure>
 
   <para>
-    Le rapport de couverture de code de notre exemple <literal>CompteBancaire</literal> 
+    Le rapport de couverture de code de notre exemple <literal>CompteBancaire</literal>
     montre que nous n'avons actuellement aucun test qui appellent les méthodes
-    <literal>setBalance()</literal>, <literal>deposerArgent()</literal> et 
+    <literal>setBalance()</literal>, <literal>deposerArgent()</literal> et
     <literal>retirerArgent()</literal> avec des valeurs acceptables.
     <xref linkend="code-coverage-analysis.examples.BankAccountTest.php" />
     montre un test qui peut être ajouté à la classe de cas de test
@@ -117,11 +117,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
 
     public function testDeposerRetirerArgent()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->deposerArgent(1);
-        $this->assertEquals(1, $this->compte_bancaire->getBalance());
+        self::assertEquals(1, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->retirerArgent(1);
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -149,7 +149,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       L'annotation <literal>@covers</literal> (voir
       <xref linkend="appendixes.annotations.covers.tables.annotations"/>) peut être
       utilisée dans le code de test pour indiquer quelle(s) méthode(s) une méthode de test
-      veut test. Si elle est fournie, seules les informations de couverture de code pour 
+      veut test. Si elle est fournie, seules les informations de couverture de code pour
       la(les) méthode(s) indiquées seront prises en considération.
       <xref linkend="code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php"/>
       montre un exemple.
@@ -174,7 +174,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceEstInitialementZero()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 
     /**
@@ -187,7 +187,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
         }
 
         catch (CompteBancaireException $e) {
-            $this->assertEquals(0, $this->compte_bancaire->getBalance());
+            self::assertEquals(0, $this->compte_bancaire->getBalance());
 
             return;
         }
@@ -205,7 +205,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
         }
 
         catch (CompteBancaireException $e) {
-            $this->assertEquals(0, $this->compte_bancaire->getBalance());
+            self::assertEquals(0, $this->compte_bancaire->getBalance());
 
             return;
         }
@@ -221,11 +221,11 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
 
     public function testDeposerArgent()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->deposerArgent(1);
-        $this->assertEquals(1, $this->compte_bancaire->getBalance());
+        self::assertEquals(1, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->retirerArgent(1);
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -261,7 +261,7 @@ class IntegrationLivreDOrTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("livre_d_or");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -282,8 +282,8 @@ class IntegrationLivreDOrTest extends PHPUnit_Extensions_Database_TestCase
       voulez ignorer lors de l'analyse de couverture de code. PHPUnit vous permet
       de faire cela en utilisant les annotations
       <literal>@codeCoverageIgnore</literal>,
-      <literal>@codeCoverageIgnoreStart</literal> et 
-      <literal>@codeCoverageIgnoreEnd</literal> comme montré dans 
+      <literal>@codeCoverageIgnoreStart</literal> et
+      <literal>@codeCoverageIgnoreEnd</literal> comme montré dans
       <xref linkend="code-coverage-analysis.ignoring-code-blocks.examples.Sample.php"/>.
     </para>
 
@@ -342,7 +342,7 @@ if (FALSE) {
     <para>
       La liste noire est pré-remplie avec tous les fichiers de code source de
       PHPUnit lui-même ainsi que les tests. Quand la liste blanche est vide (par
-      défaut), le filtrage par liste noire est utilisé. Quand la liste blanche 
+      défaut), le filtrage par liste noire est utilisé. Quand la liste blanche
       n'est pas vide, le filtrage par liste blanche est utilisé. Chaque fichier
       de la liste blanche est ajouté au rapport de couverture de code, qu'il ait
       été exécuté ou pas. Toutes les lignes d'un tel fichier, incluant celles qui
@@ -350,7 +350,7 @@ if (FALSE) {
     </para>
 
     <para>
-      Quand vous configurez 
+      Quand vous configurez
       <literal>processUncoveredFilesFromWhitelist="true"</literal>
       dans votre configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.blacklist-whitelist"/>) alors ces fichiers
@@ -369,8 +369,8 @@ if (FALSE) {
 
     <para>
       Le fichier de configuration XML de PHPUnit (voir <xref linkend="appendixes.configuration.blacklist-whitelist"/>)
-      peut être utilisé pour contrôler les listes noires et blanches. Utiliser une liste 
-      blanche est recommandé comme meilleure pratique pour contrôler la liste des fichiers inclus dans 
+      peut être utilisé pour contrôler les listes noires et blanches. Utiliser une liste
+      blanche est recommandé comme meilleure pratique pour contrôler la liste des fichiers inclus dans
       le rapport de couverture de code.
     </para>
   </section>
@@ -394,8 +394,8 @@ if(false) cet_appel_de_fonction_sera_compte_comme_couvert();
 // Du fait de la façon dont la couverture de code fonctionne en interne, ces deux lignes sont spéciales.
 / Cette ligne sera comptée comme non exécutable
 if(false)
-    // Cette ligne sera comptée comme couverte car c'est en fait la 
-    // couverture de l'instruction if dans la ligne au-dessus qui 
+    // Cette ligne sera comptée comme couverte car c'est en fait la
+    // couverture de l'instruction if dans la ligne au-dessus qui
     // sera montrée ici !
     sera_egalement_comptee_comme_couverte();
 
@@ -404,8 +404,8 @@ if(false) {
     cet_appel_ne_sera_jamais_compte_comme_couvert();
 }
 ?>]]></programlisting>
-    </example>      
-        
+    </example>
+
   </section>
 
 </chapter>

--- a/src/4.7/fr/fixtures.xml
+++ b/src/4.7/fr/fixtures.xml
@@ -18,7 +18,7 @@
     La plupart du temps, cependant, la fixture sera beaucoup plus complexe
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
-    dans le bruit de configuration de la fixture. Ce problème s'aggrave quand 
+    dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
     vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
@@ -46,7 +46,7 @@
     que ce n'est pas la fixture elle-même qui est réutilisée mais le code qui l'a créée.
     D'abord nous déclarons la variable d'instance, <literal>$pile</literal>, que nous
     allons utiliser à la place d'une variable locale à la méthode. Puis nous plaçons
-    la création de la fixture <literal>tableau</literal> dans la méthode 
+    la création de la fixture <literal>tableau</literal> dans la méthode
     <literal>setUp()</literal>. Enfin, nous supprimons le code redondant des méthodes
     de test et nous utilisons la variable d'instance nouvellement introduite.
     <literal>$this->pile</literal>, à la place de la variable locale à la méthode
@@ -67,21 +67,21 @@ class PileTest extends PHPUnit_Framework_TestCase
 
     public function testVide()
     {
-        $this->assertTrue(empty($this->pile));
+        self::assertTrue(empty($this->pile));
     }
 
     public function testPush()
     {
         array_push($this->pile, 'foo');
-        $this->assertEquals('foo', $this->pile[count($this->pile)-1]);
-        $this->assertFalse(empty($this->pile));
+        self::assertEquals('foo', $this->pile[count($this->pile)-1]);
+        self::assertFalse(empty($this->pile));
     }
 
     public function testPop()
     {
         array_push($this->pile, 'foo');
-        $this->assertEquals('foo', array_pop($this->pile));
-        $this->assertTrue(empty($this->pile));
+        self::assertEquals('foo', array_pop($this->pile));
+        self::assertTrue(empty($this->pile));
     }
 }
 ?>]]></programlisting>
@@ -110,7 +110,7 @@ class PileTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>onNotSuccessfulTest()</primary></indexterm>
 
     De plus, les méthodes canevas <literal>setUpBeforeClass()</literal> et
-    <literal>tearDownAfterClass()</literal> sont appelées respectivement avant 
+    <literal>tearDownAfterClass()</literal> sont appelées respectivement avant
     que le premier test de la classe de cas de test ne soit exécuté et après
     que le dernier test de la classe de test a été exécuté.
   </para>
@@ -145,13 +145,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()
@@ -210,15 +210,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
     <para>
       <literal>setUp()</literal> et <literal>tearDown()</literal> sont sympathiquement
-      symétriques en théorie mais pas en pratique. En pratique, vous n'avez besoin 
+      symétriques en théorie mais pas en pratique. En pratique, vous n'avez besoin
       d'implémenter <literal>tearDown()</literal> que si vous avez alloué
       des ressources externes telles que des fichiers ou des sockets dans
       <literal>setUp()</literal>. Si votre <literal>setUp()</literal> ne crée simplement
-      que de purs objets PHP, vous pouvez généralement ignorer <literal>tearDown()</literal>. 
+      que de purs objets PHP, vous pouvez généralement ignorer <literal>tearDown()</literal>.
       Cependant, si vous créez de nombreux objets dans votre <literal>setUp()</literal>, vous
       pourriez vouloir libérer (<literal>unset()</literal>) les variables pointant vers
       ces objets dans votre <literal>tearDown()</literal> de façon à ce qu'ils puissent être
-      récupérés par le ramasse-miettes. Le nettoyage des objets de cas de test n'est pas 
+      récupérés par le ramasse-miettes. Le nettoyage des objets de cas de test n'est pas
       prévisible.
     </para>
   </section>
@@ -262,7 +262,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <para>
       Un bon exemple de fixture qu'il est raisonnable de partager entre plusieurs
       tests est une connexion à une base de données : vous vous connectez une fois
-      à la base de données et vous réutilisez cette connexion au lieu d'en créer 
+      à la base de données et vous réutilisez cette connexion au lieu d'en créer
       une nouvelle pour chaque test. Ceci rend vos tests plus rapides.
     </para>
 
@@ -272,7 +272,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
       <xref linkend="fixtures.sharing-fixture.examples.DatabaseTest.php" />
       utilise les méthodes canevas <literal>setUpBeforeClass()</literal> et
-      <literal>tearDownAfterClass()</literal> pour respectivement établir la connexion à la 
+      <literal>tearDownAfterClass()</literal> pour respectivement établir la connexion à la
       base de données avant le premier test de la classe de cas de test et pour
       de déconnecter de la base de données après le dernier test du cas de test.
     </para>
@@ -302,7 +302,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       entre les tests réduit la valeur de ces tests. Le problème de conception
       sous-jacent est que les objets ne sont pas faiblement couplés. Vous pourrez
       obtenir de meilleurs résultats en résolvant le problème de conception
-      sous-jacent puis en écrivant des tests utilisant des bouchons 
+      sous-jacent puis en écrivant des tests utilisant des bouchons
       (voir <xref linkend="test-doubles" />), plutôt qu'en créant
       des dépendances entre les tests à l'exécution et en ignorant l'opportunité
       d'améliorer votre conception.
@@ -315,7 +315,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     <para>
       <ulink url="http://googletesting.blogspot.com/2008/05/tott-using-dependancy-injection-to.html">Il est difficile de tester du code qui utilise des singletons.</ulink>
       La même chose est vraie pour le code qui utilise des variables globales. Typiquement,
-      le code que vous voulez tester est fortement couplé avec une variable globale et 
+      le code que vous voulez tester est fortement couplé avec une variable globale et
       vous ne pouvez pas contrôler sa création. Un problème additionnel réside dans le fait
       qu'un test qui modifie une variable globale peut faire échouer un autre test.
     </para>
@@ -357,7 +357,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       </para>
       <para>
         L'implémentation des opérations de sauvegarde et de restauration des variables
-        globales et des attributs statiques des classes utilise 
+        globales et des attributs statiques des classes utilise
         <literal>serialize()</literal> et <literal>unserialize()</literal>.
       </para>
       <para>
@@ -372,8 +372,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
       <indexterm><primary><literal>$backupGlobalsBlacklist</literal></primary></indexterm>
 
-      L'annotation <literal>@backupGlobals</literal> qui est discutée dans 
-      <xref linkend="appendixes.annotations.backupGlobals"/> peut être utilisée pour 
+      L'annotation <literal>@backupGlobals</literal> qui est discutée dans
+      <xref linkend="appendixes.annotations.backupGlobals"/> peut être utilisée pour
       contrôler les opérations de sauvegarde et de restauration des variables globales.
       Alternativement, vous pouvez fournir une liste noire des variables globales qui doivent
       être exclues des opérations de sauvegarde et de restauration comme ceci :
@@ -396,8 +396,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
       <indexterm><primary><literal>$backupStaticAttributesBlacklist</literal></primary></indexterm>
 
-      L'annotation <literal>@backupStaticAttributes</literal> qui est discutée dans 
-      <xref linkend="appendixes.annotations.backupStaticAttributes"/> peut être utilisée pour 
+      L'annotation <literal>@backupStaticAttributes</literal> qui est discutée dans
+      <xref linkend="appendixes.annotations.backupStaticAttributes"/> peut être utilisée pour
       contrôler les opérations de sauvegarde et de restauration des attributs statiques.
       Alternativement, vous pouvez fournir une liste noire des attributs statiques qui doivent
       être exclus des opérations de sauvegarde et de restauration comme ceci :

--- a/src/4.7/fr/incomplete-and-skipped-tests.xml
+++ b/src/4.7/fr/incomplete-and-skipped-tests.xml
@@ -8,14 +8,14 @@
 
     <para>
       Quand vous travaillez sur une nouvelle classe de cas de test, vous pourriez vouloir
-      commencer en écrivant des méthodes de test vides comme 
+      commencer en écrivant des méthodes de test vides comme
       <programlisting>public function testQuelquechose()
 {
-}</programlisting> pour garder la trace des tests que vous avez à écrire. Le problème avec 
+}</programlisting> pour garder la trace des tests que vous avez à écrire. Le problème avec
       les méthodes de test vides est qu'elles sont interprétées comme étant réussies par le
       framework PHPUnit. Cette mauvaise interprétation fait que le rapport de tests devient
       inutile -- vous ne pouvez pas voir si un test est effectivement réussi ou s'il n'a tout
-      simplement pas été implémenté. Appeler 
+      simplement pas été implémenté. Appeler
       <literal>$this->fail()</literal> dans une méthode de test non implémentée
       n'aide pas davantage, puisqu'alors le test sera interprété comme étant un échec.
       Ce serait tout aussi faux que d'interpréter un test non implémenté comme étant réussi.
@@ -30,16 +30,16 @@
       comme à un feu rouge, nous avons besoin d'un feu orange additionnel pour signaler
       un test comme étant incomplet ou pas encore implémenté.
       <literal>PHPUnit_Framework_IncompleteTest</literal> est une interface de marquage
-      pour signaler une exception qui est levée par une méthode de test comme résultat 
+      pour signaler une exception qui est levée par une méthode de test comme résultat
       d'un test incomplet ou actuellement pas implémenté.
-      <literal>PHPUnit_Framework_IncompleteTestError</literal> est l'implémentation 
+      <literal>PHPUnit_Framework_IncompleteTestError</literal> est l'implémentation
       standard de cette interface.
     </para>
 
     <para>
       <xref linkend="incomplete-and-skipped-tests.incomplete-tests.examples.SampleTest.php" />
       montre une classe de cas de tests, <literal>ExempleDeTest</literal>, qui contient une unique méthode de test,
-      method, <literal>testSomething()</literal>. En appelant la méthode pratique 
+      method, <literal>testSomething()</literal>. En appelant la méthode pratique
       <literal>markTestIncomplete()</literal> (qui lève automatiquement
       une exception <literal>PHPUnit_Framework_IncompleteTestError</literal>)
       dans la méthode de test, nous marquons le test comme étant incomplet.
@@ -53,7 +53,7 @@ class ExempleDeTest extends PHPUnit_Framework_TestCase
     public function testeQuelquechose()
     {
         // Facultatif: testez tout ce que vous voulez ici.
-        $this->assertTrue(TRUE, 'Ceci devrait toujours fonctionner.');
+        self::assertTrue(TRUE, 'Ceci devrait toujours fonctionner.');
 
         // Cesser ici et marquer ce test comme incomplet.
         $this->markTestIncomplete(
@@ -128,7 +128,7 @@ Tests: 1, Assertions: 1, Incomplete: 1.</screen>
     <para>
       <xref linkend="incomplete-and-skipped-tests.skipping-tests.examples.DatabaseTest.php" />
       montre une classe de cas de tests, <literal>DatabaseTest</literal>, qui contient une méthode de tests
-      <literal>testConnection()</literal>. Dans la méthode canevas <literal>setUp()</literal> 
+      <literal>testConnection()</literal>. Dans la méthode canevas <literal>setUp()</literal>
       de la classe du cas de test, nous pouvons contrôler si l'extension
       MySQLi est disponible et utiliser la méthode <literal>markTestSkipped()</literal>
       pour sauter le test si ce n'est pas le cas.
@@ -277,7 +277,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
  	<para>
 		Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
-        dans la configuration xml pour les inclusions dépendant de la version dans 
+        dans la configuration xml pour les inclusions dépendant de la version dans
         <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/4.7/fr/selenium.xml
+++ b/src/4.7/fr/selenium.xml
@@ -9,28 +9,28 @@
     <para>
       <indexterm><primary>Selenium Server</primary></indexterm>
 
-      <ulink url="http://seleniumhq.org/">Selenium Server</ulink> est un 
-      outil de test qui vous permet d'écrire des tests automatisés de 
+      <ulink url="http://seleniumhq.org/">Selenium Server</ulink> est un
+      outil de test qui vous permet d'écrire des tests automatisés de
       l'interface utilisateur d'applications web dans n'importe quel langage
       et menés sur n'importe quel site web HTTP en utilisant n'importe quel
       navigateur courant. Il réalise des tâches automatisée dans le navigateur
       en pilotant le processus du navigateur via le système d'exploitation.
       Les tests Selenium s'exécutent directement dans un navigateur, exactement
       comme des utilisateurs réels le feraient. Ces tests peuvent être utilisés
-      à la fois comme <emphasis>tests de validation</emphasis> 
+      à la fois comme <emphasis>tests de validation</emphasis>
       (en exécutant des tests au plus haut niveau sur le système intégré au lieu
       de simplement tester chaque unité du système indépendamment) et des
       <emphasis>tests de compatibilité pour les navigateurs</emphasis> (en testant l'application
       web sur différents systèmes d'exploitation et différents navigateurs).
     </para>
-    
+
     <para>
       Le seul scénario géré par PHPUnit_Selenium est celui du serveur Selenium 2.x.
       Le serveur peut être accédé via l'API classique Selenium RC déjà présente dans la version 1.x ou avec l'API serveur
       WebDriver (partiellement implémentée) à partir de PHPUnit_Selenium 1.2.
     </para>
     <para>
-      La raison derrière cette décision est que Selenium 2 est rétro compatible et que Selenium RC n'est désormais plus 
+      La raison derrière cette décision est que Selenium 2 est rétro compatible et que Selenium RC n'est désormais plus
       maintenu.
     </para>
 
@@ -87,7 +87,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -114,7 +114,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     Les commandes de Selenium2TestCase sont implémentées via __call(). Merci de vous référer à <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">the end-to-end test for PHPUnit_Extensions_Selenium2TestCase</ulink> pour la liste de toutes les fonctionnalités prises en charge.
   </para>
   </section>
@@ -152,7 +152,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -252,7 +252,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -333,7 +333,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/fr/skeleton-generator.xml
+++ b/src/4.7/fr/skeleton-generator.xml
@@ -62,7 +62,7 @@ Wrote skeleton for "CalculateurTest" to "/home/sb/CalculateurTest.php".</screen>
     <title>Classes sous espace de nom et le générateur de squelette</title>
 
     <para>
-      Lorsque vous utilisez le générateur de squelette pour générer du code basé sur 
+      Lorsque vous utilisez le générateur de squelette pour générer du code basé sur
       une classe qui est déclarée dans un <ulink url="http://php.net/namespace">espace de nommage (namespace)</ulink>
       vous devez fournir le nom qualifié de la classe ainsi que le chemin d'accès
       au fichier source dans lequel elle est déclarée.
@@ -104,7 +104,7 @@ Tests: 1, Assertions: 0, Incomplete: 1.</screen>
       <indexterm><primary>@assert</primary></indexterm>
 
       Vous pouvez utiliser l'annotation <literal>@assert</literal> dans le bloc
-      de documentation d'une méthode pour générer automatiquement des tests 
+      de documentation d'une méthode pour générer automatiquement des tests
       simples mais significatifs au lieu de cas de tests incomplets.
       <xref linkend="skeleton-generator.test.examples.Calculator.php" />
       montre un exemple.
@@ -131,13 +131,13 @@ class Calculateur
 
     <para>
       Chaque méthode de la classe originelle est contrôlée à la recherche d'annotations
-      <literal>@assert</literal>. Celles-ci sont transformées en code de test comme 
+      <literal>@assert</literal>. Celles-ci sont transformées en code de test comme
       <programlisting>    /**
      * Generated from @assert (0, 0) == 0.
      */
     public function testAdditionner() {
         $o = new Calculateur;
-        $this->assertEquals(0, $o->additionner(0, 0));
+        self::assertEquals(0, $o->additionner(0, 0));
     }</programlisting>
     </para>
 
@@ -254,7 +254,7 @@ class JeuDeBowlingTest extends PHPUnit_Framework_TestCase
     public function testScorePourJeuDansLaRigoleEst0()
     {
         $this->lancePlusieursEtRenverse(20, 0);
-        $this->assertEquals(0, $this->jeu->score());
+        self::assertEquals(0, $this->jeu->score());
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/fr/test-doubles.xml
+++ b/src/4.7/fr/test-doubles.xml
@@ -130,7 +130,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
 
         // Appeler $bouchon->faireQuelquechose() va maintenant retourner
         // 'foo'.
-        $this->assertEquals('foo', $bouchon->faireQuelquechose());
+        self::assertEquals('foo', $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -196,7 +196,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
 
         // Appeler $bouchon->faireQuelquechose() retournera maintenant
         // 'foo'.
-        $this->assertEquals('foo', $bouchon->faireQuelquechose());
+        self::assertEquals('foo', $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -233,10 +233,10 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $bouchon->faireQuelquechose('foo') retourne 'foo'
-        $this->assertEquals('foo', $bouchon->faireQuelquechose('foo'));
+        self::assertEquals('foo', $bouchon->faireQuelquechose('foo'));
 
         // $bouchon->faireQuelquechose('bar') retourne 'bar'
-        $this->assertEquals('bar', $bouchon->faireQuelquechose('bar'));
+        self::assertEquals('bar', $bouchon->faireQuelquechose('bar'));
     }
 }
 ?>]]></programlisting>
@@ -273,7 +273,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $bouchon->faireQuelquechose() retourne $bouchon
-        $this->assertSame($bouchon, $bouchon->faireQuelquechose());
+        self::assertSame($bouchon, $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -320,8 +320,8 @@ class BouchonTest extends PHPUnit_Framework_TestCase
         // $bouchon->faireQuelquechose() retourne
         // différentes valeurs selon les paramètres
         // fournis.
-        $this->assertEquals('d', $bouchon->faireQuelquechose('a', 'b', 'c'));
-        $this->assertEquals('h', $bouchon->faireQuelquechose('e', 'f', 'g'));
+        self::assertEquals('d', $bouchon->faireQuelquechose('a', 'b', 'c'));
+        self::assertEquals('h', $bouchon->faireQuelquechose('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -359,7 +359,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $bouchon->faireQuelquechose($argument) retourne str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $bouchon->faireQuelquechose('quelqueChose'));
+        self::assertEquals('fbzrguvat', $bouchon->faireQuelquechose('quelqueChose'));
     }
 }
 ?>]]></programlisting>
@@ -396,9 +396,9 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $bouchon->faireQuelquechose() retourne une valeur différente à chaque fois
-        $this->assertEquals(2, $bouchon->faireQuelquechose());
-        $this->assertEquals(3, $bouchon->faireQuelquechose());
-        $this->assertEquals(5, $bouchon->faireQuelquechose());
+        self::assertEquals(2, $bouchon->faireQuelquechose());
+        self::assertEquals(3, $bouchon->faireQuelquechose());
+        self::assertEquals(5, $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -713,7 +713,7 @@ class ClasseAbstraiteTest extends PHPUnit_Framework_TestCase
              ->method('methodeAbstraite')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->methodeConcrete());
+        self::assertTrue($stub->methodeConcrete());
     }
 }
 ?>]]></programlisting>
@@ -845,7 +845,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() va maintenant retourner un result bouchon et
          * la méthode doGoogleSearch() du web service ne sera pas invoquée.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -945,10 +945,10 @@ class ExempleTest extends PHPUnit_Framework_TestCase
     public function testReprtoireEstCree()
     {
         $example = new Exemple('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setRepertoire(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -994,10 +994,10 @@ class ExempleTest extends PHPUnit_Framework_TestCase
     public function testRepertoireEstCree()
     {
         $exemple = new Exemple('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $exemple->setRepertoire(vfsStream::url('exempleRepertoire'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/fr/writing-tests-for-phpunit.xml
+++ b/src/4.7/fr/writing-tests-for-phpunit.xml
@@ -27,14 +27,14 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testerPushEtPop()
     {
         $pile = array();
-        $this->assertEquals(0, count($pile));
+        self::assertEquals(0, count($pile));
 
         array_push($pile, 'foo');
-        $this->assertEquals('foo', $pile[count($pile)-1]);
-        $this->assertEquals(1, count($pile));
+        self::assertEquals('foo', $pile[count($pile)-1]);
+        self::assertEquals(1, count($pile));
 
-        $this->assertEquals('foo', array_pop($pile));
-        $this->assertEquals(0, count($pile));
+        self::assertEquals('foo', array_pop($pile));
+        self::assertEquals(0, count($pile));
     }
 }
 ?>]]></programlisting>
@@ -98,7 +98,7 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testVide()
     {
         $pile = array();
-        $this->assertEmpty($pile);
+        self::assertEmpty($pile);
 
         return $pile;
     }
@@ -109,8 +109,8 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testPush(array $pile)
     {
         array_push($pile, 'foo');
-        $this->assertEquals('foo', $pile[count($pile)-1]);
-        $this->assertNotEmpty($pile);
+        self::assertEquals('foo', $pile[count($pile)-1]);
+        self::assertNotEmpty($pile);
 
         return $pile;
     }
@@ -120,8 +120,8 @@ class PileTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $pile)
     {
-        $this->assertEquals('foo', array_pop($pile));
-        $this->assertEmpty($pile);
+        self::assertEquals('foo', array_pop($pile));
+        self::assertEmpty($pile);
     }
 }
 ?>]]></programlisting>
@@ -154,7 +154,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testUn()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -228,7 +228,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdditionne($a, $b, $c)
     {
-        $this->assertEquals($c, $a + $b);
+        self::assertEquals($c, $a + $b);
     }
 
     public function fournisseur()
@@ -273,7 +273,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdditionne($a, $b, $c)
     {
-        $this->assertEquals($c, $a + $b);
+        self::assertEquals($c, $a + $b);
     }
 
     public function fournisseur()
@@ -673,7 +673,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testEcritureFichier() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->ecrit('/non-accessible-en-ecriture/fichier', 'texte'));
+        self::assertFalse(@$writer->ecrit('/non-accessible-en-ecriture/fichier', 'texte'));
     }
 }
 class FileWriter
@@ -825,7 +825,7 @@ class TableauPossedeUneClefTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -862,7 +862,7 @@ class ClassePossedeUnAttributTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -899,7 +899,7 @@ class ClassePossedeUnAttributStatiqueTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -939,7 +939,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -971,7 +971,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -1000,12 +1000,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -1046,7 +1046,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -1087,7 +1087,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -1127,7 +1127,7 @@ class VideTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -1165,7 +1165,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $attendu = new DOMElement('foo');
         $constate = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($attendu, $constate);
+        self::assertEqualXMLStructure($attendu, $constate);
     }
 
     public function testEchecAvecDifferentsAttributsDeNoeud()
@@ -1176,7 +1176,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild, TRUE
         );
     }
@@ -1189,7 +1189,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild
         );
     }
@@ -1202,7 +1202,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild
         );
     }
@@ -1271,17 +1271,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testEchec2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testEchec3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -1338,12 +1338,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSucces()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testEchec()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -1380,7 +1380,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($attendu, $constate);
+        self::assertEquals($attendu, $constate);
     }
 }
 ?>]]></programlisting>
@@ -1429,7 +1429,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $constate->foo = 'bar';
         $constate->baz = 'bar';
 
-        $this->assertEquals($attendu, $constate);
+        self::assertEquals($attendu, $constate);
     }
 }
 ?>]]></programlisting>
@@ -1470,7 +1470,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -1516,7 +1516,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -1553,7 +1553,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFileEquals('/home/sb/attendu', '/home/sb/constate');
+        self::assertFileEquals('/home/sb/attendu', '/home/sb/constate');
     }
 }
 ?>]]></programlisting>
@@ -1596,7 +1596,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFileExists('/chemin/vers/fichier');
+        self::assertFileExists('/chemin/vers/fichier');
     }
 }
 ?>]]></programlisting>
@@ -1633,7 +1633,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -1670,7 +1670,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -1710,7 +1710,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1750,7 +1750,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1789,7 +1789,7 @@ class JsonFileEqualsJsonFile extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'chemin/vers/fixture/fichier', 'chemin/vers/constate/fichier');
     }
 }
@@ -1827,7 +1827,7 @@ class JsonStringEqualsJsonFile extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'chemin/vers/fixture/fichier', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1868,7 +1868,7 @@ class JsonStringEqualsJsonString extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1914,7 +1914,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1951,7 +1951,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1988,7 +1988,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -2025,7 +2025,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -2062,7 +2062,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -2099,7 +2099,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2150,7 +2150,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringMatchesFormatFile('/chemin/vers/attendu.txt', 'foo');
+        self::assertStringMatchesFormatFile('/chemin/vers/attendu.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2191,7 +2191,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -2223,7 +2223,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -2270,22 +2270,22 @@ class SelectCountTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectCount('foo bar', FALSE, $this->xml);
+        self::assertSelectCount('foo bar', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectCount('foo baz', TRUE, $this->xml);
+        self::assertSelectCount('foo baz', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectCount('foo bar', 5, $this->xml);
+        self::assertSelectCount('foo bar', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectCount('foo bar', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectCount('foo bar', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2347,22 +2347,22 @@ class SelectEqualsTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', FALSE, $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Bat', TRUE, $this->xml);
+        self::assertSelectEquals('foo bar', 'Bat', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', 5, $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2424,22 +2424,22 @@ class SelectRegExpTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', FALSE, $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/B[oe]z]/', TRUE, $this->xml);
+        self::assertSelectRegExp('foo bar', '/B[oe]z]/', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', 5, $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2491,7 +2491,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringEndsWith('suffixe', 'foo');
+        self::assertStringEndsWith('suffixe', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2528,7 +2528,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringEqualsFile('/home/sb/attendu', 'constate');
+        self::assertStringEqualsFile('/home/sb/attendu', 'constate');
     }
 }
 ?>]]></programlisting>
@@ -2571,7 +2571,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringStartsWith('prefixe', 'foo');
+        self::assertStringStartsWith('prefixe', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2699,10 +2699,10 @@ $matcher = array(
 );
 
 // Utilise assertTag() pour appliquer un $matcher à un morceau de $html.
-$this->assertTag($matcher, $html);
+self::assertTag($matcher, $html);
 
 // Utilise assertTag() pour appliquer un matcher à un morceau de $xml.
-$this->assertTag($matcher, $xml, '', FALSE);
+self::assertTag($matcher, $xml, '', FALSE);
 ?>]]></programlisting>
       </example>
     </section>
@@ -2734,7 +2734,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $leBiscuit = new Biscuit('Ginger');
         $monBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $leBiscuit,
           $this->logicalNot(
             $this->equalTo($monBiscuit)
@@ -2919,7 +2919,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -2956,7 +2956,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/attendu.xml', '/home/sb/constate.xml');
     }
 }
@@ -3002,7 +3002,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/attendu.xml', '<foo><baz/></foo>');
     }
 }
@@ -3048,7 +3048,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.7/ja/annotations.xml
+++ b/src/4.7/ja/annotations.xml
@@ -269,7 +269,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
@@ -801,7 +801,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.7/ja/assertions.xml
+++ b/src/4.7/ja/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -99,7 +99,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.7/ja/code-coverage-analysis.xml
+++ b/src/4.7/ja/code-coverage-analysis.xml
@@ -294,7 +294,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -307,7 +307,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -325,7 +325,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -340,11 +340,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -381,7 +381,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -415,6 +415,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.7/ja/database.xml
+++ b/src/4.7/ja/database.xml
@@ -215,7 +215,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -1176,7 +1176,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1204,12 +1204,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1239,7 +1239,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1299,7 +1299,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1324,7 +1324,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1342,7 +1342,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/ja/fixtures.xml
+++ b/src/4.7/ja/fixtures.xml
@@ -69,21 +69,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -146,13 +146,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.7/ja/incomplete-and-skipped-tests.xml
+++ b/src/4.7/ja/incomplete-and-skipped-tests.xml
@@ -57,7 +57,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // オプション: お望みなら、ここで何かのテストをしてください。
-        $this->assertTrue(TRUE, 'これは動いているはずです。');
+        self::assertTrue(TRUE, 'これは動いているはずです。');
 
         // ここで処理を止め、テストが未完成であるという印をつけます。
         $this->markTestIncomplete(

--- a/src/4.7/ja/selenium.xml
+++ b/src/4.7/ja/selenium.xml
@@ -24,7 +24,7 @@
       (ウェブアプリケーションを、さまざまなオペレーティングシステムやブラウザでテストする)
       などがあります。
     </para>
-    
+
     <para>
       PHPUnit_Selenium がサポートしている唯一のシナリオは、
       Selenium 2.x サーバを使うものです。
@@ -37,7 +37,7 @@
     </para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>インストール</title>
 
@@ -95,7 +95,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -122,7 +122,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     Selenium2TestCase のコマンドは __call() を使って実装しています。
     サポートする機能の一覧は
     <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">PHPUnit_Extensions_Selenium2TestCase のエンドツーエンドテスト</ulink>
@@ -163,7 +163,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -265,7 +265,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -346,7 +346,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/ja/test-doubles.xml
+++ b/src/4.7/ja/test-doubles.xml
@@ -156,7 +156,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() をコールすると
         // 'foo' を返すようになります
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -195,7 +195,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() をコールすると
         // 'foo' を返すようになります
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -252,10 +252,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') は 'foo' を返します
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') は 'bar' を返します
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -290,7 +290,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() は $stub を返します
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -332,8 +332,8 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnValueMap($map));
 
         // $stub->doSomething() は、渡した引数に応じて異なる値を返します
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -372,7 +372,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) は str_rot13($argument) を返します
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -408,9 +408,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() は毎回異なる値を返します
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -520,12 +520,12 @@ class Subject
 {
     protected $observers = array();
     protected $name;
-    
+
     public function __construct($name)
     {
         $this->name = $name;
     }
-    
+
     public function getName()
     {
         return $this->name;
@@ -936,7 +936,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -974,7 +974,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -1050,7 +1050,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() はスタブが用意した結果を返し、
          * ウェブサービスの doGoogleSearch() が呼び出されることはありません
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1151,10 +1151,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1200,10 +1200,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/ja/textui.xml
+++ b/src/4.7/ja/textui.xml
@@ -401,7 +401,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.7/ja/writing-tests-for-phpunit.xml
+++ b/src/4.7/ja/writing-tests-for-phpunit.xml
@@ -26,14 +26,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -111,7 +111,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -122,8 +122,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -133,8 +133,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -169,7 +169,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -226,13 +226,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -242,7 +242,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -294,7 +294,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -339,7 +339,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -434,13 +434,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -451,7 +451,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -862,7 +862,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -1005,7 +1005,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1055,7 +1055,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1109,7 +1109,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.7/pt_br/annotations.xml
+++ b/src/4.7/pt_br/annotations.xml
@@ -6,25 +6,25 @@
   <para>
     <indexterm><primary>Anotações</primary></indexterm>
 
-    Uma anotação é uma forma especial de metadados sintáticos que podem ser adicionados ao 
-    código-fonte de algumas linguagens de programação. Enquanto o PHP não tem 
-    um recurso de linguagem dedicado a anotação de código-fonte, o uso de tags 
-    como <literal>@annotation arguments</literal> em bloco de documentação tem sido 
-    estabelecido na comunidade do PHP para anotar o código-fonte. Os blocos 
-    de documentação PHP são reflexivos: eles podem ser acessados através do 
-    método <literal>getDocComment()</literal> da API Reflection a nível de função, 
-    classe, método e atributo. Aplicações como o PHPUnit usam essa 
+    Uma anotação é uma forma especial de metadados sintáticos que podem ser adicionados ao
+    código-fonte de algumas linguagens de programação. Enquanto o PHP não tem
+    um recurso de linguagem dedicado a anotação de código-fonte, o uso de tags
+    como <literal>@annotation arguments</literal> em bloco de documentação tem sido
+    estabelecido na comunidade do PHP para anotar o código-fonte. Os blocos
+    de documentação PHP são reflexivos: eles podem ser acessados através do
+    método <literal>getDocComment()</literal> da API Reflection a nível de função,
+    classe, método e atributo. Aplicações como o PHPUnit usam essa
     informação em tempo de execução para configurar seu comportamento.
   </para>
 
   <note>
     <para>
-      Um comentário de documentação em PHP deve começar com <literal>/**</literal> e terminar com 
-      <literal>*/</literal>. Anotações em algum outro estilo de comentário será 
+      Um comentário de documentação em PHP deve começar com <literal>/**</literal> e terminar com
+      <literal>*/</literal>. Anotações em algum outro estilo de comentário será
       ignorada.
     </para>
   </note>
-  
+
   <para>
     Este apêndice mostra todas as variedades de anotações suportadas pelo PHPUnit.
   </para>
@@ -37,17 +37,17 @@
 
       A anotação <literal>@author</literal> é um apelido para a anotação
       <literal>@group</literal> (veja <xref
-      linkend="appendixes.annotations.group"/>) e permite filtrar os testes baseado 
+      linkend="appendixes.annotations.group"/>) e permite filtrar os testes baseado
       em seus autores.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.after">
     <title>@after</title>
 
     <para>
 
-      A anotação <literal>@after</literal> pode ser usada para especificar métodos 
+      A anotação <literal>@after</literal> pode ser usada para especificar métodos
       que devem ser chamados depois de cada método em uma classe de caso de teste.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -69,14 +69,14 @@
 }</programlisting>
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.afterClass">
     <title>@afterClass</title>
 
     <para>
 
-      A anotação <literal>@afterClass</literal> pode ser usada para especificar 
-      métodos estáticos que devem ser chamados depois de todos os métodos de teste em uma classe 
+      A anotação <literal>@afterClass</literal> pode ser usada para especificar
+      métodos estáticos que devem ser chamados depois de todos os métodos de teste em uma classe
       de teste foram executados para limpar ambientes compartilhados.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -105,7 +105,7 @@
     <para>
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
-      As operações de cópia de segurança e restauração para variáveis globais podem ser completamente 
+      As operações de cópia de segurança e restauração para variáveis globais podem ser completamente
       desabilitadas para todos os testes de uma classe de caso de teste como esta <programlisting>/**
  * @backupGlobals disabled
  */
@@ -118,8 +118,8 @@ class MyTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
-      A anotação <literal>@backupGlobals</literal> também pode ser usada a nível 
-      de método de teste. Isso permite uma configuração refinada das 
+      A anotação <literal>@backupGlobals</literal> também pode ser usada a nível
+      de método de teste. Isso permite uma configuração refinada das
       operações de cópia de segurança e restauração: <programlisting>/**
  * @backupGlobals disabled
  */
@@ -142,8 +142,8 @@ class MyTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
 
-      A anotação <literal>@backupStaticAttributes</literal> pode ser usada para 
-      copiar todos valores de propriedades estáticas em todas classes declaradas antes de cada 
+      A anotação <literal>@backupStaticAttributes</literal> pode ser usada para
+      copiar todos valores de propriedades estáticas em todas classes declaradas antes de cada
       teste e restaurá-los depois. Pode ser usado em nível de classe de caso de teste ou
       método de teste:
 
@@ -166,23 +166,23 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        <literal>@backupStaticAttributes</literal> é limitada pela parte interna do PHP 
-        e pode causar valores estáticos não intencionais ao persistir e vazar para 
+        <literal>@backupStaticAttributes</literal> é limitada pela parte interna do PHP
+        e pode causar valores estáticos não intencionais ao persistir e vazar para
         testes subsequentes em algumas circunstâncias.
       </para>
       <para>
         Veja <xref linkend="fixtures.global-state"/> para detalhes.
       </para>
     </note>
-    
+
   </section>
-  
+
   <section id="appendixes.annotations.before">
     <title>@before</title>
 
     <para>
 
-      A anotação <literal>@before</literal> pode ser usada para especificar métodos 
+      A anotação <literal>@before</literal> pode ser usada para especificar métodos
       que devem ser chamados antes de cada método de teste em uma classe de caso de teste.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -204,14 +204,14 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.beforeClass">
     <title>@beforeClass</title>
 
     <para>
 
-      A anotação <literal>@beforeClass</literal> pode ser usada para especificar métodos 
-      estáticos que devem ser chamados antes de quaisquer métodos de teste em uma classe 
+      A anotação <literal>@beforeClass</literal> pode ser usada para especificar métodos
+      estáticos que devem ser chamados antes de quaisquer métodos de teste em uma classe
       de teste serem executados para criar ambientes compartilahdos.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -244,7 +244,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 
       As anotações <literal>@codeCoverageIgnore</literal>,
       <literal>@codeCoverageIgnoreStart</literal> e
-      <literal>@codeCoverageIgnoreEnd</literal> podem ser usadas 
+      <literal>@codeCoverageIgnoreEnd</literal> podem ser usadas
       para excluir linhas de código da análise de cobertura.
     </para>
 
@@ -261,23 +261,23 @@ class MyTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Cobertura de Código</primary></indexterm>
       <indexterm><primary>@covers</primary></indexterm>
 
-      A anotação <literal>@covers</literal> pode ser usada no código de teste para 
+      A anotação <literal>@covers</literal> pode ser usada no código de teste para
       especificar quais métodos um método de teste quer testar: <programlisting>/**
  * @covers BankAccount::getBalance
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
     <para>
-      Se fornecida, apenas a informação de cobertura de código para o(s) 
+      Se fornecida, apenas a informação de cobertura de código para o(s)
       método(s) especificado(s) será considerada.
     </para>
 
     <para>
-      <xref linkend="appendixes.annotations.covers.tables.annotations"/> mostra 
+      <xref linkend="appendixes.annotations.covers.tables.annotations"/> mostra
       a sintaxe da anotação <literal>@covers</literal>.
     </para>
 
@@ -336,7 +336,7 @@ public function testBalanceIsInitiallyZero()
       </tgroup>
     </table>
   </section>
-  
+
   <section id="appendixes.annotations.coversDefaultClass">
     <title>@coversDefaultClass</title>
 
@@ -376,8 +376,8 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@coversNothing</primary></indexterm>
 
-      A anotação <literal>@coversNothing</literal> pode ser usada no 
-      código de teste para especificar que nenhuma informação de cobertura de código será 
+      A anotação <literal>@coversNothing</literal> pode ser usada no
+      código de teste para especificar que nenhuma informação de cobertura de código será
       gravada para o caso de teste anotado.
     </para>
 
@@ -388,7 +388,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     </para>
 
     <para>
-        A anotação pode ser usada nos níveis de classe e de método e 
+        A anotação pode ser usada nos níveis de classe e de método e
         vão sobrescrever quaisquer tags <literal>@covers</literal>.
     </para>
   </section>
@@ -399,7 +399,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@dataProvider</primary></indexterm>
 
-      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser 
+      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser
       fornecidos por um método provedor  (<literal>provider()</literal> em
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
       O método provedor de dados a ser usado é especificado usando a anotação
@@ -407,7 +407,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.data-providers"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.data-providers"/> para mais
       detalhes.
     </para>
   </section>
@@ -418,17 +418,17 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@depends</primary></indexterm>
 
-      O PHPUnit suporta a declaração de dependências explícitas entre métodos 
-      de teste. Tais dependências não definem a ordem em que os métodos de teste 
-      devem ser executados, mas permitem o retorno de uma instância do 
+      O PHPUnit suporta a declaração de dependências explícitas entre métodos
+      de teste. Tais dependências não definem a ordem em que os métodos de teste
+      devem ser executados, mas permitem o retorno de uma instância do
       ambiente de teste por um produtor e passá-la aos consumidores dependentes.
-      O <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> mostra 
-      como usar a anotação <literal>@depends</literal> para expressar 
+      O <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> mostra
+      como usar a anotação <literal>@depends</literal> para expressar
       dependências entre métodos de teste.
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.test-dependencies"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.test-dependencies"/> para mais
       detalhes.
     </para>
   </section>
@@ -440,12 +440,12 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>@expectedException</primary></indexterm>
 
       O <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest.php" />
-      mostra como usar a anotação <literal>@expectedException</literal> para 
+      mostra como usar a anotação <literal>@expectedException</literal> para
       testar se uma exceção é lançada dentro do código testado.
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.exceptions"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.exceptions"/> para mais
       detalhes.
     </para>
   </section>
@@ -456,9 +456,9 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
-      A anotação <literal>@expectedExceptionCode</literal> em conjunção 
-      com a <literal>@expectedException</literal> permite fazer asserções no 
-      código de erro de uma exceção lançada, permitindo diminuir uma 
+      A anotação <literal>@expectedExceptionCode</literal> em conjunção
+      com a <literal>@expectedException</literal> permite fazer asserções no
+      código de erro de uma exceção lançada, permitindo diminuir uma
       exceção específica.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -473,7 +473,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     }
 }</programlisting>
 
-      Para facilitar o teste e reduzir a duplicação, um atalho pode ser usado para 
+      Para facilitar o teste e reduzir a duplicação, um atalho pode ser usado para
       especificar uma constante de classe como um
       <literal>@expectedExceptionCode</literal> usando a sintaxe
       "<literal>@expectedExceptionCode ClassName::CONST</literal>".
@@ -504,8 +504,8 @@ class MyClass
     <para>
       <indexterm><primary>@expectedExceptionMessage</primary></indexterm>
 
-      A anotação <literal>@expectedExceptionMessage</literal> trabalha de modo similar 
-      a <literal>@expectedExceptionCode</literal> já que lhe permite fazer uma 
+      A anotação <literal>@expectedExceptionMessage</literal> trabalha de modo similar
+      a <literal>@expectedExceptionCode</literal> já que lhe permite fazer uma
       asserção na mensagem de erro de uma exceção.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -520,9 +520,9 @@ class MyClass
     }
 }</programlisting>
 
-      A mensagem esperada pode ser uma substring de uma Mensagem de exceção. 
-      Isso pode ser útil para asseverar apenas que um certo nome ou parâmetro que 
-      foi passado é mostrado na exceção e não fixar toda a 
+      A mensagem esperada pode ser uma substring de uma Mensagem de exceção.
+      Isso pode ser útil para asseverar apenas que um certo nome ou parâmetro que
+      foi passado é mostrado na exceção e não fixar toda a
       mensagem de exceção no teste.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -538,7 +538,7 @@ class MyClass
      }
 }</programlisting>
 
-      Para facilitar o teste e reduzir duplicação um atalho pode ser usado para 
+      Para facilitar o teste e reduzir duplicação um atalho pode ser usado para
       especificar uma constante de classe como uma
       <literal>@expectedExceptionMessage</literal> usando a sintaxe
       "<literal>@expectedExceptionMessage ClassName::CONST</literal>".
@@ -547,7 +547,7 @@ class MyClass
     </para>
 
   </section>
-  
+
   <section id="appendixes.annotations.expectedExceptionMessageRegExp">
     <title>@expectedExceptionMessageRegExp</title>
 
@@ -556,7 +556,7 @@ class MyClass
 
       A mensagem experada também pode ser especificada como uma expressão regular usando
       a anotação <literal>@expectedExceptionMessageRegExp</literal>. Isso
-      é útil em situações aonde uma substring não é adequada para combinar 
+      é útil em situações aonde uma substring não é adequada para combinar
       uma determinada mensagem.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -580,7 +580,7 @@ class MyClass
     <para>
       <indexterm><primary>@group</primary></indexterm>
 
-      Um teste pode ser marcado como pertencente a um ou mais grupos usando a 
+      Um teste pode ser marcado como pertencente a um ou mais grupos usando a
       anotação <literal>@group</literal> desta forma <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -601,20 +601,20 @@ class MyClass
     </para>
 
     <para>
-      Testes podem ser selecionados para execução baseada em grupos usando as 
-      opções <literal>--group</literal> e <literal>--exclude-group</literal> 
-      do executor de teste em linha-de-comando ou usando as respectivas diretivas do 
+      Testes podem ser selecionados para execução baseada em grupos usando as
+      opções <literal>--group</literal> e <literal>--exclude-group</literal>
+      do executor de teste em linha-de-comando ou usando as respectivas diretivas do
       arquivo de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.large">
     <title>@large</title>
 
     <para>
       <indexterm><primary><literal>@large</literal></primary></indexterm>
 
-      A anotação <literal>@large</literal> é um apelido para 
+      A anotação <literal>@large</literal> é um apelido para
       <literal>@group large</literal>.
     </para>
 
@@ -622,14 +622,14 @@ class MyClass
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForLargeTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
-      estrito estiver habilitado, um teste grande irá falhar se ele demorar mais de 60 
-      segundos para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForLargeTests</literal> no arquivo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
+      estrito estiver habilitado, um teste grande irá falhar se ele demorar mais de 60
+      segundos para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForLargeTests</literal> no arquivo
       de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.medium">
     <title>@medium</title>
 
@@ -645,26 +645,26 @@ class MyClass
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForMediumTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
-      estrito estiver habilitado, um teste médio irá falhar se ele demorar mais de 10 
-      segundos para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForMediumTests</literal> no arquivo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
+      estrito estiver habilitado, um teste médio irá falhar se ele demorar mais de 10
+      segundos para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForMediumTests</literal> no arquivo
       de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.preserveGlobalState">
     <title>@preserveGlobalState</title>
 
     <para>
       <indexterm><primary>@preserveGlobalState</primary></indexterm>
 
-      Quando um teste é executado em um processo separado, o PHPUnit 
-      tentará preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
-      contém globais que não são serializáveis. Para corrigir isto, você pode prevenir o 
-      PHPUnit de preservar o estado global com a 
+      Quando um teste é executado em um processo separado, o PHPUnit
+      tentará preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
+      contém globais que não são serializáveis. Para corrigir isto, você pode prevenir o
+      PHPUnit de preservar o estado global com a
       anotação <literal>@preserveGlobalState</literal>.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -703,7 +703,7 @@ class MyClass
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indica que todos testes em uma classe de teste devem ser executados em um processo 
+      Indica que todos testes em uma classe de teste devem ser executados em um processo
       PHP separado. <programlisting>/**
  * @runTestsInSeparateProcesses
  */
@@ -713,11 +713,11 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
 
       <emphasis role="strong">Nota:</emphasis> Por padrão, o PHPUnit tentará
-      preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
+      preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
       contém globais que não são serializáveis. Veja <xref
-      linkend="appendixes.annotations.preserveGlobalState"/> para informações 
+      linkend="appendixes.annotations.preserveGlobalState"/> para informações
       de como corrigir isso.
     </para>
   </section>
@@ -741,15 +741,15 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
 
       <emphasis role="strong">Nota:</emphasis> Por padrão, o PHPUnit tentará
-      preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
+      preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
       contém globais que não são serializáveis. Veja <xref
-      linkend="appendixes.annotations.preserveGlobalState"/> para informações 
+      linkend="appendixes.annotations.preserveGlobalState"/> para informações
       de como corrigir isso.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.small">
     <title>@small</title>
 
@@ -765,19 +765,19 @@ class MyTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
       estrito estiver habilitado, um teste pequeno irá falhar se ele demorar mais de 1
-      segundo para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForLargeTests</literal> no arquivo 
+      segundo para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForLargeTests</literal> no arquivo
       de configuração XML.
     </para>
 
     <note>
       <para>
-        Pr padrão, todos testes são considerados pequenos se eles não são 
+        Pr padrão, todos testes são considerados pequenos se eles não são
         como <literal>@medium</literal> ou <literal>@large</literal>. Note, por favor,
-        no entanto, que <literal>--group</literal> e as opções relacionadas irão 
-        apenas considerarão um teste ser do grupo <literal>small</literal> se ele 
+        no entanto, que <literal>--group</literal> e as opções relacionadas irão
+        apenas considerarão um teste ser do grupo <literal>small</literal> se ele
         é marcado explicitamente com a anotação apropriada.
       </para>
     </note>
@@ -797,7 +797,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>
@@ -822,14 +822,14 @@ public function initialBalanceShouldBe0()
 
     <programlisting></programlisting>
   </section>
-  
+
   <section id="appendixes.annotations.uses">
     <title>@uses</title>
 
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      A anotação <literal>@uses</literal> especifica o código que irá 
+      A anotação <literal>@uses</literal> especifica o código que irá
       ser executado por um teste, mas não se destina a ser coberto pelo teste. Um bom
       exemplo é um objeto valor que é necessário para testar um unidade de código.
       <programlisting>/**
@@ -843,9 +843,9 @@ public function testMoneyCanBeDepositedInAccount()
     </para>
 
     <para>
-      Essa anotação é especialmente útil em modo de cobertura estrita aonde 
+      Essa anotação é especialmente útil em modo de cobertura estrita aonde
       código coberto involuntariamente fará um teste falhar. Veja
-      <xref linkend="risky-tests.unintentionally-covered-code"/> para mais 
+      <xref linkend="risky-tests.unintentionally-covered-code"/> para mais
       informação sobre modo de cobertura estrito.
     </para>
   </section>

--- a/src/4.7/pt_br/assertions.xml
+++ b/src/4.7/pt_br/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -84,7 +84,7 @@ FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </example>
   </section>
-  
+
   <section id="appendixes.assertions.assertClassHasAttribute">
     <title>assertClassHasAttribute()</title>
     <indexterm><primary>assertClassHasAttribute()</primary></indexterm>
@@ -99,7 +99,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1089,7 +1089,7 @@ Tests: 1, Assertions: 3, Failures: 1.</screen>
     <indexterm><primary>assertJsonStringNotEqualsJsonFile()</primary></indexterm>
     <para><literal>assertJsonStringEqualsJsonFile(mixed $expectedFile, mixed $actualJson[, string $message = ''])</literal></para>
     <para>
-      Reporta um erro identificado pela <literal>$message</literal> se o valor de <literal>$actualJson</literal> não combina com o valor de 
+      Reporta um erro identificado pela <literal>$message</literal> se o valor de <literal>$actualJson</literal> não combina com o valor de
       <literal>$expectedFile</literal>.
     </para>
     <example id="appendixes.assertions.assertJsonStringEqualsJsonFile.example">
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1640,10 +1640,10 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertThat()</primary></indexterm>
 
     <para>
-      Asserções mais complexas podem ser formuladas usando as 
-      classes <literal>PHPUnit_Framework_Constraint</literal>. Elas podem ser 
+      Asserções mais complexas podem ser formuladas usando as
+      classes <literal>PHPUnit_Framework_Constraint</literal>. Elas podem ser
       avaliadas usando o método <literal>assertThat()</literal>.
-      <xref linkend="appendixes.assertions.assertThat.example" /> mostra como as 
+      <xref linkend="appendixes.assertions.assertThat.example" /> mostra como as
       restrições <literal>logicalNot()</literal> e <literal>equalTo()</literal>
       podem ser usadas para expressar a mesma asserção como
       <literal>assertNotEquals()</literal>.
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.7/pt_br/code-coverage-analysis.xml
+++ b/src/4.7/pt_br/code-coverage-analysis.xml
@@ -8,7 +8,7 @@
     <para>
       Na ciência da computação, cobertura de código é um mensuração usada para descrever o
       grau em que um código fonte de um programa é testado por uma suíte
-      de testes particular. Um programa com cobertura de código alta foi mais exaustivamente 
+      de testes particular. Um programa com cobertura de código alta foi mais exaustivamente
       testado e tem uma menor chance de conter erros de software do que um programa
       com baixa cobertura de código.
     </para>
@@ -18,39 +18,39 @@
     <indexterm><primary>Cobertura de Código</primary></indexterm>
     <indexterm><primary>Xdebug</primary></indexterm>
 
-    Neste capítulo você aprenderá tudo sobre a funcionalidade de cobertura de código 
-    do PHPUnit que lhe dará uma perspicácia sobre quais partes do código de produção 
+    Neste capítulo você aprenderá tudo sobre a funcionalidade de cobertura de código
+    do PHPUnit que lhe dará uma perspicácia sobre quais partes do código de produção
     são executadas quando os testes são executados. Ele faz uso do componente
     <ulink url="https://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>,
-    que por sua vez utiliza a funcionalidade de cobertura de código fornecido 
+    que por sua vez utiliza a funcionalidade de cobertura de código fornecido
     pela extensão <ulink url="http://xdebug.org/">Xdebug</ulink> para PHP.
   </para>
-  
+
   <note>
     <para>
-      Xdebug não é distribuído como parte do PHPUnit. Se você Se você receber um aviso 
-      durante a execução de testes que a extensão Xdebug não está carregada, isso significa 
+      Xdebug não é distribuído como parte do PHPUnit. Se você Se você receber um aviso
+      durante a execução de testes que a extensão Xdebug não está carregada, isso significa
       que Xdebug ou não está instalada ou não está configurada corretamente. Antes
       que você possa usar as funcionalidades de análise de cobertura de código no PHPUnit, você deve
       ler <ulink url="http://xdebug.org/docs/install">o manual de instalação Xdebug</ulink>.
     </para>
   </note>
-  
+
   <para>
-    PHPUnit pode gerar um relatório de cobertura de código baseado em HTML, tal como 
+    PHPUnit pode gerar um relatório de cobertura de código baseado em HTML, tal como
     arquivos de registros baseado em XML com informações de cobertura de código em vários formatos
-    (Clover, Crap4J, PHPUnit). Informação de cobertura de código também pode ser relatado 
-    como texto (e impresso na STDOUT) e exportado como código PHP para futuro 
+    (Clover, Crap4J, PHPUnit). Informação de cobertura de código também pode ser relatado
+    como texto (e impresso na STDOUT) e exportado como código PHP para futuro
     processamento.
   </para>
-  
+
   <para>
     Por favor, consulte o <xref linkend="textui"/> para uma lista de opções de linha de comando
     que controlam a funcionalidade de cobertura de código, bem como em <xref
-    linkend="appendixes.configuration.logging"/> para as definições de 
+    linkend="appendixes.configuration.logging"/> para as definições de
     configurações relevantes.
   </para>
-  
+
   <section id="code-coverage-analysis.metrics">
     <title>Métricas de Software para  Cobertura de Código</title>
 
@@ -75,9 +75,9 @@
         <term><emphasis>Cobertura de Função e Método</emphasis></term>
         <listitem>
           <para>
-            A métrica de software <emphasis>Cobertura de Função e Método</emphasis> 
+            A métrica de software <emphasis>Cobertura de Função e Método</emphasis>
             mensura se cada função ou método foi invocado.
-            PHP_CodeCoverage só considera uma função ou método como coberto quando 
+            PHP_CodeCoverage só considera uma função ou método como coberto quando
             todas suas linhas executáveis são cobertas.
           </para>
         </listitem>
@@ -101,10 +101,10 @@
         <term><emphasis>Cobertura de Código de Operação</emphasis></term>
         <listitem>
           <para>
-            A métrica de software <emphasis>Cobertura de Código de Operação</emphasis> mensura 
-            se cada código de operação de uma função ou método foi  executado enquanto 
-            executa a suíte de teste. Uma linha de código geralmente compila em mais 
-            de um código de operação. Cobertura de Linha considera uma linha de código como coberta 
+            A métrica de software <emphasis>Cobertura de Código de Operação</emphasis> mensura
+            se cada código de operação de uma função ou método foi  executado enquanto
+            executa a suíte de teste. Uma linha de código geralmente compila em mais
+            de um código de operação. Cobertura de Linha considera uma linha de código como coberta
             logo que um dos seus códigos de operações é executado.
           </para>
         </listitem>
@@ -116,7 +116,7 @@
         <listitem>
           <para>
             A métrica de software <emphasis>Cobertura de Ramo</emphasis> mensura
-            se cada expressão booleana de cada estrutura de controle avaliada 
+            se cada expressão booleana de cada estrutura de controle avaliada
             a <literal>true</literal> e <literal>false</literal> enquanto
             executa a suíte de teste.
           </para>
@@ -129,9 +129,9 @@
         <listitem>
           <para>
             A métrica de software <emphasis>Cobertura de Caminho</emphasis> mensura
-            se cada um dos caminhos de execução possíveis em uma função ou método 
-            foi seguido durante a execução da suíte de teste. Um caminho de execução é 
-            uma sequência única de ramos a partir da entrada de uma função ou 
+            se cada um dos caminhos de execução possíveis em uma função ou método
+            foi seguido durante a execução da suíte de teste. Um caminho de execução é
+            uma sequência única de ramos a partir da entrada de uma função ou
             método para a sua saída.
           </para>
         </listitem>
@@ -142,11 +142,11 @@
         <term><emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis></term>
         <listitem>
           <para>
-            O <emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis> é 
-            calculado baseado na complexidade ciclomática e cobertura de código de uma 
-            unidade de código. Código que não é muito complexo e tem uma cobertura de teste 
+            O <emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis> é
+            calculado baseado na complexidade ciclomática e cobertura de código de uma
+            unidade de código. Código que não é muito complexo e tem uma cobertura de teste
             adequada terá um baixo índice CRAP. O índice CRAP pode ser reduzido
-            escrevendo testes e refatorando o código para reduzir sua 
+            escrevendo testes e refatorando o código para reduzir sua
             complexidade.
           </para>
         </listitem>
@@ -162,16 +162,16 @@
       </para>
     </note>
   </section>
-  
+
   <section id="code-coverage-analysis.including-excluding-files">
     <title>Incluindo e Excluindo Arquivos</title>
 
     <para>
-      Por padrão, todos os arquivos de código-fonte que contém pelo menos uma linha de código que 
-      tenha sido executada (e apenas esses arquivos) são incluídos no relatório 
+      Por padrão, todos os arquivos de código-fonte que contém pelo menos uma linha de código que
+      tenha sido executada (e apenas esses arquivos) são incluídos no relatório
       de cobertura de código.
     </para>
-    
+
     <para>
       <indexterm><primary>Cobertura de código</primary><secondary>Lista-negra</secondary></indexterm>
 
@@ -179,23 +179,23 @@
       relatório de cobertura de código. Essa lista-negra é previamente preenchida com os
       arquivos-fonte do PHPUnit e suas dependências.
     </para>
-    
+
     <para>
       <indexterm><primary>Cobertura de código</primary><secondary>Lista-branca</secondary></indexterm>
 
-      É uma boa prática usar um <emphasis>lista-branca</emphasis> ao invés da 
+      É uma boa prática usar um <emphasis>lista-branca</emphasis> ao invés da
       lista-negra mencionada acima.
     </para>
-    
+
     <para>
       Opcionalmente, todos arquivos da lista-branca pode ser adicionados ao relatório
       de cobertura de código pela definição <literal>addUncoveredFilesFromWhitelist="true"</literal>
       em suas configurações do PHPUnit (veja <xref
-      linkend="appendixes.configuration.blacklist-whitelist"/>). Isso permite a 
-      inclusão de arquivos que ainda não são testados em tudo. Se você quer obter 
+      linkend="appendixes.configuration.blacklist-whitelist"/>). Isso permite a
+      inclusão de arquivos que ainda não são testados em tudo. Se você quer obter
       informação sobre quais linhas de um tal arquivo descoberto são executadas,
-      por exemplo, você também precisa definir 
-      <literal>processUncoveredFilesFromWhitelist="true"</literal> em suas 
+      por exemplo, você também precisa definir
+      <literal>processUncoveredFilesFromWhitelist="true"</literal> em suas
       configurações do PHPUnit (veja <xref
       linkend="appendixes.configuration.blacklist-whitelist"/>).
     </para>
@@ -203,13 +203,13 @@
     <note>
       <para>
         Por favor, note que o carregamento de arquivos de código-fonte que é realizado, quando
-        <literal>processUncoveredFilesFromWhitelist="true"</literal> é definido, pode 
-        causar problemas quando um arquivo de código-fonte contém código fora do escopo de 
+        <literal>processUncoveredFilesFromWhitelist="true"</literal> é definido, pode
+        causar problemas quando um arquivo de código-fonte contém código fora do escopo de
         uma classe ou função, por exemplo.
       </para>
     </note>
   </section>
-  
+
   <section id="code-coverage-analysis.ignoring-code-blocks">
     <title>Ignorando Blocos de Código</title>
 
@@ -219,11 +219,11 @@
       <indexterm><primary>@codeCoverageIgnoreStart</primary></indexterm>
       <indexterm><primary>@codeCoverageIgnoreEnd</primary></indexterm>
 
-      Às vezes você tem blocos de código que não pode testar e que pode 
-      querer ignorar durante a análise de cobertura de código. O PHPUnit permite que você o faça 
+      Às vezes você tem blocos de código que não pode testar e que pode
+      querer ignorar durante a análise de cobertura de código. O PHPUnit permite que você o faça
       usando as anotações <literal>@codeCoverageIgnore</literal>,
       <literal>@codeCoverageIgnoreStart</literal> e
-      <literal>@codeCoverageIgnoreEnd</literal> como mostrado em 
+      <literal>@codeCoverageIgnoreEnd</literal> como mostrado em
       <xref linkend="code-coverage-analysis.ignoring-code-blocks.examples.Sample.php"/>.
     </para>
 
@@ -262,11 +262,11 @@ exit; // @codeCoverageIgnore
 
     <para>
       As linhas de código ignoradas (marcadas como ignoradas usando as anotações)
-      são contadas como executadas (se forem executáveis) e não serão 
+      são contadas como executadas (se forem executáveis) e não serão
       destacadas.
     </para>
   </section>
-  
+
   <section id="code-coverage-analysis.specifying-covered-methods">
     <title>Especificando métodos cobertos</title>
 
@@ -275,9 +275,9 @@ exit; // @codeCoverageIgnore
       <indexterm><primary>@covers</primary></indexterm>
 
       A anotação <literal>@covers</literal> (veja
-      <xref linkend="appendixes.annotations.covers.tables.annotations"/>) pode ser 
-      usada em um código de teste para especificar qual(is) método(s) um método de teste quer 
-      testar. Se fornecido, apenas a informação de cobertura de código para o(s) método(s) 
+      <xref linkend="appendixes.annotations.covers.tables.annotations"/>) pode ser
+      usada em um código de teste para especificar qual(is) método(s) um método de teste quer
+      testar. Se fornecido, apenas a informação de cobertura de código para o(s) método(s)
       especificado(s) será considerada.
       <xref linkend="code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php"/>
       mostra um exemplo.
@@ -300,7 +300,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -313,7 +313,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -331,7 +331,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -346,11 +346,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -363,8 +363,8 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       Também é possível especificar que um teste não deve cobrir
       <emphasis>qualquer</emphasis> método usando a anotação
       <literal>@coversNothing</literal> (veja
-      <xref linkend="appendixes.annotations.coversNothing"/>). Isso pode ser 
-      útil quando escrever testes de integração para certificar-se de que você só 
+      <xref linkend="appendixes.annotations.coversNothing"/>). Isso pode ser
+      útil quando escrever testes de integração para certificar-se de que você só
       gerará cobertura de código com testes unitários.
     </para>
 
@@ -388,14 +388,14 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
       </programlisting>
     </example>
   </section>
-  
+
   <section id="code-coverage-analysis.edge-cases">
     <title>Casos Extremos</title>
 

--- a/src/4.7/pt_br/database.xml
+++ b/src/4.7/pt_br/database.xml
@@ -3,59 +3,59 @@
 <chapter id="database">
   <title>Testando Bancos de Dados</title>
   <para>
-    Muitos exemplos de testes unitários iniciantes e intermediários em qualquer linguagem de 
-    programação sugerem que é perfeitamente fácil testar a lógica de sua aplicação 
-    com testes simples. Para aplicações centradas em bancos de dados isso está longe 
-    da realidade. Comece a usar Wordpress, TYPO3 ou Symfony com Doctrine ou Propel, 
-    por exemplo, e você vai experimentar facilmente problemas consideráveis com o 
+    Muitos exemplos de testes unitários iniciantes e intermediários em qualquer linguagem de
+    programação sugerem que é perfeitamente fácil testar a lógica de sua aplicação
+    com testes simples. Para aplicações centradas em bancos de dados isso está longe
+    da realidade. Comece a usar Wordpress, TYPO3 ou Symfony com Doctrine ou Propel,
+    por exemplo, e você vai experimentar facilmente problemas consideráveis com o
     PHPUnit: apenas porque o banco de dados é fortemente acoplado com essas bibliotecas.
   </para>
   <para>
-    Você provavelmente conhece esse cenário dos seus trabalhos e projetos diários, 
-    onde você quer colocar em prática suas habilidades (novas ou não) com PHPUnit 
+    Você provavelmente conhece esse cenário dos seus trabalhos e projetos diários,
+    onde você quer colocar em prática suas habilidades (novas ou não) com PHPUnit
     e acaba ficando preso por um dos seguintes problemas:
   </para>
   <orderedlist numeration="arabic">
     <listitem>
       <para>
-        O método que você quer testar executa uma operação JOIN muito grande e 
+        O método que você quer testar executa uma operação JOIN muito grande e
         usa os dados para calcular alguns resultados importantes.
       </para>
     </listitem>
     <listitem>
       <para>
-        Sua lógica de negócios faz uma mistura de declarações SELECT, INSERT, UPDATE 
+        Sua lógica de negócios faz uma mistura de declarações SELECT, INSERT, UPDATE
         e DELETE.
       </para>
     </listitem>
     <listitem>
       <para>
-        Você precisa definir os dados de teste em (provavelmente muito) mais de duas tabelas 
+        Você precisa definir os dados de teste em (provavelmente muito) mais de duas tabelas
         para conseguir dados iniciais razoáveis para os métodos que deseja testar.
       </para>
     </listitem>
   </orderedlist>
   <para>
-    A extensão DbUnit simplifica consideravelmente a configuração de um banco de dados 
-    para fins de teste e permite a você verificar os conteúdos de um banco de dados após 
+    A extensão DbUnit simplifica consideravelmente a configuração de um banco de dados
+    para fins de teste e permite a você verificar os conteúdos de um banco de dados após
     fazer uma série de operações.
   </para>
   <section id="database.supported-vendors-for-database-testing">
     <title>Fornecedores Suportados para Testes de Banco de Dados</title>
     <para>
-      DbUnit atualmente suporta MySQL, PostgreSQL, Oracle e SQLite. Através 
+      DbUnit atualmente suporta MySQL, PostgreSQL, Oracle e SQLite. Através
       das integrações <ulink url="http://framework.zend.com">Zend Framework</ulink> ou
       <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink>
-      ele tem acesso a outros sistemas como IBM DB2 ou 
+      ele tem acesso a outros sistemas como IBM DB2 ou
       Microsoft SQL Server.
     </para>
   </section>
   <section id="database.difficulties-in-database-testing">
     <title>Dificuldades em Testes de Bancos de Dados</title>
     <para>
-      Existe uma boa razão pela qual todos os exemplos de testes unitários não incluírem 
-      interações com bancos de dados: esses tipos de testes são complexos tanto em 
-      configuração quanto em manutenção. Enquanto testar contra seu banco de dados você 
+      Existe uma boa razão pela qual todos os exemplos de testes unitários não incluírem
+      interações com bancos de dados: esses tipos de testes são complexos tanto em
+      configuração quanto em manutenção. Enquanto testar contra seu banco de dados você
       precisará ter cuidado com as seguintes variáveis:
     </para>
     <itemizedlist>
@@ -81,8 +81,8 @@
       </listitem>
     </itemizedlist>
     <para>
-      Por causa de muitas APIs de bancos de dados como PDO, MySQLi ou OCI8 serem incômodos 
-      de usar e verbosas para escrever, fazer esses passos manualmente é um completo 
+      Por causa de muitas APIs de bancos de dados como PDO, MySQLi ou OCI8 serem incômodos
+      de usar e verbosas para escrever, fazer esses passos manualmente é um completo
       pesadelo.
     </para>
     <para>
@@ -91,24 +91,24 @@
     <itemizedlist>
       <listitem>
         <para>
-          Você não quer modificar uma considerável quantidade de código de teste por 
+          Você não quer modificar uma considerável quantidade de código de teste por
           pequenas mudanças em seu código de produção.
         </para>
       </listitem>
       <listitem>
         <para>
-          Você quer ser capaz de ler e entender o código de teste facilmente, 
+          Você quer ser capaz de ler e entender o código de teste facilmente,
           mesmo meses depois de tê-lo escrito.
         </para>
       </listitem>
     </itemizedlist>
     <para>
-      Adicionalmente você tem que perceber que o banco de dados é essencialmente 
-      uma variável global de entrada para seu código. Dois testes em sua suíte de testes 
-      podem executar contra o mesmo banco de dados, possivelmente reutilizando dados 
-      múltiplas vezes. Falhas em um teste podem facilmente afetar o resultado dos 
-      testes seguintes, fazendo sua experiência com os testes muito difícil. O 
-      passo de limpeza mencionado anteriormente é de maior importância 
+      Adicionalmente você tem que perceber que o banco de dados é essencialmente
+      uma variável global de entrada para seu código. Dois testes em sua suíte de testes
+      podem executar contra o mesmo banco de dados, possivelmente reutilizando dados
+      múltiplas vezes. Falhas em um teste podem facilmente afetar o resultado dos
+      testes seguintes, fazendo sua experiência com os testes muito difícil. O
+      passo de limpeza mencionado anteriormente é de maior importância
       para resolver o problema do <quote>banco de dados ser uma entrada global</quote>.
     </para>
     <para>
@@ -116,26 +116,26 @@
       forma elegante.
     </para>
     <para>
-      O PHPUnit só não pode ajudá-lo no fato de que testes de banco de dados 
-      são muito lentos comparados aos testes que não usam bancos de dados. Dependendo 
-      do tamanho das interações com seu banco de dados, seus testes 
-      podem levar um tempo considerável para executar. Porém se você mantiver pequena 
-      a quantidade de dados usados para cada teste e tentar testar o máximo possível 
-      sem usar testes com bancos de dados, você facilmente conseguirá tempos abaixo de um minuto, 
+      O PHPUnit só não pode ajudá-lo no fato de que testes de banco de dados
+      são muito lentos comparados aos testes que não usam bancos de dados. Dependendo
+      do tamanho das interações com seu banco de dados, seus testes
+      podem levar um tempo considerável para executar. Porém se você mantiver pequena
+      a quantidade de dados usados para cada teste e tentar testar o máximo possível
+      sem usar testes com bancos de dados, você facilmente conseguirá tempos abaixo de um minuto,
       mesmo para grandes suítes de teste.
     </para>
     <para>
-      A suíte de testes do <ulink url="http://www.doctrine-project.org">projeto 
-      Doctrine 2</ulink> por exemplo, atualmente tem uma suíte com 
-      cerca de 1000 testes onde aproximadamente a metade deles tem acesso ao banco 
-      de dados e ainda executa em 15 segundos contra um banco de dados MySQL em 
+      A suíte de testes do <ulink url="http://www.doctrine-project.org">projeto
+      Doctrine 2</ulink> por exemplo, atualmente tem uma suíte com
+      cerca de 1000 testes onde aproximadamente a metade deles tem acesso ao banco
+      de dados e ainda executa em 15 segundos contra um banco de dados MySQL em
       um computador desktop comum.
     </para>
   </section>
   <section id="database.the-four-stages-of-a-database-test">
     <title>Os quatro estágios dos testes com banco de dados</title>
     <para>
-      Em seu livro sobre Padrões de Teste xUnit, Gerard Meszaros lista os quatro 
+      Em seu livro sobre Padrões de Teste xUnit, Gerard Meszaros lista os quatro
       estágios de um teste unitário:
     </para>
     <orderedlist numeration="arabic">
@@ -165,45 +165,45 @@
         <emphasis role="strong">O que é um ambiente (fixture)?</emphasis>
       </para>
       <para>
-        Um ambiente (fixture) descreve o estado inicial em que sua aplicação e seu banco de dados 
+        Um ambiente (fixture) descreve o estado inicial em que sua aplicação e seu banco de dados
         estão ao executar um teste.
       </para>
     </blockquote>
     <para>
-      Testar o banco de dados exige que você utilize pelo menos o 
-      setup (configuração) e teardown (desmontagem) para limpar e escrever em suas tabelas 
-      os dados de ambiente exigidos. Porém a extensão do banco de dados tem uma boa razão para 
-      reverter esses quatro estágios em um teste de banco de dados para assemelhar o seguinte 
+      Testar o banco de dados exige que você utilize pelo menos o
+      setup (configuração) e teardown (desmontagem) para limpar e escrever em suas tabelas
+      os dados de ambiente exigidos. Porém a extensão do banco de dados tem uma boa razão para
+      reverter esses quatro estágios em um teste de banco de dados para assemelhar o seguinte
       fluxo de trabalho que é executado para cada teste:
     </para>
     <section id="database.clean-up-database">
       <title>1. Limpar o Banco de Dados</title>
       <para>
-        Já que sempre existe um primeiro teste que é executado contra o banco de dados, 
-        você não sabe exatamente se já existem dados nas tabelas. 
-        O PHPUnit vai executar um TRUNCATE contra todas as tabelas que 
+        Já que sempre existe um primeiro teste que é executado contra o banco de dados,
+        você não sabe exatamente se já existem dados nas tabelas.
+        O PHPUnit vai executar um TRUNCATE contra todas as tabelas que
         você especificou para redefinir seus estados para vazio.
       </para>
     </section>
     <section id="database.set-up-fixture">
       <title>2. Configurar o ambiente</title>
       <para>
-        O PHPUnit então vai iterar sobre todas as linhas do ambiente especificado e 
+        O PHPUnit então vai iterar sobre todas as linhas do ambiente especificado e
         inseri-las em suas respectivas tabelas.
       </para>
     </section>
     <section id="database.run-test-verify-outcome-and-teardown">
       <title>3–5. Executar Teste, Verificar resultado e Desmontar (Teardown)</title>
       <para>
-        Depois de redefinir o banco de dados e carregá-lo com seu estado inicial, 
-        o verdadeiro teste é executado pelo PHPUnit. Esta parte do código de teste 
-        não exige conhecimento sobre a Extensão do Banco de Dados, então você pode 
+        Depois de redefinir o banco de dados e carregá-lo com seu estado inicial,
+        o verdadeiro teste é executado pelo PHPUnit. Esta parte do código de teste
+        não exige conhecimento sobre a Extensão do Banco de Dados, então você pode
         prosseguir e testar o que quiser com seu código.
       </para>
       <para>
         Em seu teste use uma asserção especial chamada
-        <literal>assertDataSetsEqual()</literal> para fins de verificação, 
-        porém isso é totalmente opcional. Esta função será explicada 
+        <literal>assertDataSetsEqual()</literal> para fins de verificação,
+        porém isso é totalmente opcional. Esta função será explicada
         na seção <quote>Asserções em Bancos de Dados</quote>.
       </para>
     </section>
@@ -211,8 +211,8 @@
   <section id="database.configuration-of-a-phpunit-database-testcase">
     <title>Configuração de um Caso de Teste de Banco de Dados do PHPUnit</title>
     <para>
-      Ao usar o PHPUnit seus casos de teste vão estender a 
-      classe <literal>PHPUnit_Framework_TestCase</literal> da 
+      Ao usar o PHPUnit seus casos de teste vão estender a
+      classe <literal>PHPUnit_Framework_TestCase</literal> da
       seguinte forma:
     </para>
     <programlisting><![CDATA[<?php
@@ -220,13 +220,13 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
     <para>
-      Se você quer um código de teste que trabalha com a Extensão para Banco de Dados a 
-      configuração é um pouco mais complexa e você terá que estender um TestCase abstrato 
+      Se você quer um código de teste que trabalha com a Extensão para Banco de Dados a
+      configuração é um pouco mais complexa e você terá que estender um TestCase abstrato
       diferente, exigindo que você implemente dois métodos abstratos
       <literal>getConnection()</literal> e
       <literal>getDataSet()</literal>:
@@ -255,65 +255,65 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.implementing-getconnection">
       <title>Implementando getConnection()</title>
       <para>
-        Para permitir que a limpeza e o carregamento de funcionalidades do ambiente funcionem, 
-        a Extensão do Banco de Dados do PHPUnit exige acesso a uma conexão 
-        abstrata do banco de dados através dos fornecedores da biblioteca PDO. É 
-        importante notar que sua aplicação não precisa ser 
-        baseada em PDO para usar a Extensão para Banco de Dados do PHPUnit, pois a conexão é 
+        Para permitir que a limpeza e o carregamento de funcionalidades do ambiente funcionem,
+        a Extensão do Banco de Dados do PHPUnit exige acesso a uma conexão
+        abstrata do banco de dados através dos fornecedores da biblioteca PDO. É
+        importante notar que sua aplicação não precisa ser
+        baseada em PDO para usar a Extensão para Banco de Dados do PHPUnit, pois a conexão é
         meramente usada para limpeza e configuração de ambiente.
       </para>
       <para>
-        No exemplo anterior criamos uma conexão Sqlite na memória e 
+        No exemplo anterior criamos uma conexão Sqlite na memória e
         a passamos ao método <literal>createDefaultDBConnection</literal>
-        que embrulha a instância do PDO e o segundo parâmetro (o 
-        nome do banco de dados) em uma camada simples de abstração para conexões 
+        que embrulha a instância do PDO e o segundo parâmetro (o
+        nome do banco de dados) em uma camada simples de abstração para conexões
         do banco de dados do tipo
         <literal>PHPUnit_Extensions_Database_DB_IDatabaseConnection</literal>.
       </para>
       <para>
-        A seção <quote>Usando a Conexão de Banco de Dados</quote> explica 
+        A seção <quote>Usando a Conexão de Banco de Dados</quote> explica
         a API desta interface e como você pode usá-la da melhor forma possível.
       </para>
     </section>
     <section id="database.implementing-getdataset">
       <title>Implementando getDataSet()</title>
       <para>
-        O método <literal>getDataSet()</literal> define como deve ser o estado 
-        inicial do banco de dados antes de cada teste ser 
-        executado. O estado do banco de dados é abstraído através de 
-        conceitos DataSet (Conjunto de Dados) e DataTable (Tabela de Dados), ambos sendo representados 
+        O método <literal>getDataSet()</literal> define como deve ser o estado
+        inicial do banco de dados antes de cada teste ser
+        executado. O estado do banco de dados é abstraído através de
+        conceitos DataSet (Conjunto de Dados) e DataTable (Tabela de Dados), ambos sendo representados
         pelas interfaces
         <literal>PHPUnit_Extensions_Database_DataSet_IDataSet</literal> e
         <literal>PHPUnit_Extensions_Database_DataSet_IDataTable</literal>.
-        A próxima seção vai descrever em detalhes como esses conceitos trabalham 
+        A próxima seção vai descrever em detalhes como esses conceitos trabalham
         e quais os benefícios de usá-los nos testes com bancos de dados.
       </para>
       <para>
-        Para a implementação precisaremos apenas saber que o 
+        Para a implementação precisaremos apenas saber que o
         método <literal>getDataSet()</literal> é chamado uma vez durante o
-        <literal>setUp()</literal> para recuperar o conjunto de dados do ambiente e 
-        inseri-lo no banco de dados. No exemplo estamos usando um método de fábrica 
-        <literal>createFlatXMLDataSet($filename)</literal> que 
+        <literal>setUp()</literal> para recuperar o conjunto de dados do ambiente e
+        inseri-lo no banco de dados. No exemplo estamos usando um método de fábrica
+        <literal>createFlatXMLDataSet($filename)</literal> que
         representa um conjunto de dados através de uma representação XML.
       </para>
     </section>
     <section id="database.what-about-the-database-schema-ddl">
       <title>E quanto ao Esquema do Banco de Dados (DDL)?</title>
       <para>
-        O PHPUnit assume que o esquema do banco de dados com todas as suas tabelas, 
-        gatilhos, sequências e visualizações é criado antes que um teste seja executado. Isso 
-        quer dizer que você como desenvolvedor deve se certificar que o banco de dados está 
+        O PHPUnit assume que o esquema do banco de dados com todas as suas tabelas,
+        gatilhos, sequências e visualizações é criado antes que um teste seja executado. Isso
+        quer dizer que você como desenvolvedor deve se certificar que o banco de dados está
         corretamente configurado antes de executar a suíte.
       </para>
       <para>
-        Existem vários meios para realizar esta pré-condição para 
+        Existem vários meios para realizar esta pré-condição para
         testar bancos de dados.
       </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Se você está usando um banco de dados persistente (não Sqlite Memory) você pode 
-            facilmente configurar o banco de dados uma vez com ferramentas como phpMyAdmin para 
+            Se você está usando um banco de dados persistente (não Sqlite Memory) você pode
+            facilmente configurar o banco de dados uma vez com ferramentas como phpMyAdmin para
             MySQL e reutilizar o banco de dados para cada execução de teste.
           </para>
         </listitem>
@@ -322,8 +322,8 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
             Se você estiver usando bibliotecas como
             <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink> ou
             <ulink url="http://www.propelorm.org/">Propel</ulink>
-            você pode usar suas APIs para criar o esquema de banco de dados que 
-            precisa antes de rodar os testes. Você pode utilizar as capacidades de 
+            você pode usar suas APIs para criar o esquema de banco de dados que
+            precisa antes de rodar os testes. Você pode utilizar as capacidades de
             <ulink url="textui.html">Configuração e Bootstrap do PHPUnit</ulink>
             para executar esse código sempre que seus testes forem executados.
           </para>
@@ -333,12 +333,12 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.tip-use-your-own-abstract-database-testcase">
       <title>Dica: Use seu próprio Caso Abstrato de Teste de Banco de Dados</title>
       <para>
-        Do exemplo prévio de implementação você pode facilmente perceber que 
-        o método <literal>getConnection()</literal> é bastante estático e 
-        pode ser reutilizado em diferentes casos de teste de banco de dados. Adicionalmente para 
-        manter uma boa performance dos seus testes e pouca carga sobre seu banco de dados, você 
-        pode refatorar o código um pouco para obter um caso de teste abstrato genérico 
-        para sua aplicação, o que ainda permite a você especificar um 
+        Do exemplo prévio de implementação você pode facilmente perceber que
+        o método <literal>getConnection()</literal> é bastante estático e
+        pode ser reutilizado em diferentes casos de teste de banco de dados. Adicionalmente para
+        manter uma boa performance dos seus testes e pouca carga sobre seu banco de dados, você
+        pode refatorar o código um pouco para obter um caso de teste abstrato genérico
+        para sua aplicação, o que ainda permite a você especificar um
         ambiente de dados diferente para cada caso de teste:
       </para>
       <programlisting><![CDATA[<?php
@@ -364,12 +364,12 @@ abstract class MyApp_Tests_DatabaseTestCase extends PHPUnit_Extensions_Database_
 }
 ?>]]></programlisting>
       <para>
-        Entretanto, isso tem a conexão ao banco de dados codificada na conexão do PDO. 
-        O PHPUnit tem outra incrível característica que pode fazer este 
+        Entretanto, isso tem a conexão ao banco de dados codificada na conexão do PDO.
+        O PHPUnit tem outra incrível característica que pode fazer este
         caso de teste ainda mais genérico. Se você usar a
         <ulink url="appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">Configuração XML</ulink>
-        você pode tornar a conexão com o banco de dados configurável por execução de teste. 
-        Primeiro vamos criar um arquivo <quote>phpunit.xml</quote> em nosso diretório/de/teste 
+        você pode tornar a conexão com o banco de dados configurável por execução de teste.
+        Primeiro vamos criar um arquivo <quote>phpunit.xml</quote> em nosso diretório/de/teste
         da aplicação, de forma semelhante a isto:
       </para>
       <screen><![CDATA[
@@ -409,16 +409,16 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 }
 ?>]]></programlisting>
       <para>
-        Agora podemos executar a suíte de testes de banco de dados usando diferentes 
+        Agora podemos executar a suíte de testes de banco de dados usando diferentes
         configurações através da interface de linha-de-comando:
       </para>
       <screen><userinput>user@desktop> phpunit --configuration developer-a.xml MyTests/</userinput>
 <userinput>user@desktop> phpunit --configuration developer-b.xml MyTests/</userinput></screen>
       <para>
-        A possibilidade de executar facilmente os testes de banco de dados contra diferentes 
-        alvos é muito importante se você está desenvolvendo na 
-        máquina de desenvolvimento. Se vários desenvolvedores executarem os testes de banco 
-        de dados contra a mesma conexão de banco de dados você experimentará facilmente 
+        A possibilidade de executar facilmente os testes de banco de dados contra diferentes
+        alvos é muito importante se você está desenvolvendo na
+        máquina de desenvolvimento. Se vários desenvolvedores executarem os testes de banco
+        de dados contra a mesma conexão de banco de dados você experimentará facilmente
         falhas de testes devido à condição de execução.
       </para>
     </section>
@@ -426,36 +426,36 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
   <section id="database.understanding-datasets-and-datatables">
     <title>Entendendo Conjunto de Dados e Tabelas de Dados</title>
     <para>
-      Um conceito central da Extensão para Banco de Dados do PHPUnit são 
-      os Conjuntos de Dados e as Tabelas de Dados. Você deveria tentar entender este conceito simples para 
-      dominar os testes de banco de dados com PHPUnit. Conjunto de Dados e Tabela de Dados formam 
-      uma camada abstrata em torno das tabelas, linhas e 
-      colunas do seu banco de dados. Uma simples API esconde os conteúdos subjacentes do banco de dados em uma 
-      estrutura de objetos, que também podem ser implementada por outra 
+      Um conceito central da Extensão para Banco de Dados do PHPUnit são
+      os Conjuntos de Dados e as Tabelas de Dados. Você deveria tentar entender este conceito simples para
+      dominar os testes de banco de dados com PHPUnit. Conjunto de Dados e Tabela de Dados formam
+      uma camada abstrata em torno das tabelas, linhas e
+      colunas do seu banco de dados. Uma simples API esconde os conteúdos subjacentes do banco de dados em uma
+      estrutura de objetos, que também podem ser implementada por outra
       fonte que não seja um banco de dados.
     </para>
     <para>
-      Essa abstração é necessária para comparar os conteúdos reais de um 
-      banco de dados contra os conteúdos esperados. Expectativas podem ser 
-      representadas como arquivos XML, YAML, CSV ou vetores PHP, por exemplo. As 
-      interfaces DataSet (Conjunto de Dados) e DataTable (Tabela de Dados)  permitem a comparação dessas 
-      fontes conceitualmente diferentes, emulando o armazenamento de banco de dados 
+      Essa abstração é necessária para comparar os conteúdos reais de um
+      banco de dados contra os conteúdos esperados. Expectativas podem ser
+      representadas como arquivos XML, YAML, CSV ou vetores PHP, por exemplo. As
+      interfaces DataSet (Conjunto de Dados) e DataTable (Tabela de Dados)  permitem a comparação dessas
+      fontes conceitualmente diferentes, emulando o armazenamento de banco de dados
       relacional em uma abordagem semanticamente similar.
     </para>
     <para>
-      Um fluxo de trabalho para asserções em banco de dados em seus testes então consiste de 
+      Um fluxo de trabalho para asserções em banco de dados em seus testes então consiste de
       três passos simples:
     </para>
     <itemizedlist>
       <listitem>
         <para>
-          Especificar uma ou mais tabelas em seu banco de dados por nome de tabela (conjunto de dados 
+          Especificar uma ou mais tabelas em seu banco de dados por nome de tabela (conjunto de dados
           real)
         </para>
       </listitem>
       <listitem>
         <para>
-          Especificar o Conjunto de Dados esperado no seu formato preferido (YAML, XML, 
+          Especificar o Conjunto de Dados esperado no seu formato preferido (YAML, XML,
           ...)
         </para>
       </listitem>
@@ -466,10 +466,10 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
       </listitem>
     </itemizedlist>
     <para>
-      Asserções não são o único caso de uso para o Conjunto de Dados e a Tabela de Dados 
-      na Extensão para Banco de Dados do PHPUnit. Como mostrado na seção anterior, 
-      eles também descrevem os conteúdos iniciais de um banco de dados. Você é 
-      forçado a definir um conjunto de dados de ambiente pelo Caso de Teste de Banco de Dados, que 
+      Asserções não são o único caso de uso para o Conjunto de Dados e a Tabela de Dados
+      na Extensão para Banco de Dados do PHPUnit. Como mostrado na seção anterior,
+      eles também descrevem os conteúdos iniciais de um banco de dados. Você é
+      forçado a definir um conjunto de dados de ambiente pelo Caso de Teste de Banco de Dados, que
       então é usado para:
     </para>
     <itemizedlist>
@@ -507,17 +507,17 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
         </listitem>
       </itemizedlist>
       <para>
-        Os Conjuntos de Dados e Tabelas de Dados baseadas em arquivo são geralmente usados para o 
+        Os Conjuntos de Dados e Tabelas de Dados baseadas em arquivo são geralmente usados para o
         ambiente inicial e para descrever os estados esperados do banco de dados.
       </para>
       <section id="database.flat-xml-dataset">
         <title>Conjunto de Dados de XML Plano</title>
         <para>
-          O Conjunto de Dados mais comum é chamado XML Plano. É um formato xml simples 
+          O Conjunto de Dados mais comum é chamado XML Plano. É um formato xml simples
           onde uma tag dentro do nó-raiz
-          <literal><![CDATA[<dataset>]]></literal> representa exatamente uma linha no 
-          banco de dados. Os nomes das tags equivalem à tabela onde inserir a linha e 
-          um atributo representa a coluna. Um exemplo para uma simples aplicação de 
+          <literal><![CDATA[<dataset>]]></literal> representa exatamente uma linha no
+          banco de dados. Os nomes das tags equivalem à tabela onde inserir a linha e
+          um atributo representa a coluna. Um exemplo para uma simples aplicação de
           livro de visitas poderia se parecer com isto:
         </para>
         <screen><![CDATA[
@@ -529,7 +529,7 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 ]]></screen>
         <para>
           Isso é, obviamente, fácil de escrever. Aqui
-          <literal><![CDATA[<guestbook>]]></literal> é o nome da tabela onde duas linhas 
+          <literal><![CDATA[<guestbook>]]></literal> é o nome da tabela onde duas linhas
           são inseridas dentro de cada com quatro colunas <quote>id</quote>,
           <quote>content</quote>, <quote>user</quote> e
           <quote>created</quote> com seus respectivos valores.
@@ -538,9 +538,9 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
           Porém essa simplicidade tem um preço.
         </para>
         <para>
-          O exemplo anterior não deixa tão óbvio como você pode fazer para especificar uma 
-          tabela vazia. Você pode inserir uma tag sem atributos com o nome da 
-          tabela vazia. Um arquivo xml plano para uma tabela vazia do livro de visitas 
+          O exemplo anterior não deixa tão óbvio como você pode fazer para especificar uma
+          tabela vazia. Você pode inserir uma tag sem atributos com o nome da
+          tabela vazia. Um arquivo xml plano para uma tabela vazia do livro de visitas
           ficaria parecido com isso:
         </para>
         <screen><![CDATA[
@@ -550,13 +550,13 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 </dataset>
 ]]></screen>
         <para>
-          A manipulação de valores NULL com o xml plano é tedioso. Um 
-          valor NULL é diferente de uma string com valor vazio em quase todos 
-          os bancos de dados (Oracle é uma exceção), algo difícil 
-          de descrever no formato xml plano. Você pode representar um valor NULL 
-          omitindo o atributo da especificação da linha. Se nosso 
-          livro de visitas vai permitir entradas anônimas representadas por um valor NULL 
-          na coluna user, um estado hipotético para a tabela do livro de visitas 
+          A manipulação de valores NULL com o xml plano é tedioso. Um
+          valor NULL é diferente de uma string com valor vazio em quase todos
+          os bancos de dados (Oracle é uma exceção), algo difícil
+          de descrever no formato xml plano. Você pode representar um valor NULL
+          omitindo o atributo da especificação da linha. Se nosso
+          livro de visitas vai permitir entradas anônimas representadas por um valor NULL
+          na coluna user, um estado hipotético para a tabela do livro de visitas
           seria parecido com:
         </para>
         <screen><![CDATA[
@@ -567,47 +567,47 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 </dataset>
 ]]></screen>
         <para>
-          Nesse caso a segunda entrada é postada anonimamente. Porém isso 
-          acarreta um problema sério no reconhecimento de colunas. Durante as asserções de igualdade 
-          do conjunto de dados, cada conjunto de dados tem que especificar quais colunas uma 
-          tabela possui. Se um atributo for NULL para todas as linhas de uma 
-          tabela de dados, como a Extensão para Banco de Dados vai saber que a coluna 
+          Nesse caso a segunda entrada é postada anonimamente. Porém isso
+          acarreta um problema sério no reconhecimento de colunas. Durante as asserções de igualdade
+          do conjunto de dados, cada conjunto de dados tem que especificar quais colunas uma
+          tabela possui. Se um atributo for NULL para todas as linhas de uma
+          tabela de dados, como a Extensão para Banco de Dados vai saber que a coluna
           deve ser parte da tabela?
         </para>
         <para>
-          O conjunto de dados em xml plano faz uma presunção crucial agora, definindo que 
-          os atributos na primeira linha definida de uma tabela define as 
+          O conjunto de dados em xml plano faz uma presunção crucial agora, definindo que
+          os atributos na primeira linha definida de uma tabela define as
           colunas dessa tabela. No exemplo anterior isso significaria que
           <quote>id</quote>, <quote>content</quote>, <quote>user</quote> e
-          <quote>created</quote> são colunas da tabela guestbook. Para a 
-          segunda linha, onde <quote>user</quote> não está definido, um NULL seria 
+          <quote>created</quote> são colunas da tabela guestbook. Para a
+          segunda linha, onde <quote>user</quote> não está definido, um NULL seria
           inserido no banco de dados.
         </para>
         <para>
           Quando a primeira entrada do guestbook for apagada do conjunto de dados, apenas
           <quote>id</quote>, <quote>content</quote> e
-          <quote>created</quote> seriam colunas da tabela guestbook, 
+          <quote>created</quote> seriam colunas da tabela guestbook,
           já que <quote>user</quote> não é especificado.
         </para>
         <para>
-          Para usar o Conjunto de Dados em XML Plano efetivamente, quando valores NULL forem 
-          relevantes, a primeira linha de cada tabela não deve conter qualquer valor NULL 
-          e apenas as linhas seguintes poderão omitir atributos. Isso 
-          pode parecer estranho, já que a ordem das linhas é um fator relevante 
+          Para usar o Conjunto de Dados em XML Plano efetivamente, quando valores NULL forem
+          relevantes, a primeira linha de cada tabela não deve conter qualquer valor NULL
+          e apenas as linhas seguintes poderão omitir atributos. Isso
+          pode parecer estranho, já que a ordem das linhas é um fator relevante
           para as asserções com bancos de dados.
         </para>
         <para>
-          Em troca, se você especificar apenas um subconjunto das colunas da tabela no 
-          Conjunto de Dados do XML Plano, todos os valores omitidos serão definidos para seus valores 
-          padrão. Isso vai induzir a erros se uma das colunas omitidas estiver 
+          Em troca, se você especificar apenas um subconjunto das colunas da tabela no
+          Conjunto de Dados do XML Plano, todos os valores omitidos serão definidos para seus valores
+          padrão. Isso vai induzir a erros se uma das colunas omitidas estiver
           definida como <quote>NOT NULL DEFAULT NULL</quote>.
         </para>
         <para>
-          Para concluir eu posso dizer que os conjuntos de dados XML Plano só devem ser usadas se você 
+          Para concluir eu posso dizer que os conjuntos de dados XML Plano só devem ser usadas se você
           não precisar de valores NULL.
         </para>
         <para>
-          Você pode criar uma instância de conjunto de dados xml plano de dentro de seu 
+          Você pode criar uma instância de conjunto de dados xml plano de dentro de seu
           Caso de Teste de Banco de Dados chamando o método
           <literal>createFlatXmlDataSet($filename)</literal>:
         </para>
@@ -624,13 +624,13 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
       <section id="database.xml-dataset">
         <title>Conjunto de Dados XML</title>
         <para>
-          Existe um outro Conjunto de Dados em XML mais estruturado, que é um pouco mais 
-          verboso para escrever mas evita os problemas do NULL nos conjuntos de dados em 
-          XML Plano. Dentro do nó-raiz <literal><![CDATA[<dataset>]]></literal> você 
+          Existe um outro Conjunto de Dados em XML mais estruturado, que é um pouco mais
+          verboso para escrever mas evita os problemas do NULL nos conjuntos de dados em
+          XML Plano. Dentro do nó-raiz <literal><![CDATA[<dataset>]]></literal> você
           pode especificar as tags <literal><![CDATA[<table>]]></literal>,
           <literal><![CDATA[<column>]]></literal>, <literal><![CDATA[<row>]]></literal>,
           <literal><![CDATA[<value>]]></literal> e
-          <literal><![CDATA[<null />]]></literal>. Um Conjunto de Dados equivalente ao 
+          <literal><![CDATA[<null />]]></literal>. Um Conjunto de Dados equivalente ao
           definido anteriormente no Guestbook em XML Plano seria como:
         </para>
         <screen><![CDATA[
@@ -657,19 +657,19 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
 </dataset>
 ]]></screen>
         <para>
-          Qualquer <literal><![CDATA[<table>]]></literal> definida tem um nome e requer 
-          uma definição de todas as colunas com seus nomes. Pode conter zero 
-          ou qualquer número positivo de elementos <literal><![CDATA[<row>]]></literal> 
-          aninhados. Não definir nenhum elemento <literal><![CDATA[<row>]]></literal> significa 
+          Qualquer <literal><![CDATA[<table>]]></literal> definida tem um nome e requer
+          uma definição de todas as colunas com seus nomes. Pode conter zero
+          ou qualquer número positivo de elementos <literal><![CDATA[<row>]]></literal>
+          aninhados. Não definir nenhum elemento <literal><![CDATA[<row>]]></literal> significa
           que a tabela está vazia. As tags <literal><![CDATA[<value>]]></literal> e
-          <literal><![CDATA[<null />]]></literal> têm que ser especificadas na 
-          ordem dos elementos fornecidos previamente em 
-          <literal><![CDATA[<column>]]></literal>. A tag <literal><![CDATA[<null />]]></literal> obviamente significa 
+          <literal><![CDATA[<null />]]></literal> têm que ser especificadas na
+          ordem dos elementos fornecidos previamente em
+          <literal><![CDATA[<column>]]></literal>. A tag <literal><![CDATA[<null />]]></literal> obviamente significa
           que o valor é NULL.
         </para>
         <para>
-          Você pode criar uma instância de conjunto de dados xml de dentro de seu 
-          Caso de Teste de Banco de Dados chamando o método 
+          Você pode criar uma instância de conjunto de dados xml de dentro de seu
+          Caso de Teste de Banco de Dados chamando o método
           <literal>createXmlDataSet($filename)</literal>:
         </para>
         <programlisting><![CDATA[<?php
@@ -687,12 +687,12 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
         <para>
           Este novo formato XML é específico para o
           <ulink url="http://www.mysql.com">servidor de banco de dados MySQL</ulink>.
-          O suporte para ele foi adicionado no PHPUnit 3.5. Arquivos nesse formato podem 
-          ser gerados usando o utilitário 
-          <ulink url="http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html"><literal>mysqldump</literal></ulink>. 
+          O suporte para ele foi adicionado no PHPUnit 3.5. Arquivos nesse formato podem
+          ser gerados usando o utilitário
+          <ulink url="http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html"><literal>mysqldump</literal></ulink>.
           Diferente dos conjuntos de dados CSV, que o <literal>mysqldump</literal>
-          também suporta, um único arquivo neste formato XML pode conter dados 
-          para múltiplas tabelas. Você pode criar um arquivo nesse formato 
+          também suporta, um único arquivo neste formato XML pode conter dados
+          para múltiplas tabelas. Você pode criar um arquivo nesse formato
           invocando o <literal>mysqldump</literal> desta forma:
         </para>
         <screen><userinput>mysqldump --xml -t -u [username] --password=[password] [database] > /path/to/file.xml</userinput></screen>
@@ -729,13 +729,13 @@ guestbook:
     created: 2010-04-26 12:14:20
 ]]></screen>
         <para>
-          Isso é simples, conveniente E resolve o problema do NULL que o 
-          Conjunto de Dados similar do XML Plano tem. Um NULL em um YAML é apenas o nome 
+          Isso é simples, conveniente E resolve o problema do NULL que o
+          Conjunto de Dados similar do XML Plano tem. Um NULL em um YAML é apenas o nome
           da coluna sem nenhum valor especificado. Uma string vazia é especificada como
           <literal><![CDATA[column1: ""]]></literal>.
         </para>
         <para>
-          O Conjunto de Dados YAML atualmente não possui método fábrica no Caso de Teste 
+          O Conjunto de Dados YAML atualmente não possui método fábrica no Caso de Teste
           de Banco de Dados, então você tem que instanciar manualmente:
         </para>
         <programlisting><![CDATA[<?php
@@ -753,8 +753,8 @@ class YamlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.csv-dataset">
         <title>Conjunto de Dados CSV</title>
         <para>
-          Outro Conjunto de Dados baseado em arquivo, com arquivos CSV. Cada tabela do 
-          conjunto de dados é representada como um único arquivo CSV. Para nosso exemplo 
+          Outro Conjunto de Dados baseado em arquivo, com arquivos CSV. Cada tabela do
+          conjunto de dados é representada como um único arquivo CSV. Para nosso exemplo
           do guestbook, vamos definir um arquivo guestbook-table.csv:
         </para>
         <screen><![CDATA[
@@ -763,9 +763,9 @@ id,content,user,created
 2,"I like it!","nancy","2010-04-26 12:14:20"
 ]]></screen>
         <para>
-          Apesar disso ser muito conveniente para edição no Excel ou OpenOffice, 
-          você não pode especificar valores NULL em um Conjunto de Dados CSV. Uma coluna 
-          vazia levaria a um valor vazio padrão de banco de dados a ser inserido 
+          Apesar disso ser muito conveniente para edição no Excel ou OpenOffice,
+          você não pode especificar valores NULL em um Conjunto de Dados CSV. Uma coluna
+          vazia levaria a um valor vazio padrão de banco de dados a ser inserido
           na coluna.
         </para>
         <para>
@@ -786,8 +786,8 @@ class CsvGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.array-dataset">
         <title>Conjunto de Dados em Vetor</title>
         <para>
-          Desde a versão 1.3.2 da Extensão de Banco de dados do PHPUnit há um array 
-          baseado em Conjunto de dados. Nosso exemplo do guestbook 
+          Desde a versão 1.3.2 da Extensão de Banco de dados do PHPUnit há um array
+          baseado em Conjunto de dados. Nosso exemplo do guestbook
           deveria ficar parecido com:
         </para>
         <programlisting><![CDATA[<?php
@@ -805,7 +805,7 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
 }
 ?>]]></programlisting>
         <para>
-          Um Conjunto de Dados do PHP tem algumas vantagens óbvias sobre todas os outros 
+          Um Conjunto de Dados do PHP tem algumas vantagens óbvias sobre todas os outros
           conjuntos de dados baseados em arquivos:
         </para>
         <itemizedlist>
@@ -816,14 +816,14 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
           </listitem>
           <listitem>
             <para>
-              Você não precisa de arquivos adicionais para asserções e pode especificá-las diretamente 
+              Você não precisa de arquivos adicionais para asserções e pode especificá-las diretamente
               no Caso de Teste.
             </para>
           </listitem>
         </itemizedlist>
         <para>
-          Para este Conjunto de Dados, como nos Conjuntos de Dados em XML Plano, CSV e YAML, as chaves 
-          da primeira linha especificada definem os nomes das colunas das tabelas, que no 
+          Para este Conjunto de Dados, como nos Conjuntos de Dados em XML Plano, CSV e YAML, as chaves
+          da primeira linha especificada definem os nomes das colunas das tabelas, que no
           caso anterior seriam <quote>id</quote>,
           <quote>content</quote>, <quote>user</quote> e
           <quote>created</quote>.
@@ -832,8 +832,8 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.query-sql-dataset">
         <title>Conjunto de Dados Query (SQL)</title>
         <para>
-          Para asserções de banco de dados você não precisa somente de conjuntos de dados baseados em arquivos, 
-          mas também de conjuntos de dados baseados em Query/SQL que contenha os conteúdos 
+          Para asserções de banco de dados você não precisa somente de conjuntos de dados baseados em arquivos,
+          mas também de conjuntos de dados baseados em Query/SQL que contenha os conteúdos
           reais do banco de dados. É aí que entra o Query DataSet:
         </para>
         <programlisting><![CDATA[<?php
@@ -841,7 +841,7 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook');
 ?>]]></programlisting>
         <para>
-          Adicionar uma tabela apenas por nome é um modo implícito de definir a 
+          Adicionar uma tabela apenas por nome é um modo implícito de definir a
           tabela de dados com a seguinte query:
         </para>
         <programlisting><![CDATA[<?php
@@ -849,8 +849,8 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook', 'SELECT * FROM guestbook');
 ?>]]></programlisting>
         <para>
-          Você pode fazer uso disso especificando queries arbitrárias para suas 
-          tabelas, por exemplo restringindo linhas, colunas, ou adicionando 
+          Você pode fazer uso disso especificando queries arbitrárias para suas
+          tabelas, por exemplo restringindo linhas, colunas, ou adicionando
           cláusulas <literal>ORDER BY</literal>:
         </para>
         <programlisting><![CDATA[<?php
@@ -858,22 +858,22 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook', 'SELECT id, content FROM guestbook ORDER BY created DESC');
 ?>]]></programlisting>
         <para>
-          A seção nas Asserções de Banco de Dados mostrará mais alguns detalhes sobre 
+          A seção nas Asserções de Banco de Dados mostrará mais alguns detalhes sobre
           como fazer uso do Conjunto de Dados Query.
         </para>
       </section>
       <section id="database.database-db-dataset">
         <title>Conjunto de Dados de Banco de Dados (BD)</title>
         <para>
-          Acessando a Conexão de Teste você pode criar automaticamente um 
-          Conjunto de Dados que consiste de todas as tabelas com seus conteúdos no 
-          banco de dados especificado como segundo parâmetro ao método 
+          Acessando a Conexão de Teste você pode criar automaticamente um
+          Conjunto de Dados que consiste de todas as tabelas com seus conteúdos no
+          banco de dados especificado como segundo parâmetro ao método
           Fábrica de Conexões.
         </para>
         <para>
-          Você pode tanto criar um Conjunto de Dados para todo o banco de dados como mostrado 
-          em  <literal>testGuestbook()</literal>, ou restringi-lo a um conjunto de 
-          nomes específicos de tabelas com uma lista branca, como mostrado no 
+          Você pode tanto criar um Conjunto de Dados para todo o banco de dados como mostrado
+          em  <literal>testGuestbook()</literal>, ou restringi-lo a um conjunto de
+          nomes específicos de tabelas com uma lista branca, como mostrado no
           método <literal>testFilteredGuestbook()</literal>.
         </para>
         <programlisting><![CDATA[<?php
@@ -909,14 +909,14 @@ class MySqlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.replacement-dataset">
         <title>Conjunto de Dados de Reposição</title>
         <para>
-          Eu tenho falado sobre problemas com NULL nos Conjunto de Dados XML Plano e 
-          CSV, mas existe uma alternativa um pouco complicada para fazer ambos 
+          Eu tenho falado sobre problemas com NULL nos Conjunto de Dados XML Plano e
+          CSV, mas existe uma alternativa um pouco complicada para fazer ambos
           funcionarem com NULLs.
         </para>
         <para>
-          O Conjunto de Dados de Reposição é um decorador para um Conjunto de Dados existente e 
-          permite que você substitua valores em qualquer coluna do conjunto de dados por outro 
-          valor de reposição. Para fazer nosso exemplo do guestbook funcionar com valores NULL 
+          O Conjunto de Dados de Reposição é um decorador para um Conjunto de Dados existente e
+          permite que você substitua valores em qualquer coluna do conjunto de dados por outro
+          valor de reposição. Para fazer nosso exemplo do guestbook funcionar com valores NULL
           devemos especificar o arquivo como:
         </para>
         <screen><![CDATA[
@@ -945,9 +945,9 @@ class ReplacementTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.dataset-filter">
         <title>Filtro de Conjunto de Dados</title>
         <para>
-          Se você tiver um arquivo grande de ambiente você pode usar o Filtro de Conjunto de Dados para 
-          as listas branca e negra das tabelas e colunas que deveriam estar 
-          contidas em um sub-conjunto de dados. Isso ajuda especialmente em combinação 
+          Se você tiver um arquivo grande de ambiente você pode usar o Filtro de Conjunto de Dados para
+          as listas branca e negra das tabelas e colunas que deveriam estar
+          contidas em um sub-conjunto de dados. Isso ajuda especialmente em combinação
           com o DB DataSet para filtrar as colunas dos conjuntos de dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -978,9 +978,9 @@ class DataSetFilterTest extends PHPUnit_Extensions_Database_TestCase
 ?>]]></programlisting>
         <blockquote>
           <para>
-            <emphasis role="strong">NOTA</emphasis> Você não pode usar ambos os 
-            filtros de coluna excluir e incluir na mesma tabela, apenas em tabelas 
-            diferentes. E mais: só é possível para a lista branca ou negra, 
+            <emphasis role="strong">NOTA</emphasis> Você não pode usar ambos os
+            filtros de coluna excluir e incluir na mesma tabela, apenas em tabelas
+            diferentes. E mais: só é possível para a lista branca ou negra,
             mas não para ambas.
           </para>
         </blockquote>
@@ -988,9 +988,9 @@ class DataSetFilterTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.composite-dataset">
         <title>Conjunto de Dados Composto</title>
         <para>
-          O Conjunto de Dados composto é muito útil para agregar vários 
-          conjuntos de dados já existentes em um único Conjunto de Dados. Quando vários 
-          conjuntos de dados contém as mesmas tabelas, as linhas são anexadas na 
+          O Conjunto de Dados composto é muito útil para agregar vários
+          conjuntos de dados já existentes em um único Conjunto de Dados. Quando vários
+          conjuntos de dados contém as mesmas tabelas, as linhas são anexadas na
           ordem especificada. Por exemplo se tivermos dois conjuntos de dados
           <emphasis>fixture1.xml</emphasis>:
         </para>
@@ -1033,18 +1033,18 @@ class CompositeTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.beware-of-foreign-keys">
       <title>Cuidado com Chaves Estrangeiras</title>
       <para>
-        Durante a Configuração do Ambiente a Extensão para Banco de Dados do PHPUnit insere as linhas 
-        no banco de dados na ordem que são especificadas em seu ambiente. 
-        Se seu esquema de banco de dados usa chaves estrangeiras isso significa que você tem que 
-        especificar as tabelas em uma ordem que não faça as restrições das chaves estrangeiras 
+        Durante a Configuração do Ambiente a Extensão para Banco de Dados do PHPUnit insere as linhas
+        no banco de dados na ordem que são especificadas em seu ambiente.
+        Se seu esquema de banco de dados usa chaves estrangeiras isso significa que você tem que
+        especificar as tabelas em uma ordem que não faça as restrições das chaves estrangeiras
         falharem.
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
       <title>Implementando seus próprios Conjuntos de Dados/ Tabelas de Dados</title>
       <para>
-        Para entender os interiores dos Conjuntos de Dados e Tabelas de Dados, vamos dar uma 
-        olhada na interface de um Conjunto de Dados. Você pode pular esta parte se você 
+        Para entender os interiores dos Conjuntos de Dados e Tabelas de Dados, vamos dar uma
+        olhada na interface de um Conjunto de Dados. Você pode pular esta parte se você
         não planeja implementar seu próprio Conjunto de Dados ou Tabela de Dados.
       </para>
       <programlisting><![CDATA[<?php
@@ -1060,18 +1060,18 @@ interface PHPUnit_Extensions_Database_DataSet_IDataSet extends IteratorAggregate
 ?>]]></programlisting>
       <para>
         A interface pública é usada internamente pela asserção
-        <literal>assertDataSetsEqual()</literal> no Caso de Teste de 
+        <literal>assertDataSetsEqual()</literal> no Caso de Teste de
         Banco de Dados para verificar a qualidade do conjunto de dados. Da interface
-        <literal>IteratorAggregate</literal> o IDataSet 
-        herda o método <literal>getIterator()</literal> para iterar 
-        sobre todas as tabelas do conjunto de dados. O iterador reverso permite o PHPUnit 
-        truncar corretamente as tabelas em ordem reversa à que foi criada para satisfazer 
+        <literal>IteratorAggregate</literal> o IDataSet
+        herda o método <literal>getIterator()</literal> para iterar
+        sobre todas as tabelas do conjunto de dados. O iterador reverso permite o PHPUnit
+        truncar corretamente as tabelas em ordem reversa à que foi criada para satisfazer
         as restrições de chaves estrangeiras.
       </para>
       <para>
-        Dependendo da implementação, diferentes abordagens são usadas para 
-        adicionar instâncias de tabela a um Conjunto de Dados. Por exemplo, tabelas são adicionadas 
-        internamente durante a construção a partir de um arquivo fonte em todos 
+        Dependendo da implementação, diferentes abordagens são usadas para
+        adicionar instâncias de tabela a um Conjunto de Dados. Por exemplo, tabelas são adicionadas
+        internamente durante a construção a partir de um arquivo fonte em todos
         os conjuntos de dados baseados em arquivo como <literal>YamlDataSet</literal>,
         <literal>XmlDataSet</literal> ou <literal>FlatXmlDataSet</literal>.
       </para>
@@ -1089,14 +1089,14 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
 }
 ?>]]></programlisting>
       <para>
-        Com exceção do método <literal>getTableMetaData()</literal> isso é 
-        bastante auto-explicativo. Os métodos usados são todos requeridos para 
-        as diferentes asserções da Extensão para Banco de Dados que são 
+        Com exceção do método <literal>getTableMetaData()</literal> isso é
+        bastante auto-explicativo. Os métodos usados são todos requeridos para
+        as diferentes asserções da Extensão para Banco de Dados que são
         explicados no próximo capítulo. O método
-        <literal>getTableMetaData()</literal> deve retornar uma 
+        <literal>getTableMetaData()</literal> deve retornar uma
         implementação da interface
         <literal>PHPUnit_Extensions_Database_DataSet_ITableMetaData</literal>
-        que descreve a estrutura da tabela. Possui informações 
+        que descreve a estrutura da tabela. Possui informações
         sobre:
       </para>
       <itemizedlist>
@@ -1107,7 +1107,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
         </listitem>
         <listitem>
           <para>
-            Um vetor de nomes de coluna da tabela, ordenado por suas aparições 
+            Um vetor de nomes de coluna da tabela, ordenado por suas aparições
             nos conjuntos de resultados.
           </para>
         </listitem>
@@ -1118,8 +1118,8 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
         </listitem>
       </itemizedlist>
       <para>
-        Essa interface também tem uma asserção que verifica se duas instâncias 
-        de Metadados de Tabela se equivalem, o que é usado pela asserção de igualdade 
+        Essa interface também tem uma asserção que verifica se duas instâncias
+        de Metadados de Tabela se equivalem, o que é usado pela asserção de igualdade
         do conjunto de dados.
       </para>
     </section>
@@ -1127,7 +1127,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
   <section id="database.the-connection-api">
     <title>A API de Conexão</title>
     <para>
-      Existem três métodos interessantes na interface Connection 
+      Existem três métodos interessantes na interface Connection
       que devem ser retornados do método
       <literal>getConnection()</literal> no Caso de Teste de Banco de Dados:
     </para>
@@ -1144,7 +1144,7 @@ interface PHPUnit_Extensions_Database_DB_IDatabaseConnection
     <orderedlist numeration="arabic">
       <listitem>
         <para>
-          O método <literal>createDataSet()</literal> cria um Conjunto de Dados 
+          O método <literal>createDataSet()</literal> cria um Conjunto de Dados
           de Banco de Dados (BD) como descrito na seção de implementações de Conjunto de Dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1160,10 +1160,10 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
       </listitem>
       <listitem>
         <para>
-          O método <literal>createQueryTable()</literal> pode ser usado para 
-          criar instâncias de uma QueryTable, dado um nome de resultado e uma query 
+          O método <literal>createQueryTable()</literal> pode ser usado para
+          criar instâncias de uma QueryTable, dado um nome de resultado e uma query
           SQL. Este é um método conveniente quando se fala sobre asserções de resultado/tabela
-          como será mostrado na próxima seção de API de Asserções 
+          como será mostrado na próxima seção de API de Asserções
           de Banco de Dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1179,9 +1179,9 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
       </listitem>
       <listitem>
         <para>
-          O método <literal>getRowCount()</literal> é uma forma conveniente de 
-          acessar o número de linhas em uma tabela, opcionalmente filtradas por uma 
-          cláusula where adicional. Isso pode ser usado com uma simples asserção 
+          O método <literal>getRowCount()</literal> é uma forma conveniente de
+          acessar o número de linhas em uma tabela, opcionalmente filtradas por uma
+          cláusula where adicional. Isso pode ser usado com uma simples asserção
           de igualdade:
         </para>
         <programlisting><![CDATA[<?php
@@ -1189,7 +1189,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1199,19 +1199,19 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
   <section id="database.database-assertions-api">
     <title>API de Asserções de Banco de Dados</title>
     <para>
-      Para uma ferramenta de testes, a Extensão para Banco de Dados certamente fornece algumas 
-      asserções que você pode usar para verificar o estado atual do banco de dados, 
-      tabelas e a contagem de linhas de tabelas. Esta seção 
+      Para uma ferramenta de testes, a Extensão para Banco de Dados certamente fornece algumas
+      asserções que você pode usar para verificar o estado atual do banco de dados,
+      tabelas e a contagem de linhas de tabelas. Esta seção
       descreve essa funcionalidade em detalhes:
     </para>
     <section id="database.asserting-the-row-count-of-a-table">
       <title>Asseverado a contagem de linhas de uma Tabela</title>
       <para>
-        Às vezes ajuda verificar se uma tabela contém uma quantidade específica 
-        de linhas. Você pode conseguir isso facilmente sem colar códigos adicionais 
-        usando a API de Conexão. Suponha que queiramos verificar se após a 
-        inserção de uma linha em nosso guestbook não apenas temos as duas entradas 
-        iniciais que nos acompanharam em todos os exemplos 
+        Às vezes ajuda verificar se uma tabela contém uma quantidade específica
+        de linhas. Você pode conseguir isso facilmente sem colar códigos adicionais
+        usando a API de Conexão. Suponha que queiramos verificar se após a
+        inserção de uma linha em nosso guestbook não apenas temos as duas entradas
+        iniciais que nos acompanharam em todos os exemplos
         anteriores, mas uma terceira:
       </para>
       <programlisting><![CDATA[<?php
@@ -1219,12 +1219,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1232,14 +1232,14 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Asseverando o Estado de uma Tabela</title>
       <para>
-       A asserção anterior ajuda, mas certamente queremos verificar os 
-        conteúdos reais da tabela para verificar se todos os valores foram 
-        escritos nas colunas corretas. Isso pode ser conseguido com uma 
+       A asserção anterior ajuda, mas certamente queremos verificar os
+        conteúdos reais da tabela para verificar se todos os valores foram
+        escritos nas colunas corretas. Isso pode ser conseguido com uma
         asserção de tabela.
       </para>
       <para>
-        Para isso vamos definir uma instância de Tabela Query que deriva seu 
-        conteúdo de um nome de tabela e de uma query SQL e compara isso a um 
+        Para isso vamos definir uma instância de Tabela Query que deriva seu
+        conteúdo de um nome de tabela e de uma query SQL e compara isso a um
         Conjunto de Dados baseado em Arquivo/Vetor:
       </para>
       <programlisting><![CDATA[<?php
@@ -1255,12 +1255,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
       <para>
-        Agora temos que escrever o arquivo XML Plano <emphasis>expectedBook.xml</emphasis> 
+        Agora temos que escrever o arquivo XML Plano <emphasis>expectedBook.xml</emphasis>
         para esta asserção:
       </para>
       <screen><![CDATA[
@@ -1272,15 +1272,15 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 </dataset>
 ]]></screen>
       <para>
-        Apesar disso, esta asserção só vai passar em exatamente um segundo 
-        do universo, em <emphasis>2010–05–01 21:47:08</emphasis>. Datas 
-        possuem um problema especial nos testes de bancos de dados e podemos circundar 
-        a falha omitindo a coluna <quote>created</quote> 
+        Apesar disso, esta asserção só vai passar em exatamente um segundo
+        do universo, em <emphasis>2010–05–01 21:47:08</emphasis>. Datas
+        possuem um problema especial nos testes de bancos de dados e podemos circundar
+        a falha omitindo a coluna <quote>created</quote>
         da asserção.
       </para>
       <para>
-        O arquivo ajustado <emphasis>expectedBook.xml</emphasis> em XML Plano 
-        provavelmente vai ficar parecido com o seguinte para fazer a 
+        O arquivo ajustado <emphasis>expectedBook.xml</emphasis> em XML Plano
+        provavelmente vai ficar parecido com o seguinte para fazer a
         asserção passar:
       </para>
       <screen><![CDATA[
@@ -1303,8 +1303,8 @@ $queryTable = $this->getConnection()->createQueryTable(
     <section id="database.asserting-the-result-of-a-query">
       <title>Asseverando o Resultado de uma Query</title>
       <para>
-        Você também pode asseverar o resultado de querys complexas com a abordagem 
-        da Tabela Query, apenas especificando um nome de resultado com uma query e 
+        Você também pode asseverar o resultado de querys complexas com a abordagem
+        da Tabela Query, apenas especificando um nome de resultado com uma query e
         comparando isso a um conjunto de dados:
       </para>
       <programlisting><![CDATA[<?php
@@ -1317,7 +1317,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1325,14 +1325,14 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-multiple-tables">
       <title>Asseverando o Estado de Múltiplas Tabelas</title>
       <para>
-        Certamente você pode asseverar o estado de múltiplas tabelas de uma vez e 
-        comparar um conjunto de dados de query contra um conjunto de dados baseado em arquivo. Existem duas 
+        Certamente você pode asseverar o estado de múltiplas tabelas de uma vez e
+        comparar um conjunto de dados de query contra um conjunto de dados baseado em arquivo. Existem duas
         formas diferentes de asserções de Conjuntos de Dados.
       </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Você pode usar o Database (Banco de Dados - DB) e o DataSet (Conjunto de Dados) da Connection (Conexão) e 
+            Você pode usar o Database (Banco de Dados - DB) e o DataSet (Conjunto de Dados) da Connection (Conexão) e
             compará-lo com um Conjunto de Dados Baseado em Arquivo.
           </para>
           <programlisting><![CDATA[<?php
@@ -1342,7 +1342,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1360,7 +1360,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1371,33 +1371,33 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
   <section id="database.frequently-asked-questions">
     <title>Perguntas Mais Frequentes</title>
     <section id="database.will-phpunit-re-create-the-database-schema-for-each-test">
-      <title>O PHPUnit vai (re)criar o esquema do banco de dados para cada 
+      <title>O PHPUnit vai (re)criar o esquema do banco de dados para cada
              teste?</title>
       <para>
-        Não, o PHPUnit exige que todos os objetos do banco de dados estejam disponíveis quando a 
-        suíte começar os testes. O Banco de Dados, tabelas, sequências, gatilhos e 
+        Não, o PHPUnit exige que todos os objetos do banco de dados estejam disponíveis quando a
+        suíte começar os testes. O Banco de Dados, tabelas, sequências, gatilhos e
         visualizações devem ser criadas antes que você execute a suíte de testes.
       </para>
       <para>
         <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink> ou
-        <ulink url="http://www.ezcomponents.org">eZ Components</ulink> possuem 
-        ferramentas poderosas que permitem a você criar o esquema de banco de dados através 
-        de estruturas de dados pré-definidas, porém devem ser ligados à 
-        extensão do PHPUnit para permitir a recriação automática de banco de dados 
+        <ulink url="http://www.ezcomponents.org">eZ Components</ulink> possuem
+        ferramentas poderosas que permitem a você criar o esquema de banco de dados através
+        de estruturas de dados pré-definidas, porém devem ser ligados à
+        extensão do PHPUnit para permitir a recriação automática de banco de dados
         antes que a suíte de testes completa seja executada.
       </para>
       <para>
-        Já que cada teste limpa completamente o banco de dados, você nem sequer é 
-        forçado a recriar o banco de dados para cada execução de teste. Um banco de dados 
+        Já que cada teste limpa completamente o banco de dados, você nem sequer é
+        forçado a recriar o banco de dados para cada execução de teste. Um banco de dados
         permanentemente disponível funciona perfeitamente.
       </para>
     </section>
     <section id="database.am-i-required-to-use-pdo-in-my-application-for-the-database-extension-to-work">
-      <title>Sou forçado a usar PDO em minha aplicação para que a Extensão para 
+      <title>Sou forçado a usar PDO em minha aplicação para que a Extensão para
              Banco de Dados funcione?</title>
       <para>
-        Não, PDO só é exigido para limpeza e configuração do ambiente e para 
-        asserções. Você pode usar qualquer abstração de banco de dados que quiser 
+        Não, PDO só é exigido para limpeza e configuração do ambiente e para
+        asserções. Você pode usar qualquer abstração de banco de dados que quiser
         dentro de seu próprio código.
       </para>
     </section>
@@ -1405,24 +1405,24 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
       <title>O que posso fazer quando recebo um Erro
              <quote>Too much Connections</quote>?</title>
       <para>
-        Se você não armazena em cache a instância de PDO que é criada a partir do 
-        método do Caso de Teste <literal>getConnection()</literal> o número de 
-        conexões ao banco de dados é aumentado em um ou mais com cada 
-        teste do banco de dados. Com a configuração padrão o MySQL só permite 100 
-        conexões concorrentes e outros fornecedores também têm um limite máximo 
+        Se você não armazena em cache a instância de PDO que é criada a partir do
+        método do Caso de Teste <literal>getConnection()</literal> o número de
+        conexões ao banco de dados é aumentado em um ou mais com cada
+        teste do banco de dados. Com a configuração padrão o MySQL só permite 100
+        conexões concorrentes e outros fornecedores também têm um limite máximo
         de conexões.
       </para>
       <para>
         A Sub-seção
-        <quote>Use seu próprio Caso Abstrato de Teste de Banco de Dados</quote> mostra como 
-        você pode prevenir o acontecimento desse erro usando uma instância única armazenada 
+        <quote>Use seu próprio Caso Abstrato de Teste de Banco de Dados</quote> mostra como
+        você pode prevenir o acontecimento desse erro usando uma instância única armazenada
         em cache do PDO em todos os seus testes.
       </para>
     </section>
     <section id="database.how-to-handle-null-with-flat-xml-csv-datasets">
       <title>Como lidar com NULL usando Conjuntos de Dados XML Plano / CSV?</title>
       <para>
-        Não faça isso. Em vez disso, você deveria usar Conjuntos de Dados ou 
+        Não faça isso. Em vez disso, você deveria usar Conjuntos de Dados ou
         XML ou YAML.
       </para>
     </section>

--- a/src/4.7/pt_br/fixtures.xml
+++ b/src/4.7/pt_br/fixtures.xml
@@ -6,21 +6,21 @@
   <para>
     <indexterm><primary>Ambientes</primary></indexterm>
 
-    Uma das partes que mais consomem tempo ao se escrever testes é escrever o 
-    código para ajustar o ambiente para um estado conhecido e então retorná-lo ao seu 
-    estado original quando o teste está completo. Esse estado conhecido é chamado 
+    Uma das partes que mais consomem tempo ao se escrever testes é escrever o
+    código para ajustar o ambiente para um estado conhecido e então retorná-lo ao seu
+    estado original quando o teste está completo. Esse estado conhecido é chamado
     de <emphasis>ambiente</emphasis> do teste.
   </para>
 
   <para>
-    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" />, o 
+    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" />, o
     ambiente era simplesmente o vetor que está guardado na variável <literal>$stack</literal>.
-    Na maior parte do tempo, porém, o ambiente será mais complexo 
-    que um simples vetor, e a quantidade de código necessária para defini-lo aumentará 
-    na mesma proporção. O conteúdo real do teste se perde na bagunça 
-    da configuração do ambiente. Esse problema piora ainda mais quando você escreve 
-    vários testes com ambientes similares. Sem alguma ajuda do framework de teste, 
-    teríamos que duplicar o código que define o ambiente 
+    Na maior parte do tempo, porém, o ambiente será mais complexo
+    que um simples vetor, e a quantidade de código necessária para defini-lo aumentará
+    na mesma proporção. O conteúdo real do teste se perde na bagunça
+    da configuração do ambiente. Esse problema piora ainda mais quando você escreve
+    vários testes com ambientes similares. Sem alguma ajuda do framework de teste,
+    teríamos que duplicar o código que define o ambiente
     para cada teste que escrevermos.
   </para>
 
@@ -29,25 +29,25 @@
     <indexterm><primary>setUp()</primary></indexterm>
     <indexterm><primary>tearDown()</primary></indexterm>
 
-    O PHPUnit suporta compartilhamento do código de configuração. Antes que um método seja executado, um 
+    O PHPUnit suporta compartilhamento do código de configuração. Antes que um método seja executado, um
     método modelo chamado <literal>setUp()</literal> é invocado.
-    <literal>setUp()</literal> é onde você cria os objetos que serão 
-    alvo dos testes. Uma vez que o método de teste tenha terminado sua execução, seja 
+    <literal>setUp()</literal> é onde você cria os objetos que serão
+    alvo dos testes. Uma vez que o método de teste tenha terminado sua execução, seja
     bem-sucedido ou falho, outro método modelo chamado
     <literal>tearDown()</literal> é invocado. <literal>tearDown()</literal>
     é onde você limpa os objetos que foram alvo dos testes.
   </para>
 
   <para>
-    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> usamos 
-    a relação produtor-consumidor entre testes para compartilhar ambientes. Isso 
+    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> usamos
+    a relação produtor-consumidor entre testes para compartilhar ambientes. Isso
     nem sempre é desejável, ou mesmo possível. <xref linkend="fixtures.examples.StackTest.php"/>
-    mostra como podemos escrever os testes do <literal>StackTest</literal> de forma 
-    que o próprio ambiente não é reutilizado, mas o código que o cria. 
-    Primeiro declaramos a variável de instância <literal>$stack</literal>, que 
-    usaremos no lugar de uma variável do método local. Então colocamos a 
+    mostra como podemos escrever os testes do <literal>StackTest</literal> de forma
+    que o próprio ambiente não é reutilizado, mas o código que o cria.
+    Primeiro declaramos a variável de instância <literal>$stack</literal>, que
+    usaremos no lugar de uma variável do método local. Então colocamos a
     criação do ambiente <literal>vetor</literal> dentro do método
-    <literal>setUp()</literal>. Finalmente, removemos o código redundante 
+    <literal>setUp()</literal>. Finalmente, removemos o código redundante
     dos métodos de teste e usamos a nova variável de instância,
     <literal>$this->stack</literal>, em vez da variável de método local
     <literal>$stack</literal> com o método de asserção <literal>assertEquals()</literal>.
@@ -67,21 +67,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -94,8 +94,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>tearDown()</primary></indexterm>
     <indexterm><primary>tearDownAfterClass()</primary></indexterm>
 
-    Os métodos-modelo <literal>setUp()</literal> e <literal>tearDown()</literal> 
-    são executados uma vez para cada método de teste (e em novas instâncias) da 
+    Os métodos-modelo <literal>setUp()</literal> e <literal>tearDown()</literal>
+    são executados uma vez para cada método de teste (e em novas instâncias) da
     classe do caso de teste.
   </para>
 
@@ -110,15 +110,15 @@ class StackTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>onNotSuccessfulTest()</primary></indexterm>
 
     Além disso, os métodos-modelo <literal>setUpBeforeClass()</literal> e
-    <literal>tearDownAfterClass()</literal> são chamados antes 
-    do primeiro teste da classe do caso de teste ser executado e após o último teste da 
+    <literal>tearDownAfterClass()</literal> são chamados antes
+    do primeiro teste da classe do caso de teste ser executado e após o último teste da
     classe do caso de teste ser executado, respectivamente.
   </para>
 
   <para>
     <indexterm><primary>Método Modelo</primary></indexterm>
 
-    O exemplo abaixo mostra todos os métodos-modelo que estão disponíveis em uma classe 
+    O exemplo abaixo mostra todos os métodos-modelo que estão disponíveis em uma classe
     de casos de teste.
   </para>
 
@@ -145,13 +145,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()
@@ -209,15 +209,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Mais setUp() que tearDown()</title>
 
     <para>
-      <literal>setUp()</literal> e <literal>tearDown()</literal> são bastante 
-      simétricos em teoria, mas não na prática. Na prática, você só precisa 
-      implementar <literal>tearDown()</literal> se você tiver alocado 
+      <literal>setUp()</literal> e <literal>tearDown()</literal> são bastante
+      simétricos em teoria, mas não na prática. Na prática, você só precisa
+      implementar <literal>tearDown()</literal> se você tiver alocado
       recursos externos como arquivos ou sockets no <literal>setUp()</literal>.
-      Se seu <literal>setUp()</literal> apenas cria objetos planos do PHP, você 
-      pode geralmente ignorar o <literal>tearDown()</literal>. Porém, se você 
-      criar muitos objetos em seu <literal>setUp()</literal>, você pode querer 
+      Se seu <literal>setUp()</literal> apenas cria objetos planos do PHP, você
+      pode geralmente ignorar o <literal>tearDown()</literal>. Porém, se você
+      criar muitos objetos em seu <literal>setUp()</literal>, você pode querer
       <literal>unset()</literal> as variáveis que apontam para aqueles objetos
-      em seu <literal>tearDown()</literal> para que eles possam ser coletados como lixo. 
+      em seu <literal>tearDown()</literal> para que eles possam ser coletados como lixo.
       A coleta de lixo dos objetos dos casos de teste não é previsível.
     </para>
   </section>
@@ -226,23 +226,23 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variações</title>
 
     <para>
-      O que acontece quando você tem dois testes com definições (setups) ligeiramente diferentes? 
+      O que acontece quando você tem dois testes com definições (setups) ligeiramente diferentes?
       Existem duas possibilidades:
     </para>
 
     <itemizedlist>
       <listitem>
         <para>
-          Se o código <literal>setUp()</literal> diferir só um pouco, mova 
-          o código que difere do código do <literal>setUp()</literal> para 
+          Se o código <literal>setUp()</literal> diferir só um pouco, mova
+          o código que difere do código do <literal>setUp()</literal> para
           o método de teste.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          Se você tiver um <literal>setUp()</literal> realmente diferente, você precisará 
-          de uma classe de caso de teste diferente. Nomeie a classe após a diferença 
+          Se você tiver um <literal>setUp()</literal> realmente diferente, você precisará
+          de uma classe de caso de teste diferente. Nomeie a classe após a diferença
           na configuração.
         </para>
       </listitem>
@@ -253,15 +253,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Compartilhando Ambientes</title>
 
     <para>
-      Existem algumas boas razões para compartilhar ambientes entre testes, mas na maioria 
-        dos casos a necessidade de compartilhar um ambiente entre testes deriva de um problema 
+      Existem algumas boas razões para compartilhar ambientes entre testes, mas na maioria
+        dos casos a necessidade de compartilhar um ambiente entre testes deriva de um problema
         de design não resolvido.
     </para>
 
     <para>
-      Um bom exemplo de um ambiente que faz sentido compartilhar através de vários 
-        testes é a conexão ao banco de dados: você loga no banco de dados uma vez e 
-        reutiliza essa conexão em vez de criar uma nova conexão para cada 
+      Um bom exemplo de um ambiente que faz sentido compartilhar através de vários
+        testes é a conexão ao banco de dados: você loga no banco de dados uma vez e
+        reutiliza essa conexão em vez de criar uma nova conexão para cada
         teste. Isso faz seus testes serem executados mais rápido.
     </para>
 
@@ -271,8 +271,8 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
       <xref linkend="fixtures.sharing-fixture.examples.DatabaseTest.php" />
       usa os métodos-modelo <literal>setUpBeforeClass()</literal> e
-      <literal>tearDownAfterClass()</literal> para conectar ao 
-      banco de dados antes do primeiro teste da classe de casos de teste e para desconectar do 
+      <literal>tearDownAfterClass()</literal> para conectar ao
+      banco de dados antes do primeiro teste da classe de casos de teste e para desconectar do
       banco de dados após o último teste dos casos de teste, respectivamente.
     </para>
 
@@ -297,12 +297,12 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Não dá pra enfatizar o suficiente o quanto o compartilhamento de ambientes entre testes 
-      reduz o custo dos testes. O problema de design subjacente é 
-      que objetos não são de baixo acoplamento. Você vai conseguir 
-      melhores resultados resolvendo o problema de design subjacente e então escrevendo testes 
-      usando pontas (veja <xref linkend="test-doubles" />), do que criando 
-      dependências entre os testes em tempo de execução e ignorando a oportunidade 
+      Não dá pra enfatizar o suficiente o quanto o compartilhamento de ambientes entre testes
+      reduz o custo dos testes. O problema de design subjacente é
+      que objetos não são de baixo acoplamento. Você vai conseguir
+      melhores resultados resolvendo o problema de design subjacente e então escrevendo testes
+      usando pontas (veja <xref linkend="test-doubles" />), do que criando
+      dependências entre os testes em tempo de execução e ignorando a oportunidade
       de melhorar seu design.
     </para>
   </section>
@@ -312,8 +312,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     <para>
       <ulink url="http://googletesting.blogspot.com/2008/05/tott-using-dependancy-injection-to.html">É difícil testar um código que usa singletons (instâncias únicas de objetos).</ulink>
-      Isso também vale para os códigos que usam variáveis globais. Tipicamente, o código 
-      que você quer testar é fortemente acoplado com uma variável global e você não pode 
+      Isso também vale para os códigos que usam variáveis globais. Tipicamente, o código
+      que você quer testar é fortemente acoplado com uma variável global e você não pode
       controlar sua criação. Um problema adicional é o fato de que uma alteração em uma
       variável global para um teste pode quebrar um outro teste.
     </para>
@@ -330,7 +330,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </itemizedlist>
 
     <para>
-      Além das variáveis globais, atributos estáticos de classes também são parte do 
+      Além das variáveis globais, atributos estáticos de classes também são parte do
       estado global.
     </para>
 
@@ -338,24 +338,24 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary>Isolamento de Testes</primary></indexterm>
 
-      Por padrão, o PHPUnit executa seus testes de forma que mudanças às 
+      Por padrão, o PHPUnit executa seus testes de forma que mudanças às
       variáveis globais ou super-globais (<literal>$GLOBALS</literal>,
       <literal>$_ENV</literal>, <literal>$_POST</literal>,
       <literal>$_GET</literal>, <literal>$_COOKIE</literal>,
       <literal>$_SERVER</literal>, <literal>$_FILES</literal>,
-      <literal>$_REQUEST</literal>) não afetem outros testes. Opcionalmente, este 
+      <literal>$_REQUEST</literal>) não afetem outros testes. Opcionalmente, este
       isolamento pode ser estendido a atributos estáticos de classes.
     </para>
 
     <note>
       <para>
-        A operações de cópia de segurança e restauração para variáveis globais e atributos 
+        A operações de cópia de segurança e restauração para variáveis globais e atributos
         estáticos de classes usa <literal>serialize()</literal> e
         <literal>unserialize()</literal>.
       </para>
       <para>
-        Objetos de algumas classes (e.g., <literal>PDO</literal>) não podem ser 
-        serializadas e a operação de cópia de segurança vai quebrar quando esse tipo de objeto 
+        Objetos de algumas classes (e.g., <literal>PDO</literal>) não podem ser
+        serializadas e a operação de cópia de segurança vai quebrar quando esse tipo de objeto
         for guardado no vetor <literal>$GLOBALS</literal>, por exemplo.
       </para>
     </note>
@@ -365,9 +365,9 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>$backupGlobalsBlacklist</literal></primary></indexterm>
 
       A anotação <literal>@backupGlobals</literal> que é discutida na
-      <xref linkend="appendixes.annotations.backupGlobals"/> pode ser usada para 
-      controlar as operações de cópia de segurança e restauração para variáveis globais. 
-      Alternativamente, você pode fornecer uma lista-negra de variáveis globais que deverão 
+      <xref linkend="appendixes.annotations.backupGlobals"/> pode ser usada para
+      controlar as operações de cópia de segurança e restauração para variáveis globais.
+      Alternativamente, você pode fornecer uma lista-negra de variáveis globais que deverão
       ser excluídas das operações de backup e restauração como esta:
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -379,7 +379,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        Definir a propriedade <literal>$backupGlobalsBlacklist</literal> dentro 
+        Definir a propriedade <literal>$backupGlobalsBlacklist</literal> dentro
         do método <literal>setUp()</literal>, por exemplo, não tem efeito.
       </para>
     </note>
@@ -387,39 +387,39 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
       <indexterm><primary><literal>$backupStaticAttributesBlacklist</literal></primary></indexterm>
-      
+
       A anotação <literal>@backupStaticAttributes</literal> que é discutida na
-      <xref linkend="appendixes.annotations.backupStaticAttributes"/> 
-      pode ser usado para fazer backup de todos os valores de propriedades estáticas em todas as classes declaradas 
+      <xref linkend="appendixes.annotations.backupStaticAttributes"/>
+      pode ser usado para fazer backup de todos os valores de propriedades estáticas em todas as classes declaradas
       antes de cada teste e restaurá-los depois.
     </para>
-    
+
     <para>
-      Ele processa todas as classes que são declaradas no momento que um teste começa, 
-      não só a classe de teste. Ele só se aplica a propriedades da classe estática, 
+      Ele processa todas as classes que são declaradas no momento que um teste começa,
+      não só a classe de teste. Ele só se aplica a propriedades da classe estática,
       e não variáveis estáticas dentro de funções.
     </para>
 
     <note>
       <para>
-        A operação <literal>@backupStaticAttributes</literal> é executada 
-        antes de um método de teste, mas somente se ele está habilitado. Se um valor estático foi 
-        alterado por um teste executado anteriormente que não 
-        tinha ativado <literal>@backupStaticAttributes</literal>, esse valor então será 
-        feito o backup e restaurado - não o valor padrão originalmente declarado. 
-        O PHP não registra o valor padrão originalmente declarado de nenhuma variável 
+        A operação <literal>@backupStaticAttributes</literal> é executada
+        antes de um método de teste, mas somente se ele está habilitado. Se um valor estático foi
+        alterado por um teste executado anteriormente que não
+        tinha ativado <literal>@backupStaticAttributes</literal>, esse valor então será
+        feito o backup e restaurado - não o valor padrão originalmente declarado.
+        O PHP não registra o valor padrão originalmente declarado de nenhuma variável
         estática.
       </para>
       <para>
-        O mesmo se aplica a propriedades estáticas de classes que foram 
-        recém-carregadas/declaradas dentro de um teste. Elas não podem ser redefinidas para o seu valor 
-        padrão originalmente declarado após o teste, uma vez que esse valor é desconhecido. 
+        O mesmo se aplica a propriedades estáticas de classes que foram
+        recém-carregadas/declaradas dentro de um teste. Elas não podem ser redefinidas para o seu valor
+        padrão originalmente declarado após o teste, uma vez que esse valor é desconhecido.
         Qualquer que seja o valor definido irá vazar para testes subsequentes.
       </para>
       <para>
-        Para testes de unidade, recomenda-se redefinir explicitamente os valores das 
-        propriedades estáticas em teste em seu código <literal>setUp()</literal> 
-        ao invés (e, idealmente, também <literal>tearDown()</literal>, de modo a não 
+        Para testes de unidade, recomenda-se redefinir explicitamente os valores das
+        propriedades estáticas em teste em seu código <literal>setUp()</literal>
+        ao invés (e, idealmente, também <literal>tearDown()</literal>, de modo a não
         afetar os testes posteriormente executados).
       </para>
     </note>

--- a/src/4.7/pt_br/incomplete-and-skipped-tests.xml
+++ b/src/4.7/pt_br/incomplete-and-skipped-tests.xml
@@ -7,17 +7,17 @@
     <title>Testes Incompletos</title>
 
     <para>
-      Quando você está trabalhando em uma nova classe de caso de teste, você pode querer começar 
+      Quando você está trabalhando em uma nova classe de caso de teste, você pode querer começar
       a escrever métodos de teste vazios, como: <programlisting>public function testSomething()
 {
-}</programlisting> para manter o controle sobre os testes que você já escreveu. O 
-      problema com os métodos de teste vazios é que eles são interpretados como 
-      bem-sucedidos pelo framework do PHPUnit. Esse erro de interpretação leva à 
-      inutilização dos relatórios de testes -- você não pode ver se um teste foi 
-      realmente bem-sucedido ou simplesmente ainda não foi implementado. Chamar 
-      <literal>$this->fail()</literal> no teste não implementado 
-      não ajuda em nada, já que o teste será interpretado como uma 
-      falha. Isso seria tão errado quanto interpretar um teste não implementado 
+}</programlisting> para manter o controle sobre os testes que você já escreveu. O
+      problema com os métodos de teste vazios é que eles são interpretados como
+      bem-sucedidos pelo framework do PHPUnit. Esse erro de interpretação leva à
+      inutilização dos relatórios de testes -- você não pode ver se um teste foi
+      realmente bem-sucedido ou simplesmente ainda não foi implementado. Chamar
+      <literal>$this->fail()</literal> no teste não implementado
+      não ajuda em nada, já que o teste será interpretado como uma
+      falha. Isso seria tão errado quanto interpretar um teste não implementado
       como bem-sucedido.
     </para>
 
@@ -26,22 +26,22 @@
       <indexterm><primary>PHPUnit_Framework_IncompleteTest</primary></indexterm>
       <indexterm><primary>PHPUnit_Framework_IncompleteTestError</primary></indexterm>
 
-      Se imaginarmos que um teste bem-sucedido é uma luz verde e um teste mal-sucedido (falho) 
-      é uma luz vermelha, precisaremos de uma luz amarela adicional para marcar um teste 
-      como incompleto ou ainda não implementado. 
-      O <literal>PHPUnit_Framework_IncompleteTest</literal> é uma interface 
-      marcadora para marcar uma exceção que surge de um método de teste como 
-      resultado do teste ser incompleto ou atualmente não implementado. 
-      O <literal>PHPUnit_Framework_IncompleteTestError</literal> é a 
+      Se imaginarmos que um teste bem-sucedido é uma luz verde e um teste mal-sucedido (falho)
+      é uma luz vermelha, precisaremos de uma luz amarela adicional para marcar um teste
+      como incompleto ou ainda não implementado.
+      O <literal>PHPUnit_Framework_IncompleteTest</literal> é uma interface
+      marcadora para marcar uma exceção que surge de um método de teste como
+      resultado do teste ser incompleto ou atualmente não implementado.
+      O <literal>PHPUnit_Framework_IncompleteTestError</literal> é a
       implementação padrão dessa interface.
     </para>
 
     <para>
       O <xref linkend="incomplete-and-skipped-tests.incomplete-tests.examples.SampleTest.php" />
-      mostra uma classe de caso de teste, <literal>SampleTest</literal>, que contém um método 
-      de teste, <literal>testSomething()</literal>. Chamando o método de conveniência 
-      <literal>markTestIncomplete()</literal> (que automaticamente 
-      traz uma exceção <literal>PHPUnit_Framework_IncompleteTestError</literal>) 
+      mostra uma classe de caso de teste, <literal>SampleTest</literal>, que contém um método
+      de teste, <literal>testSomething()</literal>. Chamando o método de conveniência
+      <literal>markTestIncomplete()</literal> (que automaticamente
+      traz uma exceção <literal>PHPUnit_Framework_IncompleteTestError</literal>)
       no método de teste, marcamos o teste como sendo incompleto.
     </para>
 
@@ -53,7 +53,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // Opcional: Teste alguma coisa aqui, se quiser
-        $this->assertTrue(TRUE, 'This should already work.');
+        self::assertTrue(TRUE, 'This should already work.');
 
         // Pare aqui e marque este teste como incompleto.
         $this->markTestIncomplete(
@@ -65,8 +65,8 @@ class SampleTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Um teste incompleto é denotado por um <literal>I</literal> na saída 
-      do executor de testes em linha-de-comando do PHPUnit, como mostrado no exemplo 
+      Um teste incompleto é denotado por um <literal>I</literal> na saída
+      do executor de testes em linha-de-comando do PHPUnit, como mostrado no exemplo
       abaixo:
     </para>
 
@@ -119,18 +119,18 @@ Tests: 1, Assertions: 1, Incomplete: 1.</screen>
     <title>Pulando Testes</title>
 
     <para>
-      Nem todos os testes podem ser executados em qualquer ambiente. Considere, por exemplo, 
+      Nem todos os testes podem ser executados em qualquer ambiente. Considere, por exemplo,
       uma camada de abstração de banco de dados contendo vários drivers para os diversos
-      sistemas de banco de dados que suporta. Os testes para o driver MySQL podem ser 
+      sistemas de banco de dados que suporta. Os testes para o driver MySQL podem ser
       executados apenas, é claro, se um servidor MySQL estiver disponível.
     </para>
 
     <para>
       O <xref linkend="incomplete-and-skipped-tests.skipping-tests.examples.DatabaseTest.php" />
-      mostra uma classe de caso de teste, <literal>DatabaseTest</literal>, que contém um método 
-      de teste, <literal>testConnection()</literal>. No método-modelo <literal>setUp()</literal> 
-      da classe de caso de teste, verificamos se a extensão MySQLi 
-      está disponível e usamos o método <literal>markTestSkipped()</literal> 
+      mostra uma classe de caso de teste, <literal>DatabaseTest</literal>, que contém um método
+      de teste, <literal>testConnection()</literal>. No método-modelo <literal>setUp()</literal>
+      da classe de caso de teste, verificamos se a extensão MySQLi
+      está disponível e usamos o método <literal>markTestSkipped()</literal>
       para pular o teste caso contrário.
     </para>
 
@@ -157,8 +157,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Um teste que tenha sido pulado é denotado por um <literal>S</literal> na 
-      saída do executor de testes em linha-de-comando do PHPUnit, como mostrado 
+      Um teste que tenha sido pulado é denotado por um <literal>S</literal> na
+      saída do executor de testes em linha-de-comando do PHPUnit, como mostrado
       no seguinte exemplo:
     </para>
 
@@ -211,7 +211,7 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
     <title>Pulando Testes usando @requires</title>
 
     <para>
-      Além do método acima também é possível usar a 
+      Além do método acima também é possível usar a
       anotação <literal>@requires</literal> para expressar pré-condições comuns para um caso de teste.
     </para>
 
@@ -283,7 +283,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Se você está usando uma sintaxe que não compila com uma certa versão do PHP, procure dentro da configuração 
+      Se você está usando uma sintaxe que não compila com uma certa versão do PHP, procure dentro da configuração
       xml por includes dependentes de versão na <xref linkend="appendixes.configuration.testsuites" />.
     </para>
   </section>

--- a/src/4.7/pt_br/selenium.xml
+++ b/src/4.7/pt_br/selenium.xml
@@ -9,21 +9,21 @@
     <para>
       <indexterm><primary>Servidor Selenium</primary></indexterm>
 
-      <ulink url="http://seleniumhq.org/">Servidor Selenium</ulink> é uma 
-      ferramenta de testes que permite a você escrever testes automatizados de interface de usuário para 
-      aplicações web em qualquer linguagem de programação contra qualquer website HTTP 
-      usando um dos principais navegadores. Ele realiza tarefas automatizadas no navegador 
-      guiando seu processo através do sistema operacional. 
-      O Selenium executa os testes diretamente em um navegador, exatamente como os usuários reais fazem. Esses 
+      <ulink url="http://seleniumhq.org/">Servidor Selenium</ulink> é uma
+      ferramenta de testes que permite a você escrever testes automatizados de interface de usuário para
+      aplicações web em qualquer linguagem de programação contra qualquer website HTTP
+      usando um dos principais navegadores. Ele realiza tarefas automatizadas no navegador
+      guiando seu processo através do sistema operacional.
+      O Selenium executa os testes diretamente em um navegador, exatamente como os usuários reais fazem. Esses
       testes podem ser usados para ambos <emphasis>testes de aceitação</emphasis>
-      (realizando testes de alto-nível no sistema integrado em vez de 
-      apenas testar cada unidade do sistema independentemente) e 
-      <emphasis>testes de compatibilidade de navegador</emphasis> (testando a aplicação web em 
+      (realizando testes de alto-nível no sistema integrado em vez de
+      apenas testar cada unidade do sistema independentemente) e
+      <emphasis>testes de compatibilidade de navegador</emphasis> (testando a aplicação web em
       diferentes sistemas operacionais e navegadores).
     </para>
-    
+
     <para>
-      O único cenário suportado do PHPUnit_Selenium é o do servidor Selenium 2.x. 
+      O único cenário suportado do PHPUnit_Selenium é o do servidor Selenium 2.x.
       O servidor pode ser acessado através da Api clássica Selenium RC, já presente no 1.x, ou com a API WebDriver (parcialmente implementada) do PHPUnit_Selenium 1.2.
     </para>
     <para>
@@ -44,17 +44,17 @@
       <listitem>Descompacte o arquivo de distribuição e copie o <filename>selenium-server-standalone-2.9.0.jar</filename> (verifique o sufixo da versão) para <filename>/usr/local/bin</filename>, por exemplo.</listitem>
       <listitem>Inicie o Servidor Selenium executando <userinput>java -jar /usr/local/bin/selenium-server-standalone-2.9.0.jar</userinput>.</listitem>
     </orderedlist>
-    
+
     <para>
-      O pacote PHPUnit_Selenium está incluso na distribuição PHAR 
+      O pacote PHPUnit_Selenium está incluso na distribuição PHAR
       do PHPUnit. Ele pode ser instalado através do Composer, adicionando a seguinte
       dependência <literal>"require-dev"</literal>:
     </para>
-    
+
     <screen><userinput>"phpunit/phpunit-selenium": ">=1.2"</userinput></screen>
 
     <para>
-      Agora podemos enviar comandos para o Servidor Selenium usando seu protocolo 
+      Agora podemos enviar comandos para o Servidor Selenium usando seu protocolo
       cliente/servidor.
     </para>
   </section>
@@ -69,9 +69,9 @@
     </para>
 
     <para>
-      <xref linkend="selenium.selenium2testcase.examples.WebTest.php" /> mostra 
+      <xref linkend="selenium.selenium2testcase.examples.WebTest.php" /> mostra
       como testar os conteúdos do elemento <literal><![CDATA[<title>]]></literal>
-      do site 
+      do site
       <systemitem role="URL">http://www.example.com/</systemitem>.
     </para>
     <example id="selenium.selenium2testcase.examples.WebTest.php">
@@ -88,7 +88,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -126,15 +126,15 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
     <para>
       <indexterm><primary><literal>PHPUnit_Extensions_SeleniumTestCase</literal></primary></indexterm>
 
-      A extensão de caso de teste <literal>PHPUnit_Extensions_SeleniumTestCase</literal> 
-      implementa o protocolo cliente/servidor para conversar com o Servidor Selenium assim como 
+      A extensão de caso de teste <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
+      implementa o protocolo cliente/servidor para conversar com o Servidor Selenium assim como
       métodos de asserção especializados para testes web.
     </para>
 
     <para>
-      O <xref linkend="selenium.seleniumtestcase.examples.WebTest.php" /> mostra 
+      O <xref linkend="selenium.seleniumtestcase.examples.WebTest.php" /> mostra
       como testar os conteúdos do elemento <literal><![CDATA[<title>]]></literal>
-      para o site 
+      para o site
       <systemitem role="URL">http://www.exemplo.com/</systemitem>.
     </para>
 
@@ -154,7 +154,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -180,8 +180,8 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 
     <para>
       Diferente da classe <literal>PHPUnit_Framework_TestCase</literal>,
-      classes de caso de teste que estendem o <literal>PHPUnit_Extensions_SeleniumTestCase</literal> 
-      têm que fornecer um método <literal>setUp()</literal>. Esse método é usado 
+      classes de caso de teste que estendem o <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
+      têm que fornecer um método <literal>setUp()</literal>. Esse método é usado
       para configurar a sessão do Servidor Selenium. Veja
       <xref linkend="selenium.seleniumtestcase.tables.seleniumrc-api.setup" />
       para uma lista de métodos que estão disponíveis para isso.
@@ -227,7 +227,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </table>
 
     <para>
-      O PHPUnit pode opcionalmente capturar a tela quando um teste do Selenium falha. Para 
+      O PHPUnit pode opcionalmente capturar a tela quando um teste do Selenium falha. Para
       habilitar isso, configure <literal>$captureScreenshotOnFailure</literal>,
       <literal>$screenshotPath</literal> e <literal>$screenshotUrl</literal>
       em sua classe de caso de teste como mostrado em
@@ -254,7 +254,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -280,12 +280,12 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 
     <para>
       Você pode executar cada teste usando um conjunto de navegadores: Em vez de usar
-      <literal>setBrowser()</literal> para configurar um navegador, você pode declarar um 
+      <literal>setBrowser()</literal> para configurar um navegador, você pode declarar um
       vetor <literal>public static</literal> chamado <literal>$browsers</literal>
-      em sua classe de caso de testes. Cada item nesse vetor descreve uma configuração 
-      de navegador. Cada um desses navegadores pode ser hospedado em diferentes 
+      em sua classe de caso de testes. Cada item nesse vetor descreve uma configuração
+      de navegador. Cada um desses navegadores pode ser hospedado em diferentes
       Servidores Selenium.
-      O <xref linkend="selenium.seleniumtestcase.examples.WebTest3.php" /> mostra 
+      O <xref linkend="selenium.seleniumtestcase.examples.WebTest3.php" /> mostra
       um exemplo.
     </para>
 
@@ -335,14 +335,14 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      <literal>PHPUnit_Extensions_SeleniumTestCase</literal> pode coletar a 
+      <literal>PHPUnit_Extensions_SeleniumTestCase</literal> pode coletar a
       informação de cobertura de código para execução de testes através do Selenium:
     </para>
 
@@ -353,7 +353,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </orderedlist>
 
     <para>
-      <xref linkend="selenium.seleniumtestcase.tables.assertions" /> lista os 
+      <xref linkend="selenium.seleniumtestcase.tables.assertions" /> lista os
       vários métodos de asserção que o <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
       fornece.
     </para>
@@ -422,7 +422,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      <xref linkend="selenium.seleniumtestcase.tables.template-methods" /> mostra 
+      <xref linkend="selenium.seleniumtestcase.tables.template-methods" /> mostra
       o método modelo de <literal>PHPUnit_Extensions_SeleniumTestCase</literal>:
     </para>
 
@@ -446,7 +446,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Por favor, verifique a <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentação dos comandos do Selenium</ulink> 
+      Por favor, verifique a <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentação dos comandos do Selenium</ulink>
       para uma referência de todos os comandos disponíveis e como eles são utilizados.
     </para>
     <para>
@@ -454,13 +454,13 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </para>
 
     <para>
-      Usando o método <literal>runSelenese($filename)</literal> você também pode 
-      executar um teste Selenium a partir de sua especificação Selenese/HTML. Além disso, 
-      usando o atributo estático <literal>$seleneseDirectory</literal>, você pode 
-      criar automaticamente objetos de teste a partir de um diretório que contenha 
-      arquivos Selenese/HTML. O diretório especificado é pesquisado recursivamente por 
+      Usando o método <literal>runSelenese($filename)</literal> você também pode
+      executar um teste Selenium a partir de sua especificação Selenese/HTML. Além disso,
+      usando o atributo estático <literal>$seleneseDirectory</literal>, você pode
+      criar automaticamente objetos de teste a partir de um diretório que contenha
+      arquivos Selenese/HTML. O diretório especificado é pesquisado recursivamente por
       arquivos <literal>.htm</literal> que possam conter Selenese/HTML.
-     O <xref linkend="selenium.seleniumtestcase.examples.WebTest4.php" /> mostra um 
+     O <xref linkend="selenium.seleniumtestcase.examples.WebTest4.php" /> mostra um
      exemplo.
     </para>
 
@@ -477,8 +477,8 @@ class SeleneseTests extends PHPUnit_Extensions_SeleniumTestCase
     </example>
 
     <para>
-    Desde o Selenium 1.1.1, um recurso experimental foi incluído para permitir ao usuário compartilhar a sessão entre testes. O único caso suportado é compartilhar a sessão entre todos os testes quando um único navegador é usado. 
-    Chame <literal>PHPUnit_Extensions_SeleniumTestCase::shareSession(true)</literal> em seu arquivo bootstrap para habilitar o compartilhamento de sessão. 
+    Desde o Selenium 1.1.1, um recurso experimental foi incluído para permitir ao usuário compartilhar a sessão entre testes. O único caso suportado é compartilhar a sessão entre todos os testes quando um único navegador é usado.
+    Chame <literal>PHPUnit_Extensions_SeleniumTestCase::shareSession(true)</literal> em seu arquivo bootstrap para habilitar o compartilhamento de sessão.
     A sessão será reiniciada no caso de testes mal-sucedidos (falhos ou incompletos); cabe ao usuário evitar interações entre testes seja resetando cookies ou deslogando da aplicação sob teste (com um método tearDown()).
     </para>
   </section>

--- a/src/4.7/pt_br/test-doubles.xml
+++ b/src/4.7/pt_br/test-doubles.xml
@@ -13,11 +13,11 @@
     <para>
       <indexterm><primary>Sistema Sob Teste</primary></indexterm>
 
-      Às vezes é muito difícil testar o sistema sob teste (SST - em inglês: system under test - SUT) 
-      porque isso depende de outros ambientes que não podem ser usados no ambiente 
-      de testes. Isso pode ser porque não estão disponíveis, não retornarão 
-      os resultados necessários para o teste, ou porque executá-los 
-      causaria efeitos colaterais indesejáveis. Em outros casos, nossa estratégia de testes requer 
+      Às vezes é muito difícil testar o sistema sob teste (SST - em inglês: system under test - SUT)
+      porque isso depende de outros ambientes que não podem ser usados no ambiente
+      de testes. Isso pode ser porque não estão disponíveis, não retornarão
+      os resultados necessários para o teste, ou porque executá-los
+      causaria efeitos colaterais indesejáveis. Em outros casos, nossa estratégia de testes requer
       que tenhamos mais controle ou visibilidade do comportamento interno do SST.
     </para>
 
@@ -25,27 +25,27 @@
       <indexterm><primary>Componente Dependente</primary></indexterm>
       <indexterm><primary>Dublê de Teste</primary></indexterm>
 
-      Quando estamos escrevendo um teste no qual não podemos (ou decidimos não) usar um componente 
-      dependente (depended-on component - DOC) real, podemos substitui-lo por um Dublê de Teste. O 
-      Dublê de Teste não precisa se comportar exatamente como o DOC real; apenas precisa 
-      fornecer a mesma API como o real, de forma que o SST pense que é 
+      Quando estamos escrevendo um teste no qual não podemos (ou decidimos não) usar um componente
+      dependente (depended-on component - DOC) real, podemos substitui-lo por um Dublê de Teste. O
+      Dublê de Teste não precisa se comportar exatamente como o DOC real; apenas precisa
+      fornecer a mesma API como o real, de forma que o SST pense que é
       o real!
     </para>
   </blockquote>
 
   <para>
-    O método <literal>getMockBuilder($type)</literal> fornecido pelo PHPUnit pode 
-    ser usado em um teste para gerar automaticamente um objeto que possa atuar como um dublê 
-    de teste para a classe original especificada. Esse objeto de 
-    dublê de teste pode ser usado em cada contexto onde um objeto da classe original 
+    O método <literal>getMockBuilder($type)</literal> fornecido pelo PHPUnit pode
+    ser usado em um teste para gerar automaticamente um objeto que possa atuar como um dublê
+    de teste para a classe original especificada. Esse objeto de
+    dublê de teste pode ser usado em cada contexto onde um objeto da classe original
     é esperado ou requerido.
   </para>
 
   <para>
-    Por padrão, todos os métodos da classe original são substituídos com uma implementação 
-    simulada que apenas retorna <literal>null</literal> (sem chamar 
-    o método original). Usando o método <literal>will($this->returnValue())</literal>, 
-    por exemplo, você pode configurar essas implementações simuladas para 
+    Por padrão, todos os métodos da classe original são substituídos com uma implementação
+    simulada que apenas retorna <literal>null</literal> (sem chamar
+    o método original). Usando o método <literal>will($this->returnValue())</literal>,
+    por exemplo, você pode configurar essas implementações simuladas para
     retornar um valor quando chamadas.
   </para>
 
@@ -54,8 +54,8 @@
 
     <para>
       Por favor, note que os métodos <literal>final</literal>, <literal>private</literal>
-      e <literal>static</literal> não podem ser esboçados (stubbed) ou falsificados (mocked). Eles 
-      são ignorados pela funcionalidade de dublê de teste do PHPUnit e mantêm seus 
+      e <literal>static</literal> não podem ser esboçados (stubbed) ou falsificados (mocked). Eles
+      são ignorados pela funcionalidade de dublê de teste do PHPUnit e mantêm seus
       comportamentos originais.
     </para>
   </note>
@@ -64,7 +64,7 @@
     <title>Aviso</title>
 
     <para>
-        Por favor atente para o fato de que a gestão de parâmetros foi mudada. 
+        Por favor atente para o fato de que a gestão de parâmetros foi mudada.
         A implementação anterior clona todos os parâmetros de objetos. Isso não permite verificar se o mesmo objeto foi passado para um método ou não.
         <xref linkend="test-doubles.mock-objects.examples.clone-object-parameters-usecase.php" /> mostra onde a nova implementação pode ser útil.
         <xref linkend="test-doubles.mock-objects.examples.enable-clone-object-parameters.php" /> mostra como voltar para o comportamento anterior.
@@ -77,27 +77,27 @@
     <para>
       <indexterm><primary>Esboço</primary></indexterm>
 
-      A prática de substituir um objeto por um dublê de teste que (opcionalmente) 
+      A prática de substituir um objeto por um dublê de teste que (opcionalmente)
       retorna valores de retorno configurados é chamada de
-      <emphasis>delineamento</emphasis>. Você pode usar um <emphasis>esboço</emphasis> para 
-      "substituir um componente real do qual o SST depende de modo que o teste tenha um 
-      ponto de controle para as entradas indiretas do SST. Isso permite ao teste 
+      <emphasis>delineamento</emphasis>. Você pode usar um <emphasis>esboço</emphasis> para
+      "substituir um componente real do qual o SST depende de modo que o teste tenha um
+      ponto de controle para as entradas indiretas do SST. Isso permite ao teste
       forçar o SST através de caminhos que não seriam executáveis de outra forma".
     </para>
 
     <para>
       <indexterm><primary>Interface Fluente</primary></indexterm>
 
-      <xref linkend="test-doubles.stubs.examples.StubTest.php" /> mostra como 
-      esboçar chamadas de método e configurar valores de retorno. Primeiro usamos o 
-      método <literal>getMockBuilder()</literal> que é fornecido pela 
-      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um esboço 
+      <xref linkend="test-doubles.stubs.examples.StubTest.php" /> mostra como
+      esboçar chamadas de método e configurar valores de retorno. Primeiro usamos o
+      método <literal>getMockBuilder()</literal> que é fornecido pela
+      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um esboço
       de objeto que parece com um objeto de <literal>SomeClass</literal>
-      (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). Então 
+      (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). Então
       usamos a <ulink url="http://martinfowler.com/bliki/FluentInterface.html">Interface Fluente</ulink>
-      que o PHPUnit fornece para especificar o comportamento para o esboço. Essencialmente, 
-      isso significa que você não precisa criar vários objetos temporários e 
-      uni-los depois. Em vez disso, você encadeia chamadas de método como mostrado no 
+      que o PHPUnit fornece para especificar o comportamento para o esboço. Essencialmente,
+      isso significa que você não precisa criar vários objetos temporários e
+      uni-los depois. Em vez disso, você encadeia chamadas de método como mostrado no
       exemplo. Isso leva a códigos mais legíveis e "fluentes".
     </para>
 
@@ -134,22 +134,22 @@ class StubTest extends PHPUnit_Framework_TestCase
         $stub->method('doSomething')
              ->willReturn('foo');
 
-        // Chamando $esboco->fazAlgumaCoisa() agora vai retornar 
+        // Chamando $esboco->fazAlgumaCoisa() agora vai retornar
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      "Atrás dos bastidores" o PHPUnit automaticamente gera uma nova classe PHP que 
+      "Atrás dos bastidores" o PHPUnit automaticamente gera uma nova classe PHP que
       implementa o comportamento desejado quando o método <literal>getMock()</literal>
       é usado.
     </para>
 
     <para>
-      <xref linkend="test-doubles.stubs.examples.StubTest2.php"/> mostra um 
+      <xref linkend="test-doubles.stubs.examples.StubTest2.php"/> mostra um
       exemplo de como usar a interface fluente do Mock Builder para configurar a
       criação do dublê de teste.
     </para>
@@ -177,7 +177,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Chamar $stub->doSomething() agora vai retornar
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -195,18 +195,18 @@ class StubTest extends PHPUnit_Framework_TestCase
       <listitem><para><literal>disableOriginalClone()</literal> pode ser usado para desabilitar a chamada ao construtor do clone da classe original.</para></listitem>
       <listitem><para><literal>disableAutoload()</literal> pode ser usado para desabilitar o <literal>__autoload()</literal> durante a geração da classe de dublê de teste.</para></listitem>
     </itemizedlist>
-    
+
     <para>
       Nos exemplos até agora temos retornado valores simples usando
-      <literal>willReturn($value)</literal>. Essa sintaxe curta é o mesmo que 
-      <literal>will($this->returnValue($value))</literal>. Podemos usar variações 
+      <literal>willReturn($value)</literal>. Essa sintaxe curta é o mesmo que
+      <literal>will($this->returnValue($value))</literal>. Podemos usar variações
       desta sintaxe longa para alcançar mais comportamento de esboço complexo.
     </para>
 
     <para>
-      Às vezes você quer retornar um dos argumentos de uma chamada de método 
+      Às vezes você quer retornar um dos argumentos de uma chamada de método
       (inalterada) como o resultado de uma chamada ao método esboçado.
-      <xref linkend="test-doubles.stubs.examples.StubTest3.php"/> mostra como você 
+      <xref linkend="test-doubles.stubs.examples.StubTest3.php"/> mostra como você
       pode conseguir isso usando <literal>returnArgument()</literal> em vez de
       <literal>returnValue()</literal>.
     </para>
@@ -233,19 +233,19 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') retorna 'foo'.
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') retorna 'bar'.
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Ao testar uma interface fluente, às vezes é útil fazer um método 
+      Ao testar uma interface fluente, às vezes é útil fazer um método
       esboçado retornar uma referência ao objeto esboçado.
-      <xref linkend="test-doubles.stubs.examples.StubTest4.php"/> mostra como você 
+      <xref linkend="test-doubles.stubs.examples.StubTest4.php"/> mostra como você
       pode usar <literal>returnSelf()</literal> para conseguir isso.
     </para>
 
@@ -271,18 +271,18 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() retorna $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Algumas vezes um método esboçado deveria retornar valores diferentes dependendo de 
+      Algumas vezes um método esboçado deveria retornar valores diferentes dependendo de
       uma lista predefinida de argumentos. Você pode usar
-      <literal>returnValueMap()</literal> para criar um mapa que associa 
+      <literal>returnValueMap()</literal> para criar um mapa que associa
       argumentos com valores de retorno correspondentes. Veja
-      <xref linkend="test-doubles.stubs.examples.StubTest5.php"/> para 
+      <xref linkend="test-doubles.stubs.examples.StubTest5.php"/> para
       ter um exemplo.
     </para>
 
@@ -313,20 +313,20 @@ class StubTest extends PHPUnit_Framework_TestCase
         $stub->method('doSomething')
              ->will($this->returnValueMap($map));
 
-        // $stub->doSomething() retorna diferentes valores dependendo do 
+        // $stub->doSomething() retorna diferentes valores dependendo do
         // argumento fornecido.
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Quando a chamada ao método esboçado deve retornar um valor calculado em vez de 
-      um fixo (veja <literal>returnValue()</literal>) ou um argumento (inalterado) 
+      Quando a chamada ao método esboçado deve retornar um valor calculado em vez de
+      um fixo (veja <literal>returnValue()</literal>) ou um argumento (inalterado)
       (veja <literal>returnArgument()</literal>), você pode usar
-      <literal>returnCallback()</literal> para que o método esboçado retorne o 
+      <literal>returnCallback()</literal> para que o método esboçado retorne o
       resultado da função ou método callback. Veja
       <xref linkend="test-doubles.stubs.examples.StubTest6.php"/> para ter um exemplo.
     </para>
@@ -353,17 +353,17 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) retorna str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Uma alternativa mais simples para configurar um método callback pode ser 
-      especificar uma lista de valores de retorno desejados. Você pode fazer isso com 
+      Uma alternativa mais simples para configurar um método callback pode ser
+      especificar uma lista de valores de retorno desejados. Você pode fazer isso com
       o método <literal>onConsecutiveCalls()</literal>. Veja
-      <xref linkend="test-doubles.stubs.examples.StubTest7.php"/> para 
+      <xref linkend="test-doubles.stubs.examples.StubTest7.php"/> para
       ter um exemplo.
     </para>
 
@@ -372,7 +372,7 @@ class StubTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>will()</primary></indexterm>
       <indexterm><primary>onConsecutiveCalls()</primary></indexterm>
-      <title>Esboçando uma chamada de método para retornar uma lista de valores na 
+      <title>Esboçando uma chamada de método para retornar uma lista de valores na
       ordem especificada</title>
       <programlisting><![CDATA[<?php
 require_once 'SomeClass.php';
@@ -390,9 +390,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() retorna um valor diferente em cada vez
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -400,7 +400,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
 
     <para>
-      Em vez de retornar um valor, um método esboçado também pode causar uma 
+      Em vez de retornar um valor, um método esboçado também pode causar uma
       exceção. <xref linkend="test-doubles.stubs.examples.StubTest8.php"/>
       mostra como usar <literal>throwException()</literal> para fazer isso.
     </para>
@@ -434,23 +434,23 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Alternativamente, você mesmo pode escrever um esboço enquanto melhora 
-      o design. Recursos amplamente utilizados são acessados através de uma única fachada, 
-      então você pode substituir facilmente o recurso pelo esboço. Por exemplo, 
-      em vez de ter chamadas diretas ao banco de dados espalhadas pelo código, 
-      você tem um único objeto <literal>Database</literal> que implementa a interface 
-      <literal>IDatabase</literal>. Então, você pode criar um esboço 
-      de implementação da <literal>IDatabase</literal> e usá-la em seus 
-      testes. Você pode até criar uma opção para executar os testes com o 
-      esboço do banco de dados ou com o banco de dados real, então você pode usar seus testes tanto 
-      para testes locais durante o desenvolvimento quanto para integração dos testes com o 
+      Alternativamente, você mesmo pode escrever um esboço enquanto melhora
+      o design. Recursos amplamente utilizados são acessados através de uma única fachada,
+      então você pode substituir facilmente o recurso pelo esboço. Por exemplo,
+      em vez de ter chamadas diretas ao banco de dados espalhadas pelo código,
+      você tem um único objeto <literal>Database</literal> que implementa a interface
+      <literal>IDatabase</literal>. Então, você pode criar um esboço
+      de implementação da <literal>IDatabase</literal> e usá-la em seus
+      testes. Você pode até criar uma opção para executar os testes com o
+      esboço do banco de dados ou com o banco de dados real, então você pode usar seus testes tanto
+      para testes locais durante o desenvolvimento quanto para integração dos testes com o
       banco de dados real.
     </para>
 
     <para>
-      Funcionalidades que precisam ser esboçadas tendem a se agrupar no mesmo 
-      objeto, aumentando a coesão. Por apresentar a funcionalidade com uma 
-      interface única e coerente, você reduz o acoplamento com o resto do 
+      Funcionalidades que precisam ser esboçadas tendem a se agrupar no mesmo
+      objeto, aumentando a coesão. Por apresentar a funcionalidade com uma
+      interface única e coerente, você reduz o acoplamento com o resto do
       sistema.
     </para>
   </section>
@@ -459,20 +459,20 @@ class StubTest extends PHPUnit_Framework_TestCase
     <title>Objetos Falsos</title>
 
     <para>
-      A prática de substituir um objeto por um dublê de teste que verifica 
-      expectativas, por exemplo asseverando que um método foi chamado, é 
+      A prática de substituir um objeto por um dublê de teste que verifica
+      expectativas, por exemplo asseverando que um método foi chamado, é
       conhecido como <emphasis>falsificação (mocking)</emphasis>.
     </para>
 
     <para>
       <indexterm><primary>Objeto Falso</primary></indexterm>
 
-      Você pode usar um <emphasis>objeto falso</emphasis> "como um ponto de observação 
-      que é usado para verificar as saídas indiretas do SST durante seu exercício. 
-      Tipicamente, o objeto falso também inclui a funcionalidade de um esboço de teste 
-      que deve retornar valores para o SST se ainda não tiver falhado 
-      nos testes, mas a ênfase está na verificação das saídas indiretas. 
-      Portanto, um objeto falso é muito mais que apenas um esboço de testes mais 
+      Você pode usar um <emphasis>objeto falso</emphasis> "como um ponto de observação
+      que é usado para verificar as saídas indiretas do SST durante seu exercício.
+      Tipicamente, o objeto falso também inclui a funcionalidade de um esboço de teste
+      que deve retornar valores para o SST se ainda não tiver falhado
+      nos testes, mas a ênfase está na verificação das saídas indiretas.
+      Portanto, um objeto falso é muito mais que apenas um esboço de testes mais
       asserções; é utilizado de uma forma fundamentalmente diferente".
     </para>
 
@@ -481,15 +481,15 @@ class StubTest extends PHPUnit_Framework_TestCase
 
       <para>
         Somente objetos falsos gerados no escopo de um teste irá ser verificado
-        automaticamente pelo PHPUnit. Objetos falsos gerados em provedores de dados, por 
+        automaticamente pelo PHPUnit. Objetos falsos gerados em provedores de dados, por
         exemplo, não serão verificados pelo PHPUnit.
       </para>
     </note>
-    
+
     <para>
       Aqui está um exemplo: suponha que queiramos testar se o método correto,
-      <literal>update()</literal> em nosso exemplo, é chamado em um objeto que 
-      observa outro objeto. <xref linkend="test-doubles.mock-objects.examples.SUT.php"/> 
+      <literal>update()</literal> em nosso exemplo, é chamado em um objeto que
+      observa outro objeto. <xref linkend="test-doubles.mock-objects.examples.SUT.php"/>
       mostra o código para as classes <literal>Subject</literal> e <literal>Observer</literal>
       que são parte do Sistema Sob Teste (SST).
     </para>
@@ -565,21 +565,21 @@ class Observer
       <indexterm><primary>Objeto Falso</primary></indexterm>
 
       <xref linkend="test-doubles.mock-objects.examples.SubjectTest.php" />
-      mostra como usar um objeto falso para testar a interação entre 
+      mostra como usar um objeto falso para testar a interação entre
       os objetos <literal>Subject</literal> e <literal>Observer</literal>.
     </para>
 
     <para>
-      Primeiro usamos o método <literal>getMock()</literal> que é fornecido pela 
-      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um objeto 
-      falso para ser o <literal>Observer</literal>. Já que fornecemos um vetor como 
-      segundo parâmetro (opcional) para o método <literal>getMock()</literal>, 
-      apenas o método <literal>update()</literal> da classe 
+      Primeiro usamos o método <literal>getMock()</literal> que é fornecido pela
+      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um objeto
+      falso para ser o <literal>Observer</literal>. Já que fornecemos um vetor como
+      segundo parâmetro (opcional) para o método <literal>getMock()</literal>,
+      apenas o método <literal>update()</literal> da classe
       <literal>Observer</literal> é substituído por uma implementação falsificada.
     </para>
 
     <para>
-      Porque estamos interessados em verificar se um método foi chamado, e com quais 
+      Porque estamos interessados em verificar se um método foi chamado, e com quais
       argumentos ele foi chamado, introduzimos os métodos <literal>expects()</literal> e
       <literal>with()</literal> para especificar como essa interação deve considerar.
     </para>
@@ -619,14 +619,14 @@ class SubjectTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      O método <literal>with()</literal> pode receber qualquer número de 
-      argumentos, correspondendo ao número de argumentos 
-      sendo falsos. Você pode especificar restrições mais avançadas 
+      O método <literal>with()</literal> pode receber qualquer número de
+      argumentos, correspondendo ao número de argumentos
+      sendo falsos. Você pode especificar restrições mais avançadas
       do que uma simples igualdade no argumento do método.
     </para>
 
     <example id="test-doubles.mock-objects.examples.MultiParameterTest.php">
-      <title>Testando se um método é chamado com um número de 
+      <title>Testando se um método é chamado com um número de
       argumentos restringidos de formas diferentes</title>
       <programlisting><![CDATA[<?php
 class SubjectTest extends PHPUnit_Framework_TestCase
@@ -657,11 +657,11 @@ class SubjectTest extends PHPUnit_Framework_TestCase
 }
 ?>]]></programlisting>
     </example>
-    
+
     <para>
-      O método <literal>withConsecutive()</literal> pode receber qualquer número de 
+      O método <literal>withConsecutive()</literal> pode receber qualquer número de
       vetores de argumentos, dependendo das chamados que você quer testar contra.
-      Cada vetor é uma lista de restrições correspondentes para os argumentos do 
+      Cada vetor é uma lista de restrições correspondentes para os argumentos do
       método falsificado, como em <literal>with()</literal>.
     </para>
 
@@ -692,9 +692,9 @@ class FooTest extends PHPUnit_Framework_TestCase
 
     <para>
       A restrição <literal>callback()</literal> pode ser usada para verificação de argumento
-      mais complexa. Essa restrição recebe um callback PHP como seu único 
-      argumento. O callback PHP receberá o argumento a ser verificado como 
-      seu único argumento e deverá retornar <literal>TRUE</literal> se o 
+      mais complexa. Essa restrição recebe um callback PHP como seu único
+      argumento. O callback PHP receberá o argumento a ser verificado como
+      seu único argumento e deverá retornar <literal>TRUE</literal> se o
       argumento passou a verificação e <literal>FALSE</literal> caso contrário.
     </para>
 
@@ -778,7 +778,7 @@ class FooTest extends PHPUnit_Framework_TestCase
       <xref linkend="appendixes.assertions.assertThat.tables.constraints"/>
       mostra as restrições que podem ser aplicadas aos argumentos do método e
       <xref linkend="test-doubles.mock-objects.tables.matchers"/>
-      mostra os comparados que estão disponíveis para especificar o número de 
+      mostra os comparados que estão disponíveis para especificar o número de
       invocações.
     </para>
 
@@ -824,22 +824,22 @@ class FooTest extends PHPUnit_Framework_TestCase
     <note>
       <para>
         O parâmetro <literal>$index</literal> para o comparador <literal>at()</literal>
-        se refere ao índice, iniciando em zero, em <emphasis>todas invocações 
-        de métodos</emphasis> para um objeto falsificado fornecido. Tenha cuidado ao 
-        usar este comparador, pois pode levar a testes frágeis que são muito 
+        se refere ao índice, iniciando em zero, em <emphasis>todas invocações
+        de métodos</emphasis> para um objeto falsificado fornecido. Tenha cuidado ao
+        usar este comparador, pois pode levar a testes frágeis que são muito
         intimamente ligados a detalhes de implementação específicos.
       </para>
     </note>
   </section>
-  
+
   <section id="test-doubles.prophecy">
     <title>Profecia</title>
 
     <para>
       <ulink url="https://github.com/phpspec/prophecy">Prophecy</ulink> é um
-      "framework PHP de falsificação de objetos muito poderoso e flexível, porém 
-      altamente opcional. Embora inicialmente criado para atender as necessidades do phpspec2, ele é 
-      flexível o suficiente para ser usado dentro de qualquer framework de teste por aí, com 
+      "framework PHP de falsificação de objetos muito poderoso e flexível, porém
+      altamente opcional. Embora inicialmente criado para atender as necessidades do phpspec2, ele é
+      flexível o suficiente para ser usado dentro de qualquer framework de teste por aí, com
       o mínimo de esforço".
     </para>
 
@@ -847,7 +847,7 @@ class FooTest extends PHPUnit_Framework_TestCase
       O PHPUnit tem suporte nativo para uso do Prophecy para criar dublês de testes
       desde a versão 4.5. <xref linkend="test-doubles.prophecy.examples.SubjectTest.php"/>
       mostra como o mesmo teste mostrado no <xref linkend="test-doubles.mock-objects.examples.SubjectTest.php"/>
-      pode ser expressado usando a filosofia do Prophecy de profecias e 
+      pode ser expressado usando a filosofia do Prophecy de profecias e
       revelações:
     </para>
 
@@ -895,7 +895,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>getMockForTrait()</primary></indexterm>
 
       O método <literal>getMockForTrait()</literal> retorna um objeto falsificado
-      que usa uma trait especificada. Todos métodos abstratos de uma dada trait 
+      que usa uma trait especificada. Todos métodos abstratos de uma dada trait
       são falsificados. Isto permite testar os métodos concretos de uma trait.
     </para>
 
@@ -922,18 +922,18 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
     </example>
-    
+
     <para>
       <indexterm><primary>getMockForAbstractClass()</primary></indexterm>
 
-      O método <literal>getMockForAbstractClass()</literal> retorna um objeto 
-      falso para uma classe abstrata. Todos os métodos abstratos da classe abstrata fornecida 
-      são falsificados. Isto permite testar os métodos concretos de uma 
+      O método <literal>getMockForAbstractClass()</literal> retorna um objeto
+      falso para uma classe abstrata. Todos os métodos abstratos da classe abstrata fornecida
+      são falsificados. Isto permite testar os métodos concretos de uma
       classe abstrata.
     </para>
 
@@ -960,7 +960,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -973,18 +973,18 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>getMockFromWsdl()</primary></indexterm>
 
-      Quando sua aplicação interage com um serviço web você quer testá-lo 
-      sem realmente interagir com o serviço web. Para tornar mais fáceis o esboço 
+      Quando sua aplicação interage com um serviço web você quer testá-lo
+      sem realmente interagir com o serviço web. Para tornar mais fáceis o esboço
       e falsificação dos serviços web, o <literal>getMockFromWsdl()</literal>
-      pode ser usado da mesma forma que o <literal>getMock()</literal> (veja acima). A única 
-      diferença é que <literal>getMockFromWsdl()</literal> retorna um esboço ou 
+      pode ser usado da mesma forma que o <literal>getMock()</literal> (veja acima). A única
+      diferença é que <literal>getMockFromWsdl()</literal> retorna um esboço ou
       falsificação baseado em uma descrição de um serviço web em WSDL e <literal>getMock()</literal>
       retorna um esboço ou falsificação baseado em uma classe ou interface PHP.
     </para>
 
     <para>
       <xref linkend="test-doubles.stubbing-and-mocking-web-services.examples.GoogleTest.php"/>
-      mostra como <literal>getMockFromWsdl()</literal> pode ser usado para esboçar, por 
+      mostra como <literal>getMockFromWsdl()</literal> pode ser usado para esboçar, por
       exemplo, o serviço web descrito em <filename>GoogleSearch.wsdl</filename>.
     </para>
 
@@ -1035,7 +1035,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() will now return a stubbed result and
          * the web service's doGoogleSearch() method will not be invoked.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1063,15 +1063,15 @@ class GoogleTest extends PHPUnit_Framework_TestCase
       <ulink url="https://github.com/mikey179/vfsStream">vfsStream</ulink>
       é um <ulink url="http://www.php.net/streams">stream wrapper</ulink> para um
       <ulink url="http://en.wikipedia.org/wiki/Virtual_file_system">sistema de arquivos virtual
-      </ulink> que pode ser útil em testes unitários para falsificar um sistema 
+      </ulink> que pode ser útil em testes unitários para falsificar um sistema
       de arquivos real.
     </para>
 
     <para>
-      Simplesmente adicione a dependência <literal>mikey179/vfsStream</literal> ao seu 
+      Simplesmente adicione a dependência <literal>mikey179/vfsStream</literal> ao seu
       arquivo <literal>composer.json</literal> do projeto se você usa o
-      <ulink url="https://getcomposer.org/">Composer</ulink> para gerenciar as 
-      dependências do seu projeto. Aqui é um exemplo simplório de um arquivo 
+      <ulink url="https://getcomposer.org/">Composer</ulink> para gerenciar as
+      dependências do seu projeto. Aqui é um exemplo simplório de um arquivo
       <literal>composer.json</literal> que apenas define uma dependência em ambiente de
       desenvolvimento para o PHPUnit 4.7 e vfsStream:
     </para>
@@ -1113,8 +1113,8 @@ class Example
     </example>
 
     <para>
-      Sem um sistema de arquivos virtual tal como o vfsStream não poderíamos testar o 
-      método <literal>setDirectory()</literal> isolado de influências 
+      Sem um sistema de arquivos virtual tal como o vfsStream não poderíamos testar o
+      método <literal>setDirectory()</literal> isolado de influências
       externas (veja <xref
       linkend="test-doubles.mocking-the-filesystem.examples.ExampleTest.php"/>).
     </para>
@@ -1136,10 +1136,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1164,7 +1164,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
 
     <para>
       <xref linkend="test-doubles.mocking-the-filesystem.examples.ExampleTest2.php"/>
-      mostra como o vfsStream pode ser usado para falsificar o sistema de arquivos em um teste para uma 
+      mostra como o vfsStream pode ser usado para falsificar o sistema de arquivos em um teste para uma
       classe que interage com o sistema de arquivos.
     </para>
 
@@ -1185,10 +1185,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/pt_br/textui.xml
+++ b/src/4.7/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -401,7 +401,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict</literal></term>
         <listitem>
@@ -601,7 +601,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -612,7 +612,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -623,18 +623,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -644,7 +644,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -672,7 +672,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -681,7 +681,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -704,17 +704,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -730,16 +730,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -798,14 +798,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -817,7 +817,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -842,7 +842,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/4.7/pt_br/writing-tests-for-phpunit.xml
+++ b/src/4.7/pt_br/writing-tests-for-phpunit.xml
@@ -6,9 +6,9 @@
   <para>
     <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
-    <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" /> mostra 
-    como podemos escrever testes usando o PHPUnit que exercita operações de vetor do PHP. 
-    O exemplo introduz as convenções básicas e passos para escrever testes 
+    <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" /> mostra
+    como podemos escrever testes usando o PHPUnit que exercita operações de vetor do PHP.
+    O exemplo introduz as convenções básicas e passos para escrever testes
     com o PHPUnit:
   </para>
 
@@ -27,14 +27,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -43,8 +43,8 @@ class StackTest extends PHPUnit_Framework_TestCase
   <blockquote>
     <attribution>Martin Fowler</attribution>
     <para>
-      Sempre que você estiver tentado a escrever algo em uma 
-      declaração <literal>print</literal> ou uma expressão depuradora, escreva 
+      Sempre que você estiver tentado a escrever algo em uma
+      declaração <literal>print</literal> ou uma expressão depuradora, escreva
       como um teste em vez disso.
     </para>
   </blockquote>
@@ -55,13 +55,13 @@ class StackTest extends PHPUnit_Framework_TestCase
     <blockquote>
       <attribution>Adrian Kuhn et. al.</attribution>
       <para>
-        Testes Unitários são primeiramente escritos como uma boa prática para ajudar desenvolvedores 
-        a identificar e corrigir defeitos, refatorar o código e servir como documentação 
-        para uma unidade de programa sob teste. Para conseguir esses benefícios, testes unitários 
-        idealmente deveriam cobrir todos os caminhos possíveis em um programa. Um teste unitário 
-        geralmente cobre um caminho específico em uma função ou método. Porém um 
-        método de teste não é necessariamente uma entidade encapsulada e independente. Às vezes 
-        existem dependências implícitas entre métodos de teste, escondidas no 
+        Testes Unitários são primeiramente escritos como uma boa prática para ajudar desenvolvedores
+        a identificar e corrigir defeitos, refatorar o código e servir como documentação
+        para uma unidade de programa sob teste. Para conseguir esses benefícios, testes unitários
+        idealmente deveriam cobrir todos os caminhos possíveis em um programa. Um teste unitário
+        geralmente cobre um caminho específico em uma função ou método. Porém um
+        método de teste não é necessariamente uma entidade encapsulada e independente. Às vezes
+        existem dependências implícitas entre métodos de teste, escondidas no
         cenário de implementação de um teste.
       </para>
     </blockquote>
@@ -69,9 +69,9 @@ class StackTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>Dependências de Testes</primary></indexterm>
 
-      O PHPUnit suporta a declaração explícita de dependências entre métodos de teste. 
-      Tais dependências não definem a ordem em que os métodos de teste 
-      devem ser executados, mas permitem o retorno de uma instância do 
+      O PHPUnit suporta a declaração explícita de dependências entre métodos de teste.
+      Tais dependências não definem a ordem em que os métodos de teste
+      devem ser executados, mas permitem o retorno de uma instância do
       ambiente do teste por um produtor e a passagem dele para os consumidores dependentes.
     </para>
 
@@ -84,8 +84,8 @@ class StackTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Anotação</primary></indexterm>
       <indexterm><primary>@depends</primary></indexterm>
 
-      <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> mostra 
-      como usar a anotação <literal>@depends</literal> para expressar 
+      <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> mostra
+      como usar a anotação <literal>@depends</literal> para expressar
       dependências entre métodos de teste.
     </para>
 
@@ -97,7 +97,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -108,8 +108,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -119,16 +119,16 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      No exemplo acima, o primeiro teste, <literal>testEmpty()</literal>, 
-      cria um novo vetor e assegura que o mesmo é vazio. O teste então retorna 
+      No exemplo acima, o primeiro teste, <literal>testEmpty()</literal>,
+      cria um novo vetor e assegura que o mesmo é vazio. O teste então retorna
       o ambiente como resultado. O segundo teste, <literal>testPush()</literal>,
       depende de <literal>testEmpty()</literal> e lhe é passado o resultado do qual
       ele depende como um argumento. Finalmente, <literal>testPop()</literal>
@@ -138,9 +138,9 @@ class StackTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>Localização de Defeitos</primary></indexterm>
 
-      Para localizar defeitos rapidamente, queremos nossa atenção focada nas 
-      falhas relevantes dos testes. É por isso que o PHPUnit pula a execução de um teste 
-      quando um teste do qual ele depende falha. Isso melhora a localização de defeitos por 
+      Para localizar defeitos rapidamente, queremos nossa atenção focada nas
+      falhas relevantes dos testes. É por isso que o PHPUnit pula a execução de um teste
+      quando um teste do qual ele depende falha. Isso melhora a localização de defeitos por
       explorar as dependências entre os testes como mostrado em
       <xref linkend="writing-tests-for-phpunit.examples.DependencyFailureTest.php" />.
     </para>
@@ -152,7 +152,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -163,7 +163,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
     }
 }
 ?>]]></programlisting>
-    
+
       <screen><userinput>phpunit --verbose DependencyFailureTest</userinput><![CDATA[
 PHPUnit 4.7.0 by Sebastian Bergmann and contributors.
 
@@ -189,19 +189,19 @@ Tests: 1, Assertions: 1, Failures: 1, Skipped: 1.]]></screen>
     </example>
 
     <para>
-      Um teste pode ter mais de uma anotação <literal>@depends</literal>. 
-      O PHPUnit não muda a ordem em que os testes são executados, portanto você deve 
-      se certificar de que as dependências de um teste podem realmente ser encontradas antes de 
+      Um teste pode ter mais de uma anotação <literal>@depends</literal>.
+      O PHPUnit não muda a ordem em que os testes são executados, portanto você deve
+      se certificar de que as dependências de um teste podem realmente ser encontradas antes de
       executar o teste.
     </para>
-    
+
     <para>
       Um teste que tem mais de uma anotação <literal>@depends</literal>
-      vai obter um ambiente a partir do primeiro produtor como o primeiro argumento, um ambiente 
+      vai obter um ambiente a partir do primeiro produtor como o primeiro argumento, um ambiente
       a partir do segundo produtor como o segundo argumento, e assim por diante.
       Veja <xref linkend="writing-tests-for-phpunit.examples.MultipleDependencies.php" />
     </para>
-    
+
     <example id="writing-tests-for-phpunit.examples.MultipleDependencies.php">
       <title>Teste com múltiplas dependências</title>
       <programlisting><![CDATA[<?php
@@ -209,13 +209,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -225,7 +225,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -250,18 +250,18 @@ OK (3 tests, 3 assertions)]]></screen>
     <para>
       <indexterm><primary>Anotação</primary></indexterm>
       <indexterm><primary>@dataProvider</primary></indexterm>
-      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser 
+      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser
       fornecidos por um método provedor de dados (<literal>additionProvider()</literal> em
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
-      O método provedor de dados a ser usado é especificado usando a 
+      O método provedor de dados a ser usado é especificado usando a
       anotação <literal>@dataProvider</literal>.
     </para>
 
     <para>
-      Um método provedor de dados deve ser <literal>public</literal> e ou retornar 
-      um vetor de vetores ou um objeto que implementa a interface <literal>Iterator</literal> 
-      e produz um vetor para cada passo da iteração. Para cada vetor que 
-      é parte da coleção o método de teste será chamado com os conteúdos 
+      Um método provedor de dados deve ser <literal>public</literal> e ou retornar
+      um vetor de vetores ou um objeto que implementa a interface <literal>Iterator</literal>
+      e produz um vetor para cada passo da iteração. Para cada vetor que
+      é parte da coleção o método de teste será chamado com os conteúdos
       do vetor como seus argumentos.
     </para>
 
@@ -275,7 +275,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -320,7 +320,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -396,13 +396,13 @@ class CsvFileIterator implements Iterator {
       <indexterm><primary>@depends</primary></indexterm>
 
       Quando um teste recebe uma entrada tanto de um método <literal>@dataProvider</literal>
-      quanto de um ou mais testes dos quais ele <literal>@depends</literal>, os 
-      argumentos do provedor de dados virão antes daqueles dos quais ele 
-      é dependente. Os argumentos dos quais o teste depende serão os 
+      quanto de um ou mais testes dos quais ele <literal>@depends</literal>, os
+      argumentos do provedor de dados virão antes daqueles dos quais ele
+      é dependente. Os argumentos dos quais o teste depende serão os
       mesmos para cada conjunto de dados.
       Veja <xref linkend="writing-tests-for-phpunit.data-providers.examples.DependencyAndDataProviderCombo.php"/>
     </para>
-    
+
     <example id="writing-tests-for-phpunit.data-providers.examples.DependencyAndDataProviderCombo.php">
       <title>Combinação de @depends e @dataProvider no mesmo teste</title>
       <programlisting><![CDATA[<?php
@@ -415,13 +415,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -432,7 +432,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -473,9 +473,9 @@ Tests: 4, Assertions: 4, Failures: 1.
         <indexterm><primary>@dataProvider</primary></indexterm>
         <indexterm><primary>@depends</primary></indexterm>
 
-        Quando um teste depende de um teste que usa provedores de dados, o teste dependente 
-        será executado quando o teste do qual ele depende for bem sucedido em pelo 
-        menos um conjunto de dados. O resultado de um teste que usa provedores de dados não pode 
+        Quando um teste depende de um teste que usa provedores de dados, o teste dependente
+        será executado quando o teste do qual ele depende for bem sucedido em pelo
+        menos um conjunto de dados. O resultado de um teste que usa provedores de dados não pode
         ser injetado dentro de um teste dependente.
       </para>
     </note>
@@ -488,8 +488,8 @@ Tests: 4, Assertions: 4, Failures: 1.
 
         Todos provedores de dados são executados antes da chamada ao método estático <literal>setUpBeforeClass</literal>
         e a primeira chamada ao método <literal>setUp</literal>.
-        Por isso você não pode acessar quaisquer variáveis que criar 
-        ali de dentro de um provedor de dados. Isto é necessário para que o PHPUnit seja capaz 
+        Por isso você não pode acessar quaisquer variáveis que criar
+        ali de dentro de um provedor de dados. Isto é necessário para que o PHPUnit seja capaz
         de calcular o número total de testes.
       </para>
     </note>
@@ -503,7 +503,7 @@ Tests: 4, Assertions: 4, Failures: 1.
       <indexterm><primary>@expectedException</primary></indexterm>
 
       <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest.php" />
-      mostra como usar a anotação <literal>@expectedException</literal> para 
+      mostra como usar a anotação <literal>@expectedException</literal> para
       testar se uma exceção é lançada dentro do código de teste.
     </para>
 
@@ -547,7 +547,7 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       Adicionalmente, você pode usar <literal>@expectedExceptionMessage</literal>,
       <literal>@expectedExceptionMessageRegExp</literal> e
       <literal>@expectedExceptionCode</literal> em combinação com
-      <literal>@expectedException</literal> para testar a mensagem de exceção e 
+      <literal>@expectedException</literal> para testar a mensagem de exceção e
       o código de exceção como mostrado em
       <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest2.php" />.
     </para>
@@ -615,16 +615,16 @@ Tests: 3, Assertions: 6, Failures: 3.]]></screen>
     <para>
       Mais exemplos de <literal>@expectedExceptionMessage</literal>,
       <literal>@expectedExceptionMessageRegExp</literal> e
-      <literal>@expectedExceptionCode</literal> são mostrados em 
+      <literal>@expectedExceptionCode</literal> são mostrados em
       <xref linkend="appendixes.annotations.expectedExceptionMessage"/>,
       <xref linkend="appendixes.annotations.expectedExceptionMessageRegExp"/> e
       <xref linkend="appendixes.annotations.expectedExceptionCode"/> respectivamente.
     </para>
-    
+
 
     <para>
       Alternativamente, você pode usar o método <literal>setExpectedException()</literal> ou
-      <literal>setExpectedExceptionRegExp()</literal> para definir a exceção esperada 
+      <literal>setExpectedExceptionRegExp()</literal> para definir a exceção esperada
       como mostrado em <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest3.php" />.
     </para>
 
@@ -750,8 +750,8 @@ class ExceptionTest extends PHPUnit_Framework_TestCase {
       Se o código que deve lançar uma exceção no <xref
       linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest4.php" />
       não lançá-la, a chamada subsequente ao
-      <literal>fail()</literal> vai parar o teste e sinalizar um problema com o 
-      teste. Se a exceção esperada é lançada, o bloco <literal>catch</literal> 
+      <literal>fail()</literal> vai parar o teste e sinalizar um problema com o
+      teste. Se a exceção esperada é lançada, o bloco <literal>catch</literal>
       será executado, e o teste terminará com sucesso.
     </para>
   </section>
@@ -765,21 +765,21 @@ class ExceptionTest extends PHPUnit_Framework_TestCase {
       <indexterm><primary>PHP Warning</primary></indexterm>
       <indexterm><primary>PHPUnit_Framework_Error</primary></indexterm>
 
-      Por padrão, o PHPUnit converte os erros, avisos e notificações do PHP que são 
-      disparados durante a execução de um teste para uma exceção. Usando essas 
-      exceções, você pode, por exemplo, esperar que um teste dispare um erro PHP como 
+      Por padrão, o PHPUnit converte os erros, avisos e notificações do PHP que são
+      disparados durante a execução de um teste para uma exceção. Usando essas
+      exceções, você pode, por exemplo, esperar que um teste dispare um erro PHP como
       mostrado no <xref linkend="writing-tests-for-phpunit.exceptions.examples.ErrorTest.php" />.
     </para>
 
     <note>
       <para>
         A configuração em tempo de execução <literal>error_reporting</literal> do PHP pode
-        limitar quais erros o PHPUnit irá converter para exceções. Se você 
+        limitar quais erros o PHPUnit irá converter para exceções. Se você
         está tendo problemas com essa funcionalidade, certifique-se que o PHP não está configurado para
         suprimir os tipos de erros que você esta testando.
       </para>
     </note>
-    
+
     <example id="writing-tests-for-phpunit.exceptions.examples.ErrorTest.php">
       <title>Esperando um erro PHP usando @expectedException</title>
       <programlisting><![CDATA[<?php
@@ -809,14 +809,14 @@ OK (1 test, 1 assertion)</screen>
       <indexterm><primary>PHPUnit_Framework_Error_Warning</primary></indexterm>
 
       <literal>PHPUnit_Framework_Error_Notice</literal> e
-      <literal>PHPUnit_Framework_Error_Warning</literal> representam notificações 
+      <literal>PHPUnit_Framework_Error_Warning</literal> representam notificações
       e avisos do PHP, respectivamente.
     </para>
 
     <note>
       <para>
-        Você deve ser o mais específico possível quando testar exceções. Testar 
-        por classes que são muito genéricas pode causar efeitos colaterais 
+        Você deve ser o mais específico possível quando testar exceções. Testar
+        por classes que são muito genéricas pode causar efeitos colaterais
         indesejáveis. Da mesma forma, testar para a classe <literal>Exception</literal>
         com <literal>@expectedException</literal> ou
         <literal>setExpectedException()</literal> não é mais permitido.
@@ -825,8 +825,8 @@ OK (1 test, 1 assertion)</screen>
 
     <para>
         Ao testar com funções que dependem de funções php que disparam erros como
-        <literal>fopen</literal> pode ser útil algumas vezes usar a supressão de 
-        erros enquanto testa. Isso permite a você verificar os valores retornados por 
+        <literal>fopen</literal> pode ser útil algumas vezes usar a supressão de
+        erros enquanto testa. Isso permite a você verificar os valores retornados por
         suprimir notificações que levariam a uma
         <literal>PHPUnit_Framework_Error_Notice</literal> phpunit.
         <example id="writing-tests-for-phpunit.exceptions.examples.TriggerErrorReturnValue.php">
@@ -837,7 +837,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -872,19 +872,19 @@ OK (1 test, 1 assertion)</screen>
     <title>Testando Saídas</title>
 
     <para>
-      Às vezes você quer assegurar que a execução de um método, por 
-      exemplo, gere uma saída esperada (via <literal>echo</literal> ou 
-      <literal>print</literal>, por exemplo). A 
+      Às vezes você quer assegurar que a execução de um método, por
+      exemplo, gere uma saída esperada (via <literal>echo</literal> ou
+      <literal>print</literal>, por exemplo). A
       classe <literal>PHPUnit_Framework_TestCase</literal> usa a funcionalidade
       <ulink url="http://www.php.net/manual/en/ref.outcontrol.php">Output
-      Buffering</ulink> do PHP para fornecer a funcionalidade que é 
+      Buffering</ulink> do PHP para fornecer a funcionalidade que é
       necessária para isso.
     </para>
 
     <para>
       <xref linkend="writing-tests-for-phpunit.output.examples.OutputTest.php" />
-      mostra como usar o método <literal>expectOutputString()</literal> para 
-      definir a saída esperada. Se essa saída esperada não for gerada, o 
+      mostra como usar o método <literal>expectOutputString()</literal> para
+      definir a saída esperada. Se essa saída esperada não for gerada, o
       teste será contado como uma falha.
     </para>
 
@@ -971,7 +971,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     <title>Saída de Erro</title>
 
     <para>
-      Sempre que um teste falha o PHPUnit faz o melhor para fornecer a você o 
+      Sempre que um teste falha o PHPUnit faz o melhor para fornecer a você o
       máximo possível de conteúdo que possa ajudar a identificar o problema.
     </para>
 
@@ -981,7 +981,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1018,12 +1018,12 @@ FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </example>
     <para>
-      Neste exemplo apenas um dos valores dos vetores diferem e os outros valores 
+      Neste exemplo apenas um dos valores dos vetores diferem e os outros valores
       são exibidos para fornecer o contexto onde o erro ocorreu.
     </para>
 
     <para>
-      Quando a saída gerada for longa demais para ler o PHPUnit vai quebrá-la 
+      Quando a saída gerada for longa demais para ler o PHPUnit vai quebrá-la
       e fornecer algumas linhas de contexto ao redor de cada diferença.
     </para>
     <example id="writing-tests-for-phpunit.error-output.examples.LongArrayDiffTest.php">
@@ -1032,7 +1032,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1071,8 +1071,8 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Casos Extremos</title>
 
       <para>
-        Quando uma comparação falha o PHPUnit cria uma representação textual da 
-        entrada de valores e as compara. Devido a essa implementação uma diferenciação 
+        Quando uma comparação falha o PHPUnit cria uma representação textual da
+        entrada de valores e as compara. Devido a essa implementação uma diferenciação
         pode mostrar mais problemas do que realmente existem.
       </para>
 
@@ -1087,7 +1087,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );
@@ -1128,7 +1128,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       </example>
       <para>
         Neste exemplo a diferença no primeiro índice entre
-        <literal>1</literal> e <literal>'1'</literal> é 
+        <literal>1</literal> e <literal>'1'</literal> é
         relatada ainda que o assertEquals considere os valores como uma combinação.
       </para>
 

--- a/src/4.7/zh_cn/assertions.xml
+++ b/src/4.7/zh_cn/assertions.xml
@@ -19,7 +19,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -56,7 +56,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -93,7 +93,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -133,7 +133,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -165,7 +165,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -194,12 +194,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -240,7 +240,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -278,7 +278,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -314,7 +314,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -354,7 +354,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -392,7 +392,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -403,7 +403,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -416,7 +416,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -429,7 +429,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -498,17 +498,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -565,12 +565,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -607,7 +607,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -656,7 +656,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -697,7 +697,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -743,7 +743,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -780,7 +780,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -860,7 +860,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -897,7 +897,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -937,7 +937,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -977,7 +977,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1013,7 +1013,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1050,7 +1050,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1088,7 +1088,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1134,7 +1134,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1171,7 +1171,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1208,7 +1208,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1245,7 +1245,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1282,7 +1282,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1319,7 +1319,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1370,7 +1370,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1411,7 +1411,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1443,7 +1443,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1480,7 +1480,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1517,7 +1517,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1560,7 +1560,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1601,7 +1601,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1794,7 +1794,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1831,7 +1831,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1877,7 +1877,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1923,7 +1923,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.7/zh_cn/code-coverage-analysis.xml
+++ b/src/4.7/zh_cn/code-coverage-analysis.xml
@@ -175,7 +175,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -188,7 +188,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -206,7 +206,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -221,11 +221,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -255,7 +255,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -286,6 +286,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.7/zh_cn/database.xml
+++ b/src/4.7/zh_cn/database.xml
@@ -98,7 +98,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -671,7 +671,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -689,12 +689,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -716,7 +716,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -759,7 +759,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -777,7 +777,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -793,7 +793,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/zh_cn/fixtures.xml
+++ b/src/4.7/zh_cn/fixtures.xml
@@ -29,21 +29,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -92,13 +92,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.7/zh_cn/incomplete-and-skipped-tests.xml
+++ b/src/4.7/zh_cn/incomplete-and-skipped-tests.xml
@@ -26,7 +26,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // 可选：如果愿意，在这里随便测试点什么。
-        $this->assertTrue(TRUE, '这应该已经是能正常工作的。');
+        self::assertTrue(TRUE, '这应该已经是能正常工作的。');
 
         // 在这里停止，并将此测试标记为未完成。
         $this->markTestIncomplete(

--- a/src/4.7/zh_cn/selenium.xml
+++ b/src/4.7/zh_cn/selenium.xml
@@ -10,12 +10,12 @@
       <indexterm><primary>Selenium Server</primary></indexterm>
 
       <ulink url="http://seleniumhq.org/">Selenium Server</ulink>是一个测试工具，它允许用任意主流浏览器为任意 HTTP 网站上的用任意编程语言开发的 web 应用程序编写自动用户界面测试。它通过操作系统来驱动浏览器进程来执行自动测试。Selenium 测试直接运行于某个浏览器中，就和真实用户一样。这些测试既可以用于 <emphasis>验收测试</emphasis>（通过在集成好的系统中执行较高层面的测试而非仅对系统的各个单元分别单独测试。）也可以用于<emphasis>浏览器兼容性测试</emphasis>（通过在不同的操作系统与浏览器上对 web 应用程序进行测试）。</para>
-    
+
     <para>PHPUnit_Selenium 只支持 Selenium 2.x 服务器的脚本。服务器可以通过从 1.x 就提供的传统 Selenium RC API 访问，也可以从 PHPUnit_Selenium 1.2 用 WebDriver API（部分实现）访问。</para>
     <para>这个决定的原因是 Selenium 2 是向后兼容的，而 Selenium RC 已经不再维护了。</para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>安装</title>
 
@@ -56,7 +56,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -111,7 +111,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -198,7 +198,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -270,7 +270,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/zh_cn/test-doubles.xml
+++ b/src/4.7/zh_cn/test-doubles.xml
@@ -76,7 +76,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->willReturn('foo');
 
         // 现在调用 $stub->doSomething() 将返回 'foo'。
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -109,7 +109,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->willReturn('foo');
 
         // 现在调用 $stub->doSomething() 将返回 'foo'。
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -152,10 +152,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // stub->doSomething('foo') 返回 'foo'
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') 返回 'bar'
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -185,7 +185,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() 返回 $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -221,8 +221,8 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnValueMap($map));
 
         // $stub->doSomething() 根据提供的参数返回不同的值。
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -252,7 +252,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) 返回 str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -282,9 +282,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() 每次返回值都不同
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -440,7 +440,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
         $subject->attach($observer);
 
         // 在 $subject 对象上调用 doSomething() 方法，
-        // 预期将以字符串 'something' 为参数调用 
+        // 预期将以字符串 'something' 为参数调用
         // Observer 仿件对象的 update() 方法。
         $subject->doSomething();
     }
@@ -659,7 +659,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
         $subject->attach($observer->reveal());
 
         // 在 $subject 对象上调用 doSomething() 方法，
-        // 预期将以字符串 'something' 为参数调用 
+        // 预期将以字符串 'something' 为参数调用
         // Observer 仿件对象的 update() 方法。
         $subject->doSomething();
     }
@@ -699,7 +699,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -731,7 +731,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -794,7 +794,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() 将会返回上桩的结果，
          * web 服务的 doGoogleSearch() 方法不会被调用。
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -876,10 +876,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -920,10 +920,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.7/zh_cn/textui.xml
+++ b/src/4.7/zh_cn/textui.xml
@@ -285,7 +285,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.7/zh_cn/writing-tests-for-phpunit.xml
+++ b/src/4.7/zh_cn/writing-tests-for-phpunit.xml
@@ -23,14 +23,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -71,7 +71,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -82,8 +82,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -93,8 +93,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -112,7 +112,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -160,13 +160,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -176,7 +176,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -214,7 +214,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -259,7 +259,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -347,13 +347,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -364,7 +364,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -691,7 +691,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -811,7 +811,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -856,7 +856,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -904,7 +904,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.8/en/annotations.xml
+++ b/src/4.8/en/annotations.xml
@@ -267,7 +267,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
@@ -797,7 +797,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.8/en/assertions.xml
+++ b/src/4.8/en/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -94,7 +94,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.8/en/code-coverage-analysis.xml
+++ b/src/4.8/en/code-coverage-analysis.xml
@@ -300,7 +300,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -313,7 +313,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -331,7 +331,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -346,11 +346,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -360,11 +360,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@coversNothing</primary></indexterm>
 
-      It is also possible to specify that a test should not cover 
-      <emphasis>any</emphasis> method by using the 
+      It is also possible to specify that a test should not cover
+      <emphasis>any</emphasis> method by using the
       <literal>@coversNothing</literal> annotation (see
       <xref linkend="appendixes.annotations.coversNothing"/>). This can be
-      helpful when writing integration tests to make sure you only 
+      helpful when writing integration tests to make sure you only
       generate code coverage with unit tests.
     </para>
 
@@ -388,7 +388,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -413,7 +413,7 @@ if (false) this_function_call_shows_up_as_covered();
 // Due to how code coverage works internally these two lines are special.
 // This line will show up as non executable
 if (false)
-    // This line will show up as covered because it is actually the 
+    // This line will show up as covered because it is actually the
     // coverage of the if statement in the line above that gets shown here!
     will_also_show_up_as_coveraged();
 
@@ -422,6 +422,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.8/en/database.xml
+++ b/src/4.8/en/database.xml
@@ -220,7 +220,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -1064,8 +1064,8 @@ interface PHPUnit_Extensions_Database_DataSet_IDataSet extends IteratorAggregate
         TestCase to check for dataset quality. From the
         <literal>IteratorAggregate</literal> interface the IDataSet
         inherits the <literal>getIterator()</literal> method to iterate
-        over all tables of the dataset. The reverse iterator allows PHPUnit to 
-        truncate tables opposite the order they were created to satisfy foreign 
+        over all tables of the dataset. The reverse iterator allows PHPUnit to
+        truncate tables opposite the order they were created to satisfy foreign
         key constraints.
       </para>
       <para>
@@ -1189,7 +1189,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1219,12 +1219,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1255,7 +1255,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1317,7 +1317,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1342,7 +1342,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1360,7 +1360,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/en/fixtures.xml
+++ b/src/4.8/en/fixtures.xml
@@ -68,21 +68,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -146,13 +146,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.8/en/incomplete-and-skipped-tests.xml
+++ b/src/4.8/en/incomplete-and-skipped-tests.xml
@@ -53,7 +53,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // Optional: Test anything here, if you want.
-        $this->assertTrue(TRUE, 'This should already work.');
+        self::assertTrue(TRUE, 'This should already work.');
 
         // Stop here and mark this test as incomplete.
         $this->markTestIncomplete(

--- a/src/4.8/en/selenium.xml
+++ b/src/4.8/en/selenium.xml
@@ -12,16 +12,16 @@
       <ulink url="http://seleniumhq.org/">Selenium Server</ulink> is a
       test tool that allows you to write automated user-interface tests for
       web applications in any programming language against any HTTP website
-      using any mainstream browser. It performs automated browser tasks 
+      using any mainstream browser. It performs automated browser tasks
       by driving the browser's process through the operating system.
-      Selenium tests run directly in a browser, just as real users do. These 
-      tests can be used for both <emphasis>acceptance testing</emphasis> 
+      Selenium tests run directly in a browser, just as real users do. These
+      tests can be used for both <emphasis>acceptance testing</emphasis>
       (by performing higher-level tests on the integrated system instead of
-      just testing each unit of the system independently) and <emphasis>browser 
+      just testing each unit of the system independently) and <emphasis>browser
       compatibility testing</emphasis> (by testing the web application on
       different operating systems and browsers).
     </para>
-    
+
     <para>
       The only supported scenario of PHPUnit_Selenium is that of a Selenium 2.x
       server. The server can be accessed through the classic Selenium RC Api, already present in 1.x, or with the WebDriver API (partially implemented) from PHPUnit_Selenium 1.2.
@@ -31,7 +31,7 @@
     </para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>Installation</title>
 
@@ -88,7 +88,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -115,7 +115,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     The commands of Selenium2TestCase are implemented via __call(). Please refer to <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">the end-to-end test for PHPUnit_Extensions_Selenium2TestCase</ulink> for a list of every supported feature.
   </para>
   </section>
@@ -154,7 +154,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -254,7 +254,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -335,7 +335,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/en/test-doubles.xml
+++ b/src/4.8/en/test-doubles.xml
@@ -136,7 +136,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Calling $stub->doSomething() will now return
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -177,7 +177,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Calling $stub->doSomething() will now return
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -233,10 +233,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') returns 'foo'
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') returns 'bar'
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -271,7 +271,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() returns $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -315,8 +315,8 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() returns different values depending on
         // the provided arguments.
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -353,7 +353,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) returns str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -390,9 +390,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() returns a different value each time
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -921,7 +921,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -959,7 +959,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -1034,7 +1034,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() will now return a stubbed result and
          * the web service's doGoogleSearch() method will not be invoked.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1135,10 +1135,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1184,10 +1184,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/en/textui.xml
+++ b/src/4.8/en/textui.xml
@@ -273,7 +273,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -405,7 +405,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.8/en/writing-tests-for-phpunit.xml
+++ b/src/4.8/en/writing-tests-for-phpunit.xml
@@ -27,14 +27,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -97,7 +97,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -108,8 +108,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -119,8 +119,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -152,7 +152,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -209,13 +209,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -225,7 +225,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -275,7 +275,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -320,7 +320,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -415,13 +415,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -432,7 +432,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -837,7 +837,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -981,7 +981,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1032,7 +1032,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1087,7 +1087,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.8/fr/annotations.xml
+++ b/src/4.8/fr/annotations.xml
@@ -9,7 +9,7 @@
     Une annotation est une forme spéciale de méta donnée syntaxique qui peut
     être ajoutée au code source de certains langages de programmation. Bien que
     PHP n'ait pas de fonctionnalité dédiée à l'annotation du code source, l'utilisation
-    d'étiquettes telles que <literal>@annotation paramètres</literal> dans les blocs de documentation 
+    d'étiquettes telles que <literal>@annotation paramètres</literal> dans les blocs de documentation
     s'est établi dans la communauté PHP pour annoter le code source. En PHP, les blocs de
     documentation sont réflexifs: ils peuvent être accédés via la méthode de l'API de réflexivité
     <literal>getDocComment()</literal> au niveau des fonctions, classes, méthodes et attributs.
@@ -92,7 +92,7 @@ class MonTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
 
-      L'annotation <literal>@backupStaticAttributes</literal> peut également être utilisée au 
+      L'annotation <literal>@backupStaticAttributes</literal> peut également être utilisée au
       niveau d'une méthode de test. Ceci permet une configuration plus fine des opérations
       de sauvegarde et de restauration: <programlisting>/**
  * @backupStaticAttributes disabled
@@ -118,8 +118,8 @@ class MonTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>@codeCoverageIgnoreStart</primary></indexterm>
       <indexterm><primary>@codeCoverageIgnoreEnd</primary></indexterm>
 
-      Les annotations <literal>@codeCoverageIgnore</literal>, 
-      <literal>@codeCoverageIgnoreStart</literal> et 
+      Les annotations <literal>@codeCoverageIgnore</literal>,
+      <literal>@codeCoverageIgnoreStart</literal> et
       <literal>@codeCoverageIgnoreEnd</literal> peuvent être utilisées pour
       exclure des lignes de code de l'analyse de couverture.
     </para>
@@ -137,18 +137,18 @@ class MonTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Code Coverage</primary></indexterm>
       <indexterm><primary>@covers</primary></indexterm>
 
-      L'annotation <literal>@covers</literal> peut être utilisée dans le code de test pour 
+      L'annotation <literal>@covers</literal> peut être utilisée dans le code de test pour
       indique quelle(s) méthode(s) un test veut tester:<programlisting>/**
  * @covers CompteBancaire::getBalance
  */
 public function testBalanceEstInitiallementAZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
     <para>
-      Si elle est fournie, seule l'information de couverture de code pour 
+      Si elle est fournie, seule l'information de couverture de code pour
       la(les) méthode(s) sera prise en considération.
     </para>
 
@@ -216,7 +216,7 @@ public function testBalanceEstInitiallementAZero()
       <indexterm><primary>@coversNothing</primary></indexterm>
 
       L'annotation <literal>@coversNothing</literal> peut être utilisée dans le code de test
-      pour indiquer qu'aucune information de couverture de code ne sera enregistrée pour le 
+      pour indiquer qu'aucune information de couverture de code ne sera enregistrée pour le
       cas de test annoté.
     </para>
 
@@ -226,7 +226,7 @@ public function testBalanceEstInitiallementAZero()
         pour un exemple.
     </para>
 
-    <para>    
+    <para>
         L'annotation peut être utilisée au niveau de la classe et de la méthode
         et sera surchargée par toute étiquette <literal>@covers</literal>.
     </para>
@@ -247,7 +247,7 @@ public function testBalanceEstInitiallementAZero()
     </para>
 
     <para>
-      Voir <xref linkend="writing-tests-for-phpunit.data-providers"/> pour plus de 
+      Voir <xref linkend="writing-tests-for-phpunit.data-providers"/> pour plus de
       détails.
     </para>
   </section>
@@ -297,7 +297,7 @@ public function testBalanceEstInitiallementAZero()
     <para>
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
-      L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec 
+      L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
       <literal>@expectedException</literal> permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
@@ -315,25 +315,25 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
 	Pour faciliter les tests et réduire la duplication, un raccourci peut être utilisé pour
-    indiquer une constante de classe comme un 
+    indiquer une constante de classe comme un
     <literal>@expectedExceptionCode</literal> en utilisant la syntaxe
     "<literal>@expectedExceptionCode ClassName::CONST</literal>".
-                                                                        
-    <programlisting>class MonTest extends PHPUnit_Framework_TestCase 
-  {                                                                      
-      /**                                                                
-        * @expectedException     MonException                             
-        * @expectedExceptionCode MaClasse::CODE_ERREUR                      
-        */                                                               
-      public function testExceptionAUnCodeErreur20()                      
-      {                                                                  
+
+    <programlisting>class MonTest extends PHPUnit_Framework_TestCase
+  {
+      /**
+        * @expectedException     MonException
+        * @expectedExceptionCode MaClasse::CODE_ERREUR
+        */
+      public function testExceptionAUnCodeErreur20()
+      {
         throw new MonException('Un message', 20);
-      }                                                                  
-  }                                                                      
-  class MaClasse                                                          
-  {                                                                      
-      const CODE_ERREUR = 20;                                              
-  }</programlisting>     
+      }
+  }
+  class MaClasse
+  {
+      const CODE_ERREUR = 20;
+  }</programlisting>
     </para>
 
   </section>
@@ -345,7 +345,7 @@ public function testBalanceEstInitiallementAZero()
       <indexterm><primary>@expectedExceptionMessage</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionMessage</literal> fonctionne de manière
-      similaire à <literal>@expectedExceptionCode</literal> en ce qu'il vous permet de 
+      similaire à <literal>@expectedExceptionCode</literal> en ce qu'il vous permet de
       faire une assertion sur le message d'erreur d'une exception.
 
       <programlisting>class MonTest extends PHPUnit_Framework_TestCase
@@ -361,7 +361,7 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
       Le message attendu peut être une partie d'une chaîne d'un message d'exception.
-      Ceci peut être utile pour faire une assertion sur le fait qu'un nom ou un 
+      Ceci peut être utile pour faire une assertion sur le fait qu'un nom ou un
       paramètre qui est passé s'affiche dans une exception sans fixer la totalité
       du message d'exception dans le test.
 
@@ -379,7 +379,7 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
 
 	Pour faciliter les tests et réduire la duplication, un raccourci peut être utilisé pour
-    indiquer une constante de classe comme un 
+    indiquer une constante de classe comme un
     <literal>@expectedExceptionCode</literal> en utilisant la syntaxe
     "<literal>@expectedExceptionCode ClassName::CONST</literal>".
 
@@ -414,10 +414,10 @@ public function testBalanceEstInitiallementAZero()
 }</programlisting>
     </para>
 
-    <para> 
+    <para>
       Des tests peuvent être sélectionnés pour l'exécution en se basant sur les groupes
       en utilisant les options <literal>--group</literal> et <literal>--exclude-group</literal>
-      du lanceur de test en ligne de commandes ou en utilisant les directives respectives du 
+      du lanceur de test en ligne de commandes ou en utilisant les directives respectives du
       fichier de configuration XML.
     </para>
   </section>
@@ -474,7 +474,7 @@ public function testBalanceEstInitiallementAZero()
  */
 public function balanceInitialeDoitEtre0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.8/fr/code-coverage-analysis.xml
+++ b/src/4.8/fr/code-coverage-analysis.xml
@@ -18,7 +18,7 @@
     <indexterm><primary>Couverture de code</primary></indexterm>
 
     Dans ce chapitre, vous apprendrez tout sur la fonctionnalité de couverture
-    de code de PHPUnit qui fournit une vision interne des parties du code de 
+    de code de PHPUnit qui fournit une vision interne des parties du code de
     production qui sont exécutées quand les tests sont exécutés. Cela aide à
     répondre à des questions comme :
   </para>
@@ -36,7 +36,7 @@
   </itemizedlist>
 
   <para>
-    Un exemple de ce que peuvent signifier des statistiques de couverture de code est, 
+    Un exemple de ce que peuvent signifier des statistiques de couverture de code est,
     s'il y a une méthode avec 100 lignes de code, et seulement 75 de ces lignes sont réellement
     exécutées quand les tests sont lancés, alors la méthode est considérée comme ayant une couverture
     de code de 75 pour cent.
@@ -45,7 +45,7 @@
   <para>
     <indexterm><primary>Xdebug</primary></indexterm>
 
-    La fonctionnalité de couverture de code de PHPUnit fait usage du composant 
+    La fonctionnalité de couverture de code de PHPUnit fait usage du composant
     <ulink url="http://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>
     qui, à son tour, tire partie de la fonctionnalité de couverture d'instructions
     fournie par l'extension <ulink url="http://www.xdebug.org/">Xdebug</ulink>
@@ -96,9 +96,9 @@ Generating report, this may take a moment.</screen>
   </figure>
 
   <para>
-    Le rapport de couverture de code de notre exemple <literal>CompteBancaire</literal> 
+    Le rapport de couverture de code de notre exemple <literal>CompteBancaire</literal>
     montre que nous n'avons actuellement aucun test qui appellent les méthodes
-    <literal>setBalance()</literal>, <literal>deposerArgent()</literal> et 
+    <literal>setBalance()</literal>, <literal>deposerArgent()</literal> et
     <literal>retirerArgent()</literal> avec des valeurs acceptables.
     <xref linkend="code-coverage-analysis.examples.BankAccountTest.php" />
     montre un test qui peut être ajouté à la classe de cas de test
@@ -117,11 +117,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
 
     public function testDeposerRetirerArgent()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->deposerArgent(1);
-        $this->assertEquals(1, $this->compte_bancaire->getBalance());
+        self::assertEquals(1, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->retirerArgent(1);
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -149,7 +149,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       L'annotation <literal>@covers</literal> (voir
       <xref linkend="appendixes.annotations.covers.tables.annotations"/>) peut être
       utilisée dans le code de test pour indiquer quelle(s) méthode(s) une méthode de test
-      veut test. Si elle est fournie, seules les informations de couverture de code pour 
+      veut test. Si elle est fournie, seules les informations de couverture de code pour
       la(les) méthode(s) indiquées seront prises en considération.
       <xref linkend="code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php"/>
       montre un exemple.
@@ -174,7 +174,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceEstInitialementZero()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 
     /**
@@ -187,7 +187,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
         }
 
         catch (CompteBancaireException $e) {
-            $this->assertEquals(0, $this->compte_bancaire->getBalance());
+            self::assertEquals(0, $this->compte_bancaire->getBalance());
 
             return;
         }
@@ -205,7 +205,7 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
         }
 
         catch (CompteBancaireException $e) {
-            $this->assertEquals(0, $this->compte_bancaire->getBalance());
+            self::assertEquals(0, $this->compte_bancaire->getBalance());
 
             return;
         }
@@ -221,11 +221,11 @@ class CompteBancaireTest extends PHPUnit_Framework_TestCase
 
     public function testDeposerArgent()
     {
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->deposerArgent(1);
-        $this->assertEquals(1, $this->compte_bancaire->getBalance());
+        self::assertEquals(1, $this->compte_bancaire->getBalance());
         $this->compte_bancaire->retirerArgent(1);
-        $this->assertEquals(0, $this->compte_bancaire->getBalance());
+        self::assertEquals(0, $this->compte_bancaire->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -261,7 +261,7 @@ class IntegrationLivreDOrTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("livre_d_or");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -282,8 +282,8 @@ class IntegrationLivreDOrTest extends PHPUnit_Extensions_Database_TestCase
       voulez ignorer lors de l'analyse de couverture de code. PHPUnit vous permet
       de faire cela en utilisant les annotations
       <literal>@codeCoverageIgnore</literal>,
-      <literal>@codeCoverageIgnoreStart</literal> et 
-      <literal>@codeCoverageIgnoreEnd</literal> comme montré dans 
+      <literal>@codeCoverageIgnoreStart</literal> et
+      <literal>@codeCoverageIgnoreEnd</literal> comme montré dans
       <xref linkend="code-coverage-analysis.ignoring-code-blocks.examples.Sample.php"/>.
     </para>
 
@@ -342,7 +342,7 @@ if (FALSE) {
     <para>
       La liste noire est pré-remplie avec tous les fichiers de code source de
       PHPUnit lui-même ainsi que les tests. Quand la liste blanche est vide (par
-      défaut), le filtrage par liste noire est utilisé. Quand la liste blanche 
+      défaut), le filtrage par liste noire est utilisé. Quand la liste blanche
       n'est pas vide, le filtrage par liste blanche est utilisé. Chaque fichier
       de la liste blanche est ajouté au rapport de couverture de code, qu'il ait
       été exécuté ou pas. Toutes les lignes d'un tel fichier, incluant celles qui
@@ -350,7 +350,7 @@ if (FALSE) {
     </para>
 
     <para>
-      Quand vous configurez 
+      Quand vous configurez
       <literal>processUncoveredFilesFromWhitelist="true"</literal>
       dans votre configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.blacklist-whitelist"/>) alors ces fichiers
@@ -369,8 +369,8 @@ if (FALSE) {
 
     <para>
       Le fichier de configuration XML de PHPUnit (voir <xref linkend="appendixes.configuration.blacklist-whitelist"/>)
-      peut être utilisé pour contrôler les listes noires et blanches. Utiliser une liste 
-      blanche est recommandé comme meilleure pratique pour contrôler la liste des fichiers inclus dans 
+      peut être utilisé pour contrôler les listes noires et blanches. Utiliser une liste
+      blanche est recommandé comme meilleure pratique pour contrôler la liste des fichiers inclus dans
       le rapport de couverture de code.
     </para>
   </section>
@@ -394,8 +394,8 @@ if(false) cet_appel_de_fonction_sera_compte_comme_couvert();
 // Du fait de la façon dont la couverture de code fonctionne en interne, ces deux lignes sont spéciales.
 / Cette ligne sera comptée comme non exécutable
 if(false)
-    // Cette ligne sera comptée comme couverte car c'est en fait la 
-    // couverture de l'instruction if dans la ligne au-dessus qui 
+    // Cette ligne sera comptée comme couverte car c'est en fait la
+    // couverture de l'instruction if dans la ligne au-dessus qui
     // sera montrée ici !
     sera_egalement_comptee_comme_couverte();
 
@@ -404,8 +404,8 @@ if(false) {
     cet_appel_ne_sera_jamais_compte_comme_couvert();
 }
 ?>]]></programlisting>
-    </example>      
-        
+    </example>
+
   </section>
 
 </chapter>

--- a/src/4.8/fr/fixtures.xml
+++ b/src/4.8/fr/fixtures.xml
@@ -18,7 +18,7 @@
     La plupart du temps, cependant, la fixture sera beaucoup plus complexe
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
-    dans le bruit de configuration de la fixture. Ce problème s'aggrave quand 
+    dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
     vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
@@ -46,7 +46,7 @@
     que ce n'est pas la fixture elle-même qui est réutilisée mais le code qui l'a créée.
     D'abord nous déclarons la variable d'instance, <literal>$pile</literal>, que nous
     allons utiliser à la place d'une variable locale à la méthode. Puis nous plaçons
-    la création de la fixture <literal>tableau</literal> dans la méthode 
+    la création de la fixture <literal>tableau</literal> dans la méthode
     <literal>setUp()</literal>. Enfin, nous supprimons le code redondant des méthodes
     de test et nous utilisons la variable d'instance nouvellement introduite.
     <literal>$this->pile</literal>, à la place de la variable locale à la méthode
@@ -67,21 +67,21 @@ class PileTest extends PHPUnit_Framework_TestCase
 
     public function testVide()
     {
-        $this->assertTrue(empty($this->pile));
+        self::assertTrue(empty($this->pile));
     }
 
     public function testPush()
     {
         array_push($this->pile, 'foo');
-        $this->assertEquals('foo', $this->pile[count($this->pile)-1]);
-        $this->assertFalse(empty($this->pile));
+        self::assertEquals('foo', $this->pile[count($this->pile)-1]);
+        self::assertFalse(empty($this->pile));
     }
 
     public function testPop()
     {
         array_push($this->pile, 'foo');
-        $this->assertEquals('foo', array_pop($this->pile));
-        $this->assertTrue(empty($this->pile));
+        self::assertEquals('foo', array_pop($this->pile));
+        self::assertTrue(empty($this->pile));
     }
 }
 ?>]]></programlisting>
@@ -110,7 +110,7 @@ class PileTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>onNotSuccessfulTest()</primary></indexterm>
 
     De plus, les méthodes canevas <literal>setUpBeforeClass()</literal> et
-    <literal>tearDownAfterClass()</literal> sont appelées respectivement avant 
+    <literal>tearDownAfterClass()</literal> sont appelées respectivement avant
     que le premier test de la classe de cas de test ne soit exécuté et après
     que le dernier test de la classe de test a été exécuté.
   </para>
@@ -145,13 +145,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()
@@ -210,15 +210,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
     <para>
       <literal>setUp()</literal> et <literal>tearDown()</literal> sont sympathiquement
-      symétriques en théorie mais pas en pratique. En pratique, vous n'avez besoin 
+      symétriques en théorie mais pas en pratique. En pratique, vous n'avez besoin
       d'implémenter <literal>tearDown()</literal> que si vous avez alloué
       des ressources externes telles que des fichiers ou des sockets dans
       <literal>setUp()</literal>. Si votre <literal>setUp()</literal> ne crée simplement
-      que de purs objets PHP, vous pouvez généralement ignorer <literal>tearDown()</literal>. 
+      que de purs objets PHP, vous pouvez généralement ignorer <literal>tearDown()</literal>.
       Cependant, si vous créez de nombreux objets dans votre <literal>setUp()</literal>, vous
       pourriez vouloir libérer (<literal>unset()</literal>) les variables pointant vers
       ces objets dans votre <literal>tearDown()</literal> de façon à ce qu'ils puissent être
-      récupérés par le ramasse-miettes. Le nettoyage des objets de cas de test n'est pas 
+      récupérés par le ramasse-miettes. Le nettoyage des objets de cas de test n'est pas
       prévisible.
     </para>
   </section>
@@ -262,7 +262,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <para>
       Un bon exemple de fixture qu'il est raisonnable de partager entre plusieurs
       tests est une connexion à une base de données : vous vous connectez une fois
-      à la base de données et vous réutilisez cette connexion au lieu d'en créer 
+      à la base de données et vous réutilisez cette connexion au lieu d'en créer
       une nouvelle pour chaque test. Ceci rend vos tests plus rapides.
     </para>
 
@@ -272,7 +272,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
       <xref linkend="fixtures.sharing-fixture.examples.DatabaseTest.php" />
       utilise les méthodes canevas <literal>setUpBeforeClass()</literal> et
-      <literal>tearDownAfterClass()</literal> pour respectivement établir la connexion à la 
+      <literal>tearDownAfterClass()</literal> pour respectivement établir la connexion à la
       base de données avant le premier test de la classe de cas de test et pour
       de déconnecter de la base de données après le dernier test du cas de test.
     </para>
@@ -302,7 +302,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       entre les tests réduit la valeur de ces tests. Le problème de conception
       sous-jacent est que les objets ne sont pas faiblement couplés. Vous pourrez
       obtenir de meilleurs résultats en résolvant le problème de conception
-      sous-jacent puis en écrivant des tests utilisant des bouchons 
+      sous-jacent puis en écrivant des tests utilisant des bouchons
       (voir <xref linkend="test-doubles" />), plutôt qu'en créant
       des dépendances entre les tests à l'exécution et en ignorant l'opportunité
       d'améliorer votre conception.
@@ -315,7 +315,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     <para>
       <ulink url="http://googletesting.blogspot.com/2008/05/tott-using-dependancy-injection-to.html">Il est difficile de tester du code qui utilise des singletons.</ulink>
       La même chose est vraie pour le code qui utilise des variables globales. Typiquement,
-      le code que vous voulez tester est fortement couplé avec une variable globale et 
+      le code que vous voulez tester est fortement couplé avec une variable globale et
       vous ne pouvez pas contrôler sa création. Un problème additionnel réside dans le fait
       qu'un test qui modifie une variable globale peut faire échouer un autre test.
     </para>
@@ -357,7 +357,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       </para>
       <para>
         L'implémentation des opérations de sauvegarde et de restauration des variables
-        globales et des attributs statiques des classes utilise 
+        globales et des attributs statiques des classes utilise
         <literal>serialize()</literal> et <literal>unserialize()</literal>.
       </para>
       <para>
@@ -372,8 +372,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
       <indexterm><primary><literal>$backupGlobalsBlacklist</literal></primary></indexterm>
 
-      L'annotation <literal>@backupGlobals</literal> qui est discutée dans 
-      <xref linkend="appendixes.annotations.backupGlobals"/> peut être utilisée pour 
+      L'annotation <literal>@backupGlobals</literal> qui est discutée dans
+      <xref linkend="appendixes.annotations.backupGlobals"/> peut être utilisée pour
       contrôler les opérations de sauvegarde et de restauration des variables globales.
       Alternativement, vous pouvez fournir une liste noire des variables globales qui doivent
       être exclues des opérations de sauvegarde et de restauration comme ceci :
@@ -396,8 +396,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
       <indexterm><primary><literal>$backupStaticAttributesBlacklist</literal></primary></indexterm>
 
-      L'annotation <literal>@backupStaticAttributes</literal> qui est discutée dans 
-      <xref linkend="appendixes.annotations.backupStaticAttributes"/> peut être utilisée pour 
+      L'annotation <literal>@backupStaticAttributes</literal> qui est discutée dans
+      <xref linkend="appendixes.annotations.backupStaticAttributes"/> peut être utilisée pour
       contrôler les opérations de sauvegarde et de restauration des attributs statiques.
       Alternativement, vous pouvez fournir une liste noire des attributs statiques qui doivent
       être exclus des opérations de sauvegarde et de restauration comme ceci :

--- a/src/4.8/fr/incomplete-and-skipped-tests.xml
+++ b/src/4.8/fr/incomplete-and-skipped-tests.xml
@@ -8,14 +8,14 @@
 
     <para>
       Quand vous travaillez sur une nouvelle classe de cas de test, vous pourriez vouloir
-      commencer en écrivant des méthodes de test vides comme 
+      commencer en écrivant des méthodes de test vides comme
       <programlisting>public function testQuelquechose()
 {
-}</programlisting> pour garder la trace des tests que vous avez à écrire. Le problème avec 
+}</programlisting> pour garder la trace des tests que vous avez à écrire. Le problème avec
       les méthodes de test vides est qu'elles sont interprétées comme étant réussies par le
       framework PHPUnit. Cette mauvaise interprétation fait que le rapport de tests devient
       inutile -- vous ne pouvez pas voir si un test est effectivement réussi ou s'il n'a tout
-      simplement pas été implémenté. Appeler 
+      simplement pas été implémenté. Appeler
       <literal>$this->fail()</literal> dans une méthode de test non implémentée
       n'aide pas davantage, puisqu'alors le test sera interprété comme étant un échec.
       Ce serait tout aussi faux que d'interpréter un test non implémenté comme étant réussi.
@@ -30,16 +30,16 @@
       comme à un feu rouge, nous avons besoin d'un feu orange additionnel pour signaler
       un test comme étant incomplet ou pas encore implémenté.
       <literal>PHPUnit_Framework_IncompleteTest</literal> est une interface de marquage
-      pour signaler une exception qui est levée par une méthode de test comme résultat 
+      pour signaler une exception qui est levée par une méthode de test comme résultat
       d'un test incomplet ou actuellement pas implémenté.
-      <literal>PHPUnit_Framework_IncompleteTestError</literal> est l'implémentation 
+      <literal>PHPUnit_Framework_IncompleteTestError</literal> est l'implémentation
       standard de cette interface.
     </para>
 
     <para>
       <xref linkend="incomplete-and-skipped-tests.incomplete-tests.examples.SampleTest.php" />
       montre une classe de cas de tests, <literal>ExempleDeTest</literal>, qui contient une unique méthode de test,
-      method, <literal>testSomething()</literal>. En appelant la méthode pratique 
+      method, <literal>testSomething()</literal>. En appelant la méthode pratique
       <literal>markTestIncomplete()</literal> (qui lève automatiquement
       une exception <literal>PHPUnit_Framework_IncompleteTestError</literal>)
       dans la méthode de test, nous marquons le test comme étant incomplet.
@@ -53,7 +53,7 @@ class ExempleDeTest extends PHPUnit_Framework_TestCase
     public function testeQuelquechose()
     {
         // Facultatif: testez tout ce que vous voulez ici.
-        $this->assertTrue(TRUE, 'Ceci devrait toujours fonctionner.');
+        self::assertTrue(TRUE, 'Ceci devrait toujours fonctionner.');
 
         // Cesser ici et marquer ce test comme incomplet.
         $this->markTestIncomplete(
@@ -128,7 +128,7 @@ Tests: 1, Assertions: 1, Incomplete: 1.</screen>
     <para>
       <xref linkend="incomplete-and-skipped-tests.skipping-tests.examples.DatabaseTest.php" />
       montre une classe de cas de tests, <literal>DatabaseTest</literal>, qui contient une méthode de tests
-      <literal>testConnection()</literal>. Dans la méthode canevas <literal>setUp()</literal> 
+      <literal>testConnection()</literal>. Dans la méthode canevas <literal>setUp()</literal>
       de la classe du cas de test, nous pouvons contrôler si l'extension
       MySQLi est disponible et utiliser la méthode <literal>markTestSkipped()</literal>
       pour sauter le test si ce n'est pas le cas.
@@ -277,7 +277,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
  	<para>
 		Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
-        dans la configuration xml pour les inclusions dépendant de la version dans 
+        dans la configuration xml pour les inclusions dépendant de la version dans
         <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/4.8/fr/selenium.xml
+++ b/src/4.8/fr/selenium.xml
@@ -9,28 +9,28 @@
     <para>
       <indexterm><primary>Selenium Server</primary></indexterm>
 
-      <ulink url="http://seleniumhq.org/">Selenium Server</ulink> est un 
-      outil de test qui vous permet d'écrire des tests automatisés de 
+      <ulink url="http://seleniumhq.org/">Selenium Server</ulink> est un
+      outil de test qui vous permet d'écrire des tests automatisés de
       l'interface utilisateur d'applications web dans n'importe quel langage
       et menés sur n'importe quel site web HTTP en utilisant n'importe quel
       navigateur courant. Il réalise des tâches automatisée dans le navigateur
       en pilotant le processus du navigateur via le système d'exploitation.
       Les tests Selenium s'exécutent directement dans un navigateur, exactement
       comme des utilisateurs réels le feraient. Ces tests peuvent être utilisés
-      à la fois comme <emphasis>tests de validation</emphasis> 
+      à la fois comme <emphasis>tests de validation</emphasis>
       (en exécutant des tests au plus haut niveau sur le système intégré au lieu
       de simplement tester chaque unité du système indépendamment) et des
       <emphasis>tests de compatibilité pour les navigateurs</emphasis> (en testant l'application
       web sur différents systèmes d'exploitation et différents navigateurs).
     </para>
-    
+
     <para>
       Le seul scénario géré par PHPUnit_Selenium est celui du serveur Selenium 2.x.
       Le serveur peut être accédé via l'API classique Selenium RC déjà présente dans la version 1.x ou avec l'API serveur
       WebDriver (partiellement implémentée) à partir de PHPUnit_Selenium 1.2.
     </para>
     <para>
-      La raison derrière cette décision est que Selenium 2 est rétro compatible et que Selenium RC n'est désormais plus 
+      La raison derrière cette décision est que Selenium 2 est rétro compatible et que Selenium RC n'est désormais plus
       maintenu.
     </para>
 
@@ -87,7 +87,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -114,7 +114,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     Les commandes de Selenium2TestCase sont implémentées via __call(). Merci de vous référer à <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">the end-to-end test for PHPUnit_Extensions_Selenium2TestCase</ulink> pour la liste de toutes les fonctionnalités prises en charge.
   </para>
   </section>
@@ -152,7 +152,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -252,7 +252,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -333,7 +333,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/fr/skeleton-generator.xml
+++ b/src/4.8/fr/skeleton-generator.xml
@@ -62,7 +62,7 @@ Wrote skeleton for "CalculateurTest" to "/home/sb/CalculateurTest.php".</screen>
     <title>Classes sous espace de nom et le générateur de squelette</title>
 
     <para>
-      Lorsque vous utilisez le générateur de squelette pour générer du code basé sur 
+      Lorsque vous utilisez le générateur de squelette pour générer du code basé sur
       une classe qui est déclarée dans un <ulink url="http://php.net/namespace">espace de nommage (namespace)</ulink>
       vous devez fournir le nom qualifié de la classe ainsi que le chemin d'accès
       au fichier source dans lequel elle est déclarée.
@@ -104,7 +104,7 @@ Tests: 1, Assertions: 0, Incomplete: 1.</screen>
       <indexterm><primary>@assert</primary></indexterm>
 
       Vous pouvez utiliser l'annotation <literal>@assert</literal> dans le bloc
-      de documentation d'une méthode pour générer automatiquement des tests 
+      de documentation d'une méthode pour générer automatiquement des tests
       simples mais significatifs au lieu de cas de tests incomplets.
       <xref linkend="skeleton-generator.test.examples.Calculator.php" />
       montre un exemple.
@@ -131,13 +131,13 @@ class Calculateur
 
     <para>
       Chaque méthode de la classe originelle est contrôlée à la recherche d'annotations
-      <literal>@assert</literal>. Celles-ci sont transformées en code de test comme 
+      <literal>@assert</literal>. Celles-ci sont transformées en code de test comme
       <programlisting>    /**
      * Generated from @assert (0, 0) == 0.
      */
     public function testAdditionner() {
         $o = new Calculateur;
-        $this->assertEquals(0, $o->additionner(0, 0));
+        self::assertEquals(0, $o->additionner(0, 0));
     }</programlisting>
     </para>
 
@@ -254,7 +254,7 @@ class JeuDeBowlingTest extends PHPUnit_Framework_TestCase
     public function testScorePourJeuDansLaRigoleEst0()
     {
         $this->lancePlusieursEtRenverse(20, 0);
-        $this->assertEquals(0, $this->jeu->score());
+        self::assertEquals(0, $this->jeu->score());
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/fr/test-doubles.xml
+++ b/src/4.8/fr/test-doubles.xml
@@ -130,7 +130,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
 
         // Appeler $bouchon->faireQuelquechose() va maintenant retourner
         // 'foo'.
-        $this->assertEquals('foo', $bouchon->faireQuelquechose());
+        self::assertEquals('foo', $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -196,7 +196,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
 
         // Appeler $bouchon->faireQuelquechose() retournera maintenant
         // 'foo'.
-        $this->assertEquals('foo', $bouchon->faireQuelquechose());
+        self::assertEquals('foo', $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -233,10 +233,10 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $bouchon->faireQuelquechose('foo') retourne 'foo'
-        $this->assertEquals('foo', $bouchon->faireQuelquechose('foo'));
+        self::assertEquals('foo', $bouchon->faireQuelquechose('foo'));
 
         // $bouchon->faireQuelquechose('bar') retourne 'bar'
-        $this->assertEquals('bar', $bouchon->faireQuelquechose('bar'));
+        self::assertEquals('bar', $bouchon->faireQuelquechose('bar'));
     }
 }
 ?>]]></programlisting>
@@ -273,7 +273,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $bouchon->faireQuelquechose() retourne $bouchon
-        $this->assertSame($bouchon, $bouchon->faireQuelquechose());
+        self::assertSame($bouchon, $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -320,8 +320,8 @@ class BouchonTest extends PHPUnit_Framework_TestCase
         // $bouchon->faireQuelquechose() retourne
         // différentes valeurs selon les paramètres
         // fournis.
-        $this->assertEquals('d', $bouchon->faireQuelquechose('a', 'b', 'c'));
-        $this->assertEquals('h', $bouchon->faireQuelquechose('e', 'f', 'g'));
+        self::assertEquals('d', $bouchon->faireQuelquechose('a', 'b', 'c'));
+        self::assertEquals('h', $bouchon->faireQuelquechose('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -359,7 +359,7 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $bouchon->faireQuelquechose($argument) retourne str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $bouchon->faireQuelquechose('quelqueChose'));
+        self::assertEquals('fbzrguvat', $bouchon->faireQuelquechose('quelqueChose'));
     }
 }
 ?>]]></programlisting>
@@ -396,9 +396,9 @@ class BouchonTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $bouchon->faireQuelquechose() retourne une valeur différente à chaque fois
-        $this->assertEquals(2, $bouchon->faireQuelquechose());
-        $this->assertEquals(3, $bouchon->faireQuelquechose());
-        $this->assertEquals(5, $bouchon->faireQuelquechose());
+        self::assertEquals(2, $bouchon->faireQuelquechose());
+        self::assertEquals(3, $bouchon->faireQuelquechose());
+        self::assertEquals(5, $bouchon->faireQuelquechose());
     }
 }
 ?>]]></programlisting>
@@ -713,7 +713,7 @@ class ClasseAbstraiteTest extends PHPUnit_Framework_TestCase
              ->method('methodeAbstraite')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->methodeConcrete());
+        self::assertTrue($stub->methodeConcrete());
     }
 }
 ?>]]></programlisting>
@@ -845,7 +845,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() va maintenant retourner un result bouchon et
          * la méthode doGoogleSearch() du web service ne sera pas invoquée.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -945,10 +945,10 @@ class ExempleTest extends PHPUnit_Framework_TestCase
     public function testReprtoireEstCree()
     {
         $example = new Exemple('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setRepertoire(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -994,10 +994,10 @@ class ExempleTest extends PHPUnit_Framework_TestCase
     public function testRepertoireEstCree()
     {
         $exemple = new Exemple('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $exemple->setRepertoire(vfsStream::url('exempleRepertoire'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/fr/writing-tests-for-phpunit.xml
+++ b/src/4.8/fr/writing-tests-for-phpunit.xml
@@ -27,14 +27,14 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testerPushEtPop()
     {
         $pile = array();
-        $this->assertEquals(0, count($pile));
+        self::assertEquals(0, count($pile));
 
         array_push($pile, 'foo');
-        $this->assertEquals('foo', $pile[count($pile)-1]);
-        $this->assertEquals(1, count($pile));
+        self::assertEquals('foo', $pile[count($pile)-1]);
+        self::assertEquals(1, count($pile));
 
-        $this->assertEquals('foo', array_pop($pile));
-        $this->assertEquals(0, count($pile));
+        self::assertEquals('foo', array_pop($pile));
+        self::assertEquals(0, count($pile));
     }
 }
 ?>]]></programlisting>
@@ -98,7 +98,7 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testVide()
     {
         $pile = array();
-        $this->assertEmpty($pile);
+        self::assertEmpty($pile);
 
         return $pile;
     }
@@ -109,8 +109,8 @@ class PileTest extends PHPUnit_Framework_TestCase
     public function testPush(array $pile)
     {
         array_push($pile, 'foo');
-        $this->assertEquals('foo', $pile[count($pile)-1]);
-        $this->assertNotEmpty($pile);
+        self::assertEquals('foo', $pile[count($pile)-1]);
+        self::assertNotEmpty($pile);
 
         return $pile;
     }
@@ -120,8 +120,8 @@ class PileTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $pile)
     {
-        $this->assertEquals('foo', array_pop($pile));
-        $this->assertEmpty($pile);
+        self::assertEquals('foo', array_pop($pile));
+        self::assertEmpty($pile);
     }
 }
 ?>]]></programlisting>
@@ -154,7 +154,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testUn()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -228,7 +228,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdditionne($a, $b, $c)
     {
-        $this->assertEquals($c, $a + $b);
+        self::assertEquals($c, $a + $b);
     }
 
     public function fournisseur()
@@ -273,7 +273,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdditionne($a, $b, $c)
     {
-        $this->assertEquals($c, $a + $b);
+        self::assertEquals($c, $a + $b);
     }
 
     public function fournisseur()
@@ -673,7 +673,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testEcritureFichier() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->ecrit('/non-accessible-en-ecriture/fichier', 'texte'));
+        self::assertFalse(@$writer->ecrit('/non-accessible-en-ecriture/fichier', 'texte'));
     }
 }
 class FileWriter
@@ -825,7 +825,7 @@ class TableauPossedeUneClefTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -862,7 +862,7 @@ class ClassePossedeUnAttributTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -899,7 +899,7 @@ class ClassePossedeUnAttributStatiqueTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -939,7 +939,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -971,7 +971,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -1000,12 +1000,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -1046,7 +1046,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -1087,7 +1087,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -1127,7 +1127,7 @@ class VideTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -1165,7 +1165,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $attendu = new DOMElement('foo');
         $constate = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($attendu, $constate);
+        self::assertEqualXMLStructure($attendu, $constate);
     }
 
     public function testEchecAvecDifferentsAttributsDeNoeud()
@@ -1176,7 +1176,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild, TRUE
         );
     }
@@ -1189,7 +1189,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild
         );
     }
@@ -1202,7 +1202,7 @@ class StructuresXMLSontEgalesTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $attendu->firstChild, $constate->firstChild
         );
     }
@@ -1271,17 +1271,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testEchec2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testEchec3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -1338,12 +1338,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSucces()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testEchec()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -1380,7 +1380,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $constate = new DOMDocument;
         $constate->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($attendu, $constate);
+        self::assertEquals($attendu, $constate);
     }
 }
 ?>]]></programlisting>
@@ -1429,7 +1429,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $constate->foo = 'bar';
         $constate->baz = 'bar';
 
-        $this->assertEquals($attendu, $constate);
+        self::assertEquals($attendu, $constate);
     }
 }
 ?>]]></programlisting>
@@ -1470,7 +1470,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -1516,7 +1516,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -1553,7 +1553,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFileEquals('/home/sb/attendu', '/home/sb/constate');
+        self::assertFileEquals('/home/sb/attendu', '/home/sb/constate');
     }
 }
 ?>]]></programlisting>
@@ -1596,7 +1596,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertFileExists('/chemin/vers/fichier');
+        self::assertFileExists('/chemin/vers/fichier');
     }
 }
 ?>]]></programlisting>
@@ -1633,7 +1633,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -1670,7 +1670,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -1710,7 +1710,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1750,7 +1750,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1789,7 +1789,7 @@ class JsonFileEqualsJsonFile extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'chemin/vers/fixture/fichier', 'chemin/vers/constate/fichier');
     }
 }
@@ -1827,7 +1827,7 @@ class JsonStringEqualsJsonFile extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'chemin/vers/fixture/fichier', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1868,7 +1868,7 @@ class JsonStringEqualsJsonString extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1914,7 +1914,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1951,7 +1951,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1988,7 +1988,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -2025,7 +2025,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -2062,7 +2062,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -2099,7 +2099,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2150,7 +2150,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringMatchesFormatFile('/chemin/vers/attendu.txt', 'foo');
+        self::assertStringMatchesFormatFile('/chemin/vers/attendu.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2191,7 +2191,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -2223,7 +2223,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -2270,22 +2270,22 @@ class SelectCountTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectCount('foo bar', FALSE, $this->xml);
+        self::assertSelectCount('foo bar', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectCount('foo baz', TRUE, $this->xml);
+        self::assertSelectCount('foo baz', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectCount('foo bar', 5, $this->xml);
+        self::assertSelectCount('foo bar', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectCount('foo bar', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectCount('foo bar', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2347,22 +2347,22 @@ class SelectEqualsTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', FALSE, $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Bat', TRUE, $this->xml);
+        self::assertSelectEquals('foo bar', 'Bat', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', 5, $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectEquals('foo bar', 'Baz', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectEquals('foo bar', 'Baz', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2424,22 +2424,22 @@ class SelectRegExpTest extends PHPUnit_Framework_TestCase
 
     public function testAbsenceEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', FALSE, $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', FALSE, $this->xml);
     }
 
     public function testPresenceEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/B[oe]z]/', TRUE, $this->xml);
+        self::assertSelectRegExp('foo bar', '/B[oe]z]/', TRUE, $this->xml);
     }
 
     public function testCompteExactEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', 5, $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', 5, $this->xml);
     }
 
     public function testPlageEchec()
     {
-        $this->assertSelectRegExp('foo bar', '/Ba.*/', array('>'=>6, '<'=>8), $this->xml);
+        self::assertSelectRegExp('foo bar', '/Ba.*/', array('>'=>6, '<'=>8), $this->xml);
     }
 }
 ?>]]></programlisting>
@@ -2491,7 +2491,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringEndsWith('suffixe', 'foo');
+        self::assertStringEndsWith('suffixe', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2528,7 +2528,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringEqualsFile('/home/sb/attendu', 'constate');
+        self::assertStringEqualsFile('/home/sb/attendu', 'constate');
     }
 }
 ?>]]></programlisting>
@@ -2571,7 +2571,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertStringStartsWith('prefixe', 'foo');
+        self::assertStringStartsWith('prefixe', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -2699,10 +2699,10 @@ $matcher = array(
 );
 
 // Utilise assertTag() pour appliquer un $matcher à un morceau de $html.
-$this->assertTag($matcher, $html);
+self::assertTag($matcher, $html);
 
 // Utilise assertTag() pour appliquer un matcher à un morceau de $xml.
-$this->assertTag($matcher, $xml, '', FALSE);
+self::assertTag($matcher, $xml, '', FALSE);
 ?>]]></programlisting>
       </example>
     </section>
@@ -2734,7 +2734,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $leBiscuit = new Biscuit('Ginger');
         $monBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $leBiscuit,
           $this->logicalNot(
             $this->equalTo($monBiscuit)
@@ -2919,7 +2919,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -2956,7 +2956,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/attendu.xml', '/home/sb/constate.xml');
     }
 }
@@ -3002,7 +3002,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/attendu.xml', '<foo><baz/></foo>');
     }
 }
@@ -3048,7 +3048,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testEchec()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.8/ja/annotations.xml
+++ b/src/4.8/ja/annotations.xml
@@ -269,7 +269,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
@@ -801,7 +801,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>

--- a/src/4.8/ja/assertions.xml
+++ b/src/4.8/ja/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -57,7 +57,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -94,7 +94,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.8/ja/code-coverage-analysis.xml
+++ b/src/4.8/ja/code-coverage-analysis.xml
@@ -294,7 +294,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -307,7 +307,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -325,7 +325,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -340,11 +340,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -381,7 +381,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -415,6 +415,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.8/ja/database.xml
+++ b/src/4.8/ja/database.xml
@@ -215,7 +215,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -1176,7 +1176,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1204,12 +1204,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1239,7 +1239,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1299,7 +1299,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1324,7 +1324,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1342,7 +1342,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/ja/fixtures.xml
+++ b/src/4.8/ja/fixtures.xml
@@ -69,21 +69,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -146,13 +146,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.8/ja/incomplete-and-skipped-tests.xml
+++ b/src/4.8/ja/incomplete-and-skipped-tests.xml
@@ -57,7 +57,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // オプション: お望みなら、ここで何かのテストをしてください。
-        $this->assertTrue(TRUE, 'これは動いているはずです。');
+        self::assertTrue(TRUE, 'これは動いているはずです。');
 
         // ここで処理を止め、テストが未完成であるという印をつけます。
         $this->markTestIncomplete(

--- a/src/4.8/ja/selenium.xml
+++ b/src/4.8/ja/selenium.xml
@@ -24,7 +24,7 @@
       (ウェブアプリケーションを、さまざまなオペレーティングシステムやブラウザでテストする)
       などがあります。
     </para>
-    
+
     <para>
       PHPUnit_Selenium がサポートしている唯一のシナリオは、
       Selenium 2.x サーバを使うものです。
@@ -37,7 +37,7 @@
     </para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>インストール</title>
 
@@ -95,7 +95,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -122,7 +122,7 @@ Failed asserting that two strings are equal.
 FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
 
-  <para>    
+  <para>
     Selenium2TestCase のコマンドは __call() を使って実装しています。
     サポートする機能の一覧は
     <ulink url="https://github.com/sebastianbergmann/phpunit-selenium/blob/master/Tests/Selenium2TestCaseTest.php">PHPUnit_Extensions_Selenium2TestCase のエンドツーエンドテスト</ulink>
@@ -163,7 +163,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -265,7 +265,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -346,7 +346,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/ja/test-doubles.xml
+++ b/src/4.8/ja/test-doubles.xml
@@ -156,7 +156,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() をコールすると
         // 'foo' を返すようになります
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -195,7 +195,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // $stub->doSomething() をコールすると
         // 'foo' を返すようになります
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -252,10 +252,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') は 'foo' を返します
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') は 'bar' を返します
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -290,7 +290,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() は $stub を返します
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -332,8 +332,8 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnValueMap($map));
 
         // $stub->doSomething() は、渡した引数に応じて異なる値を返します
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -372,7 +372,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) は str_rot13($argument) を返します
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -408,9 +408,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() は毎回異なる値を返します
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -520,12 +520,12 @@ class Subject
 {
     protected $observers = array();
     protected $name;
-    
+
     public function __construct($name)
     {
         $this->name = $name;
     }
-    
+
     public function getName()
     {
         return $this->name;
@@ -936,7 +936,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -974,7 +974,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -1050,7 +1050,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() はスタブが用意した結果を返し、
          * ウェブサービスの doGoogleSearch() が呼び出されることはありません
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1151,10 +1151,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1200,10 +1200,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/ja/textui.xml
+++ b/src/4.8/ja/textui.xml
@@ -401,7 +401,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.8/ja/writing-tests-for-phpunit.xml
+++ b/src/4.8/ja/writing-tests-for-phpunit.xml
@@ -26,14 +26,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -111,7 +111,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -122,8 +122,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -133,8 +133,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -169,7 +169,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -226,13 +226,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -242,7 +242,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -294,7 +294,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -339,7 +339,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -434,13 +434,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -451,7 +451,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -862,7 +862,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -1005,7 +1005,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1055,7 +1055,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1109,7 +1109,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );

--- a/src/4.8/pt_br/annotations.xml
+++ b/src/4.8/pt_br/annotations.xml
@@ -6,25 +6,25 @@
   <para>
     <indexterm><primary>Anotações</primary></indexterm>
 
-    Uma anotação é uma forma especial de metadados sintáticos que podem ser adicionados ao 
-    código-fonte de algumas linguagens de programação. Enquanto o PHP não tem 
-    um recurso de linguagem dedicado a anotação de código-fonte, o uso de tags 
-    como <literal>@annotation arguments</literal> em bloco de documentação tem sido 
-    estabelecido na comunidade do PHP para anotar o código-fonte. Os blocos 
-    de documentação PHP são reflexivos: eles podem ser acessados através do 
-    método <literal>getDocComment()</literal> da API Reflection a nível de função, 
-    classe, método e atributo. Aplicações como o PHPUnit usam essa 
+    Uma anotação é uma forma especial de metadados sintáticos que podem ser adicionados ao
+    código-fonte de algumas linguagens de programação. Enquanto o PHP não tem
+    um recurso de linguagem dedicado a anotação de código-fonte, o uso de tags
+    como <literal>@annotation arguments</literal> em bloco de documentação tem sido
+    estabelecido na comunidade do PHP para anotar o código-fonte. Os blocos
+    de documentação PHP são reflexivos: eles podem ser acessados através do
+    método <literal>getDocComment()</literal> da API Reflection a nível de função,
+    classe, método e atributo. Aplicações como o PHPUnit usam essa
     informação em tempo de execução para configurar seu comportamento.
   </para>
 
   <note>
     <para>
-      Um comentário de documentação em PHP deve começar com <literal>/**</literal> e terminar com 
-      <literal>*/</literal>. Anotações em algum outro estilo de comentário será 
+      Um comentário de documentação em PHP deve começar com <literal>/**</literal> e terminar com
+      <literal>*/</literal>. Anotações em algum outro estilo de comentário será
       ignorada.
     </para>
   </note>
-  
+
   <para>
     Este apêndice mostra todas as variedades de anotações suportadas pelo PHPUnit.
   </para>
@@ -37,17 +37,17 @@
 
       A anotação <literal>@author</literal> é um apelido para a anotação
       <literal>@group</literal> (veja <xref
-      linkend="appendixes.annotations.group"/>) e permite filtrar os testes baseado 
+      linkend="appendixes.annotations.group"/>) e permite filtrar os testes baseado
       em seus autores.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.after">
     <title>@after</title>
 
     <para>
 
-      A anotação <literal>@after</literal> pode ser usada para especificar métodos 
+      A anotação <literal>@after</literal> pode ser usada para especificar métodos
       que devem ser chamados depois de cada método em uma classe de caso de teste.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -69,14 +69,14 @@
 }</programlisting>
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.afterClass">
     <title>@afterClass</title>
 
     <para>
 
-      A anotação <literal>@afterClass</literal> pode ser usada para especificar 
-      métodos estáticos que devem ser chamados depois de todos os métodos de teste em uma classe 
+      A anotação <literal>@afterClass</literal> pode ser usada para especificar
+      métodos estáticos que devem ser chamados depois de todos os métodos de teste em uma classe
       de teste foram executados para limpar ambientes compartilhados.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -105,7 +105,7 @@
     <para>
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
-      As operações de cópia de segurança e restauração para variáveis globais podem ser completamente 
+      As operações de cópia de segurança e restauração para variáveis globais podem ser completamente
       desabilitadas para todos os testes de uma classe de caso de teste como esta <programlisting>/**
  * @backupGlobals disabled
  */
@@ -118,8 +118,8 @@ class MyTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
-      A anotação <literal>@backupGlobals</literal> também pode ser usada a nível 
-      de método de teste. Isso permite uma configuração refinada das 
+      A anotação <literal>@backupGlobals</literal> também pode ser usada a nível
+      de método de teste. Isso permite uma configuração refinada das
       operações de cópia de segurança e restauração: <programlisting>/**
  * @backupGlobals disabled
  */
@@ -142,8 +142,8 @@ class MyTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
 
-      A anotação <literal>@backupStaticAttributes</literal> pode ser usada para 
-      copiar todos valores de propriedades estáticas em todas classes declaradas antes de cada 
+      A anotação <literal>@backupStaticAttributes</literal> pode ser usada para
+      copiar todos valores de propriedades estáticas em todas classes declaradas antes de cada
       teste e restaurá-los depois. Pode ser usado em nível de classe de caso de teste ou
       método de teste:
 
@@ -166,23 +166,23 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        <literal>@backupStaticAttributes</literal> é limitada pela parte interna do PHP 
-        e pode causar valores estáticos não intencionais ao persistir e vazar para 
+        <literal>@backupStaticAttributes</literal> é limitada pela parte interna do PHP
+        e pode causar valores estáticos não intencionais ao persistir e vazar para
         testes subsequentes em algumas circunstâncias.
       </para>
       <para>
         Veja <xref linkend="fixtures.global-state"/> para detalhes.
       </para>
     </note>
-    
+
   </section>
-  
+
   <section id="appendixes.annotations.before">
     <title>@before</title>
 
     <para>
 
-      A anotação <literal>@before</literal> pode ser usada para especificar métodos 
+      A anotação <literal>@before</literal> pode ser usada para especificar métodos
       que devem ser chamados antes de cada método de teste em uma classe de caso de teste.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -204,14 +204,14 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.beforeClass">
     <title>@beforeClass</title>
 
     <para>
 
-      A anotação <literal>@beforeClass</literal> pode ser usada para especificar métodos 
-      estáticos que devem ser chamados antes de quaisquer métodos de teste em uma classe 
+      A anotação <literal>@beforeClass</literal> pode ser usada para especificar métodos
+      estáticos que devem ser chamados antes de quaisquer métodos de teste em uma classe
       de teste serem executados para criar ambientes compartilahdos.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -244,7 +244,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 
       As anotações <literal>@codeCoverageIgnore</literal>,
       <literal>@codeCoverageIgnoreStart</literal> e
-      <literal>@codeCoverageIgnoreEnd</literal> podem ser usadas 
+      <literal>@codeCoverageIgnoreEnd</literal> podem ser usadas
       para excluir linhas de código da análise de cobertura.
     </para>
 
@@ -261,23 +261,23 @@ class MyTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Cobertura de Código</primary></indexterm>
       <indexterm><primary>@covers</primary></indexterm>
 
-      A anotação <literal>@covers</literal> pode ser usada no código de teste para 
+      A anotação <literal>@covers</literal> pode ser usada no código de teste para
       especificar quais métodos um método de teste quer testar: <programlisting>/**
  * @covers BankAccount::getBalance
  */
 public function testBalanceIsInitiallyZero()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
 
     <para>
-      Se fornecida, apenas a informação de cobertura de código para o(s) 
+      Se fornecida, apenas a informação de cobertura de código para o(s)
       método(s) especificado(s) será considerada.
     </para>
 
     <para>
-      <xref linkend="appendixes.annotations.covers.tables.annotations"/> mostra 
+      <xref linkend="appendixes.annotations.covers.tables.annotations"/> mostra
       a sintaxe da anotação <literal>@covers</literal>.
     </para>
 
@@ -336,7 +336,7 @@ public function testBalanceIsInitiallyZero()
       </tgroup>
     </table>
   </section>
-  
+
   <section id="appendixes.annotations.coversDefaultClass">
     <title>@coversDefaultClass</title>
 
@@ -376,8 +376,8 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@coversNothing</primary></indexterm>
 
-      A anotação <literal>@coversNothing</literal> pode ser usada no 
-      código de teste para especificar que nenhuma informação de cobertura de código será 
+      A anotação <literal>@coversNothing</literal> pode ser usada no
+      código de teste para especificar que nenhuma informação de cobertura de código será
       gravada para o caso de teste anotado.
     </para>
 
@@ -388,7 +388,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     </para>
 
     <para>
-        A anotação pode ser usada nos níveis de classe e de método e 
+        A anotação pode ser usada nos níveis de classe e de método e
         vão sobrescrever quaisquer tags <literal>@covers</literal>.
     </para>
   </section>
@@ -399,7 +399,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@dataProvider</primary></indexterm>
 
-      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser 
+      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser
       fornecidos por um método provedor  (<literal>provider()</literal> em
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
       O método provedor de dados a ser usado é especificado usando a anotação
@@ -407,7 +407,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.data-providers"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.data-providers"/> para mais
       detalhes.
     </para>
   </section>
@@ -418,17 +418,17 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@depends</primary></indexterm>
 
-      O PHPUnit suporta a declaração de dependências explícitas entre métodos 
-      de teste. Tais dependências não definem a ordem em que os métodos de teste 
-      devem ser executados, mas permitem o retorno de uma instância do 
+      O PHPUnit suporta a declaração de dependências explícitas entre métodos
+      de teste. Tais dependências não definem a ordem em que os métodos de teste
+      devem ser executados, mas permitem o retorno de uma instância do
       ambiente de teste por um produtor e passá-la aos consumidores dependentes.
-      O <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> mostra 
-      como usar a anotação <literal>@depends</literal> para expressar 
+      O <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> mostra
+      como usar a anotação <literal>@depends</literal> para expressar
       dependências entre métodos de teste.
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.test-dependencies"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.test-dependencies"/> para mais
       detalhes.
     </para>
   </section>
@@ -440,12 +440,12 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>@expectedException</primary></indexterm>
 
       O <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest.php" />
-      mostra como usar a anotação <literal>@expectedException</literal> para 
+      mostra como usar a anotação <literal>@expectedException</literal> para
       testar se uma exceção é lançada dentro do código testado.
     </para>
 
     <para>
-      Veja <xref linkend="writing-tests-for-phpunit.exceptions"/> para mais 
+      Veja <xref linkend="writing-tests-for-phpunit.exceptions"/> para mais
       detalhes.
     </para>
   </section>
@@ -456,9 +456,9 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
-      A anotação <literal>@expectedExceptionCode</literal> em conjunção 
-      com a <literal>@expectedException</literal> permite fazer asserções no 
-      código de erro de uma exceção lançada, permitindo diminuir uma 
+      A anotação <literal>@expectedExceptionCode</literal> em conjunção
+      com a <literal>@expectedException</literal> permite fazer asserções no
+      código de erro de uma exceção lançada, permitindo diminuir uma
       exceção específica.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -473,7 +473,7 @@ class CoversDefaultClassTest extends PHPUnit_Framework_TestCase
     }
 }</programlisting>
 
-      Para facilitar o teste e reduzir a duplicação, um atalho pode ser usado para 
+      Para facilitar o teste e reduzir a duplicação, um atalho pode ser usado para
       especificar uma constante de classe como um
       <literal>@expectedExceptionCode</literal> usando a sintaxe
       "<literal>@expectedExceptionCode ClassName::CONST</literal>".
@@ -504,8 +504,8 @@ class MyClass
     <para>
       <indexterm><primary>@expectedExceptionMessage</primary></indexterm>
 
-      A anotação <literal>@expectedExceptionMessage</literal> trabalha de modo similar 
-      a <literal>@expectedExceptionCode</literal> já que lhe permite fazer uma 
+      A anotação <literal>@expectedExceptionMessage</literal> trabalha de modo similar
+      a <literal>@expectedExceptionCode</literal> já que lhe permite fazer uma
       asserção na mensagem de erro de uma exceção.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -520,9 +520,9 @@ class MyClass
     }
 }</programlisting>
 
-      A mensagem esperada pode ser uma substring de uma Mensagem de exceção. 
-      Isso pode ser útil para asseverar apenas que um certo nome ou parâmetro que 
-      foi passado é mostrado na exceção e não fixar toda a 
+      A mensagem esperada pode ser uma substring de uma Mensagem de exceção.
+      Isso pode ser útil para asseverar apenas que um certo nome ou parâmetro que
+      foi passado é mostrado na exceção e não fixar toda a
       mensagem de exceção no teste.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -538,7 +538,7 @@ class MyClass
      }
 }</programlisting>
 
-      Para facilitar o teste e reduzir duplicação um atalho pode ser usado para 
+      Para facilitar o teste e reduzir duplicação um atalho pode ser usado para
       especificar uma constante de classe como uma
       <literal>@expectedExceptionMessage</literal> usando a sintaxe
       "<literal>@expectedExceptionMessage ClassName::CONST</literal>".
@@ -547,7 +547,7 @@ class MyClass
     </para>
 
   </section>
-  
+
   <section id="appendixes.annotations.expectedExceptionMessageRegExp">
     <title>@expectedExceptionMessageRegExp</title>
 
@@ -556,7 +556,7 @@ class MyClass
 
       A mensagem experada também pode ser especificada como uma expressão regular usando
       a anotação <literal>@expectedExceptionMessageRegExp</literal>. Isso
-      é útil em situações aonde uma substring não é adequada para combinar 
+      é útil em situações aonde uma substring não é adequada para combinar
       uma determinada mensagem.
 
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
@@ -580,7 +580,7 @@ class MyClass
     <para>
       <indexterm><primary>@group</primary></indexterm>
 
-      Um teste pode ser marcado como pertencente a um ou mais grupos usando a 
+      Um teste pode ser marcado como pertencente a um ou mais grupos usando a
       anotação <literal>@group</literal> desta forma <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -601,20 +601,20 @@ class MyClass
     </para>
 
     <para>
-      Testes podem ser selecionados para execução baseada em grupos usando as 
-      opções <literal>--group</literal> e <literal>--exclude-group</literal> 
-      do executor de teste em linha-de-comando ou usando as respectivas diretivas do 
+      Testes podem ser selecionados para execução baseada em grupos usando as
+      opções <literal>--group</literal> e <literal>--exclude-group</literal>
+      do executor de teste em linha-de-comando ou usando as respectivas diretivas do
       arquivo de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.large">
     <title>@large</title>
 
     <para>
       <indexterm><primary><literal>@large</literal></primary></indexterm>
 
-      A anotação <literal>@large</literal> é um apelido para 
+      A anotação <literal>@large</literal> é um apelido para
       <literal>@group large</literal>.
     </para>
 
@@ -622,14 +622,14 @@ class MyClass
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForLargeTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
-      estrito estiver habilitado, um teste grande irá falhar se ele demorar mais de 60 
-      segundos para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForLargeTests</literal> no arquivo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
+      estrito estiver habilitado, um teste grande irá falhar se ele demorar mais de 60
+      segundos para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForLargeTests</literal> no arquivo
       de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.medium">
     <title>@medium</title>
 
@@ -645,26 +645,26 @@ class MyClass
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForMediumTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
-      estrito estiver habilitado, um teste médio irá falhar se ele demorar mais de 10 
-      segundos para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForMediumTests</literal> no arquivo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
+      estrito estiver habilitado, um teste médio irá falhar se ele demorar mais de 10
+      segundos para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForMediumTests</literal> no arquivo
       de configuração XML.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.preserveGlobalState">
     <title>@preserveGlobalState</title>
 
     <para>
       <indexterm><primary>@preserveGlobalState</primary></indexterm>
 
-      Quando um teste é executado em um processo separado, o PHPUnit 
-      tentará preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
-      contém globais que não são serializáveis. Para corrigir isto, você pode prevenir o 
-      PHPUnit de preservar o estado global com a 
+      Quando um teste é executado em um processo separado, o PHPUnit
+      tentará preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
+      contém globais que não são serializáveis. Para corrigir isto, você pode prevenir o
+      PHPUnit de preservar o estado global com a
       anotação <literal>@preserveGlobalState</literal>.
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -703,7 +703,7 @@ class MyClass
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indica que todos testes em uma classe de teste devem ser executados em um processo 
+      Indica que todos testes em uma classe de teste devem ser executados em um processo
       PHP separado. <programlisting>/**
  * @runTestsInSeparateProcesses
  */
@@ -713,11 +713,11 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
 
       <emphasis role="strong">Nota:</emphasis> Por padrão, o PHPUnit tentará
-      preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
+      preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
       contém globais que não são serializáveis. Veja <xref
-      linkend="appendixes.annotations.preserveGlobalState"/> para informações 
+      linkend="appendixes.annotations.preserveGlobalState"/> para informações
       de como corrigir isso.
     </para>
   </section>
@@ -741,15 +741,15 @@ class MyTest extends PHPUnit_Framework_TestCase
 }</programlisting>
 
       <emphasis role="strong">Nota:</emphasis> Por padrão, o PHPUnit tentará
-      preservar o estado global de processo pai 
-      serializando todos globais no processo pai e deserializando-os 
-      no processo filho. Isso pode causar problemas se o processo pai 
+      preservar o estado global de processo pai
+      serializando todos globais no processo pai e deserializando-os
+      no processo filho. Isso pode causar problemas se o processo pai
       contém globais que não são serializáveis. Veja <xref
-      linkend="appendixes.annotations.preserveGlobalState"/> para informações 
+      linkend="appendixes.annotations.preserveGlobalState"/> para informações
       de como corrigir isso.
     </para>
   </section>
-  
+
   <section id="appendixes.annotations.small">
     <title>@small</title>
 
@@ -765,19 +765,19 @@ class MyTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>PHP_Invoker</literal></primary></indexterm>
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
-      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo 
+      Se o pacote <literal>PHP_Invoker</literal> estiver instalado e o modo
       estrito estiver habilitado, um teste pequeno irá falhar se ele demorar mais de 1
-      segundo para executar. Esse tempo de espera é configurável através do 
-      atributo <literal>timeoutForLargeTests</literal> no arquivo 
+      segundo para executar. Esse tempo de espera é configurável através do
+      atributo <literal>timeoutForLargeTests</literal> no arquivo
       de configuração XML.
     </para>
 
     <note>
       <para>
-        Pr padrão, todos testes são considerados pequenos se eles não são 
+        Pr padrão, todos testes são considerados pequenos se eles não são
         como <literal>@medium</literal> ou <literal>@large</literal>. Note, por favor,
-        no entanto, que <literal>--group</literal> e as opções relacionadas irão 
-        apenas considerarão um teste ser do grupo <literal>small</literal> se ele 
+        no entanto, que <literal>--group</literal> e as opções relacionadas irão
+        apenas considerarão um teste ser do grupo <literal>small</literal> se ele
         é marcado explicitamente com a anotação apropriada.
       </para>
     </note>
@@ -797,7 +797,7 @@ class MyTest extends PHPUnit_Framework_TestCase
  */
 public function initialBalanceShouldBe0()
 {
-    $this->assertEquals(0, $this->ba->getBalance());
+    self::assertEquals(0, $this->ba->getBalance());
 }</programlisting>
     </para>
   </section>
@@ -822,14 +822,14 @@ public function initialBalanceShouldBe0()
 
     <programlisting></programlisting>
   </section>
-  
+
   <section id="appendixes.annotations.uses">
     <title>@uses</title>
 
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      A anotação <literal>@uses</literal> especifica o código que irá 
+      A anotação <literal>@uses</literal> especifica o código que irá
       ser executado por um teste, mas não se destina a ser coberto pelo teste. Um bom
       exemplo é um objeto valor que é necessário para testar um unidade de código.
       <programlisting>/**
@@ -843,9 +843,9 @@ public function testMoneyCanBeDepositedInAccount()
     </para>
 
     <para>
-      Essa anotação é especialmente útil em modo de cobertura estrita aonde 
+      Essa anotação é especialmente útil em modo de cobertura estrita aonde
       código coberto involuntariamente fará um teste falhar. Veja
-      <xref linkend="risky-tests.unintentionally-covered-code"/> para mais 
+      <xref linkend="risky-tests.unintentionally-covered-code"/> para mais
       informação sobre modo de cobertura estrito.
     </para>
   </section>

--- a/src/4.8/pt_br/assertions.xml
+++ b/src/4.8/pt_br/assertions.xml
@@ -20,7 +20,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -42,7 +42,7 @@ FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.</screen>
     </example>
   </section>
-  
+
   <section id="appendixes.assertions.assertClassHasAttribute">
     <title>assertClassHasAttribute()</title>
     <indexterm><primary>assertClassHasAttribute()</primary></indexterm>
@@ -57,7 +57,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -94,7 +94,7 @@ class ArraySubsetTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
+        self::assertArraySubset(['config' => ['key-a', 'key-b']], ['config' => ['key-a']]);
     }
 }
 ?>]]></programlisting>
@@ -136,7 +136,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -176,7 +176,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -208,7 +208,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -237,12 +237,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -283,7 +283,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -321,7 +321,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -357,7 +357,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -397,7 +397,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -435,7 +435,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -446,7 +446,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -459,7 +459,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -472,7 +472,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -541,17 +541,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -608,12 +608,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -650,7 +650,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -699,7 +699,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -740,7 +740,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -786,7 +786,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -866,7 +866,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -903,7 +903,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -940,7 +940,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -980,7 +980,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -1020,7 +1020,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1059,7 +1059,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1089,7 +1089,7 @@ Tests: 1, Assertions: 3, Failures: 1.</screen>
     <indexterm><primary>assertJsonStringNotEqualsJsonFile()</primary></indexterm>
     <para><literal>assertJsonStringEqualsJsonFile(mixed $expectedFile, mixed $actualJson[, string $message = ''])</literal></para>
     <para>
-      Reporta um erro identificado pela <literal>$message</literal> se o valor de <literal>$actualJson</literal> não combina com o valor de 
+      Reporta um erro identificado pela <literal>$message</literal> se o valor de <literal>$actualJson</literal> não combina com o valor de
       <literal>$expectedFile</literal>.
     </para>
     <example id="appendixes.assertions.assertJsonStringEqualsJsonFile.example">
@@ -1099,7 +1099,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1140,7 +1140,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1186,7 +1186,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1223,7 +1223,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1260,7 +1260,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1297,7 +1297,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1334,7 +1334,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1371,7 +1371,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1422,7 +1422,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1463,7 +1463,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1495,7 +1495,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1532,7 +1532,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1569,7 +1569,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1612,7 +1612,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1640,10 +1640,10 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertThat()</primary></indexterm>
 
     <para>
-      Asserções mais complexas podem ser formuladas usando as 
-      classes <literal>PHPUnit_Framework_Constraint</literal>. Elas podem ser 
+      Asserções mais complexas podem ser formuladas usando as
+      classes <literal>PHPUnit_Framework_Constraint</literal>. Elas podem ser
       avaliadas usando o método <literal>assertThat()</literal>.
-      <xref linkend="appendixes.assertions.assertThat.example" /> mostra como as 
+      <xref linkend="appendixes.assertions.assertThat.example" /> mostra como as
       restrições <literal>logicalNot()</literal> e <literal>equalTo()</literal>
       podem ser usadas para expressar a mesma asserção como
       <literal>assertNotEquals()</literal>.
@@ -1661,7 +1661,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1856,7 +1856,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1893,7 +1893,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1939,7 +1939,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1985,7 +1985,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.8/pt_br/code-coverage-analysis.xml
+++ b/src/4.8/pt_br/code-coverage-analysis.xml
@@ -8,7 +8,7 @@
     <para>
       Na ciência da computação, cobertura de código é um mensuração usada para descrever o
       grau em que um código fonte de um programa é testado por uma suíte
-      de testes particular. Um programa com cobertura de código alta foi mais exaustivamente 
+      de testes particular. Um programa com cobertura de código alta foi mais exaustivamente
       testado e tem uma menor chance de conter erros de software do que um programa
       com baixa cobertura de código.
     </para>
@@ -18,39 +18,39 @@
     <indexterm><primary>Cobertura de Código</primary></indexterm>
     <indexterm><primary>Xdebug</primary></indexterm>
 
-    Neste capítulo você aprenderá tudo sobre a funcionalidade de cobertura de código 
-    do PHPUnit que lhe dará uma perspicácia sobre quais partes do código de produção 
+    Neste capítulo você aprenderá tudo sobre a funcionalidade de cobertura de código
+    do PHPUnit que lhe dará uma perspicácia sobre quais partes do código de produção
     são executadas quando os testes são executados. Ele faz uso do componente
     <ulink url="https://github.com/sebastianbergmann/php-code-coverage">PHP_CodeCoverage</ulink>,
-    que por sua vez utiliza a funcionalidade de cobertura de código fornecido 
+    que por sua vez utiliza a funcionalidade de cobertura de código fornecido
     pela extensão <ulink url="http://xdebug.org/">Xdebug</ulink> para PHP.
   </para>
-  
+
   <note>
     <para>
-      Xdebug não é distribuído como parte do PHPUnit. Se você Se você receber um aviso 
-      durante a execução de testes que a extensão Xdebug não está carregada, isso significa 
+      Xdebug não é distribuído como parte do PHPUnit. Se você Se você receber um aviso
+      durante a execução de testes que a extensão Xdebug não está carregada, isso significa
       que Xdebug ou não está instalada ou não está configurada corretamente. Antes
       que você possa usar as funcionalidades de análise de cobertura de código no PHPUnit, você deve
       ler <ulink url="http://xdebug.org/docs/install">o manual de instalação Xdebug</ulink>.
     </para>
   </note>
-  
+
   <para>
-    PHPUnit pode gerar um relatório de cobertura de código baseado em HTML, tal como 
+    PHPUnit pode gerar um relatório de cobertura de código baseado em HTML, tal como
     arquivos de registros baseado em XML com informações de cobertura de código em vários formatos
-    (Clover, Crap4J, PHPUnit). Informação de cobertura de código também pode ser relatado 
-    como texto (e impresso na STDOUT) e exportado como código PHP para futuro 
+    (Clover, Crap4J, PHPUnit). Informação de cobertura de código também pode ser relatado
+    como texto (e impresso na STDOUT) e exportado como código PHP para futuro
     processamento.
   </para>
-  
+
   <para>
     Por favor, consulte o <xref linkend="textui"/> para uma lista de opções de linha de comando
     que controlam a funcionalidade de cobertura de código, bem como em <xref
-    linkend="appendixes.configuration.logging"/> para as definições de 
+    linkend="appendixes.configuration.logging"/> para as definições de
     configurações relevantes.
   </para>
-  
+
   <section id="code-coverage-analysis.metrics">
     <title>Métricas de Software para  Cobertura de Código</title>
 
@@ -75,9 +75,9 @@
         <term><emphasis>Cobertura de Função e Método</emphasis></term>
         <listitem>
           <para>
-            A métrica de software <emphasis>Cobertura de Função e Método</emphasis> 
+            A métrica de software <emphasis>Cobertura de Função e Método</emphasis>
             mensura se cada função ou método foi invocado.
-            PHP_CodeCoverage só considera uma função ou método como coberto quando 
+            PHP_CodeCoverage só considera uma função ou método como coberto quando
             todas suas linhas executáveis são cobertas.
           </para>
         </listitem>
@@ -101,10 +101,10 @@
         <term><emphasis>Cobertura de Código de Operação</emphasis></term>
         <listitem>
           <para>
-            A métrica de software <emphasis>Cobertura de Código de Operação</emphasis> mensura 
-            se cada código de operação de uma função ou método foi  executado enquanto 
-            executa a suíte de teste. Uma linha de código geralmente compila em mais 
-            de um código de operação. Cobertura de Linha considera uma linha de código como coberta 
+            A métrica de software <emphasis>Cobertura de Código de Operação</emphasis> mensura
+            se cada código de operação de uma função ou método foi  executado enquanto
+            executa a suíte de teste. Uma linha de código geralmente compila em mais
+            de um código de operação. Cobertura de Linha considera uma linha de código como coberta
             logo que um dos seus códigos de operações é executado.
           </para>
         </listitem>
@@ -116,7 +116,7 @@
         <listitem>
           <para>
             A métrica de software <emphasis>Cobertura de Ramo</emphasis> mensura
-            se cada expressão booleana de cada estrutura de controle avaliada 
+            se cada expressão booleana de cada estrutura de controle avaliada
             a <literal>true</literal> e <literal>false</literal> enquanto
             executa a suíte de teste.
           </para>
@@ -129,9 +129,9 @@
         <listitem>
           <para>
             A métrica de software <emphasis>Cobertura de Caminho</emphasis> mensura
-            se cada um dos caminhos de execução possíveis em uma função ou método 
-            foi seguido durante a execução da suíte de teste. Um caminho de execução é 
-            uma sequência única de ramos a partir da entrada de uma função ou 
+            se cada um dos caminhos de execução possíveis em uma função ou método
+            foi seguido durante a execução da suíte de teste. Um caminho de execução é
+            uma sequência única de ramos a partir da entrada de uma função ou
             método para a sua saída.
           </para>
         </listitem>
@@ -142,11 +142,11 @@
         <term><emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis></term>
         <listitem>
           <para>
-            O <emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis> é 
-            calculado baseado na complexidade ciclomática e cobertura de código de uma 
-            unidade de código. Código que não é muito complexo e tem uma cobertura de teste 
+            O <emphasis>Índice de Anti-Patterns de Mudança de Risco (CRAP - Change Risk Anti-Patterns)</emphasis> é
+            calculado baseado na complexidade ciclomática e cobertura de código de uma
+            unidade de código. Código que não é muito complexo e tem uma cobertura de teste
             adequada terá um baixo índice CRAP. O índice CRAP pode ser reduzido
-            escrevendo testes e refatorando o código para reduzir sua 
+            escrevendo testes e refatorando o código para reduzir sua
             complexidade.
           </para>
         </listitem>
@@ -162,16 +162,16 @@
       </para>
     </note>
   </section>
-  
+
   <section id="code-coverage-analysis.including-excluding-files">
     <title>Incluindo e Excluindo Arquivos</title>
 
     <para>
-      Por padrão, todos os arquivos de código-fonte que contém pelo menos uma linha de código que 
-      tenha sido executada (e apenas esses arquivos) são incluídos no relatório 
+      Por padrão, todos os arquivos de código-fonte que contém pelo menos uma linha de código que
+      tenha sido executada (e apenas esses arquivos) são incluídos no relatório
       de cobertura de código.
     </para>
-    
+
     <para>
       <indexterm><primary>Cobertura de código</primary><secondary>Lista-negra</secondary></indexterm>
 
@@ -179,23 +179,23 @@
       relatório de cobertura de código. Essa lista-negra é previamente preenchida com os
       arquivos-fonte do PHPUnit e suas dependências.
     </para>
-    
+
     <para>
       <indexterm><primary>Cobertura de código</primary><secondary>Lista-branca</secondary></indexterm>
 
-      É uma boa prática usar um <emphasis>lista-branca</emphasis> ao invés da 
+      É uma boa prática usar um <emphasis>lista-branca</emphasis> ao invés da
       lista-negra mencionada acima.
     </para>
-    
+
     <para>
       Opcionalmente, todos arquivos da lista-branca pode ser adicionados ao relatório
       de cobertura de código pela definição <literal>addUncoveredFilesFromWhitelist="true"</literal>
       em suas configurações do PHPUnit (veja <xref
-      linkend="appendixes.configuration.blacklist-whitelist"/>). Isso permite a 
-      inclusão de arquivos que ainda não são testados em tudo. Se você quer obter 
+      linkend="appendixes.configuration.blacklist-whitelist"/>). Isso permite a
+      inclusão de arquivos que ainda não são testados em tudo. Se você quer obter
       informação sobre quais linhas de um tal arquivo descoberto são executadas,
-      por exemplo, você também precisa definir 
-      <literal>processUncoveredFilesFromWhitelist="true"</literal> em suas 
+      por exemplo, você também precisa definir
+      <literal>processUncoveredFilesFromWhitelist="true"</literal> em suas
       configurações do PHPUnit (veja <xref
       linkend="appendixes.configuration.blacklist-whitelist"/>).
     </para>
@@ -203,13 +203,13 @@
     <note>
       <para>
         Por favor, note que o carregamento de arquivos de código-fonte que é realizado, quando
-        <literal>processUncoveredFilesFromWhitelist="true"</literal> é definido, pode 
-        causar problemas quando um arquivo de código-fonte contém código fora do escopo de 
+        <literal>processUncoveredFilesFromWhitelist="true"</literal> é definido, pode
+        causar problemas quando um arquivo de código-fonte contém código fora do escopo de
         uma classe ou função, por exemplo.
       </para>
     </note>
   </section>
-  
+
   <section id="code-coverage-analysis.ignoring-code-blocks">
     <title>Ignorando Blocos de Código</title>
 
@@ -219,11 +219,11 @@
       <indexterm><primary>@codeCoverageIgnoreStart</primary></indexterm>
       <indexterm><primary>@codeCoverageIgnoreEnd</primary></indexterm>
 
-      Às vezes você tem blocos de código que não pode testar e que pode 
-      querer ignorar durante a análise de cobertura de código. O PHPUnit permite que você o faça 
+      Às vezes você tem blocos de código que não pode testar e que pode
+      querer ignorar durante a análise de cobertura de código. O PHPUnit permite que você o faça
       usando as anotações <literal>@codeCoverageIgnore</literal>,
       <literal>@codeCoverageIgnoreStart</literal> e
-      <literal>@codeCoverageIgnoreEnd</literal> como mostrado em 
+      <literal>@codeCoverageIgnoreEnd</literal> como mostrado em
       <xref linkend="code-coverage-analysis.ignoring-code-blocks.examples.Sample.php"/>.
     </para>
 
@@ -262,11 +262,11 @@ exit; // @codeCoverageIgnore
 
     <para>
       As linhas de código ignoradas (marcadas como ignoradas usando as anotações)
-      são contadas como executadas (se forem executáveis) e não serão 
+      são contadas como executadas (se forem executáveis) e não serão
       destacadas.
     </para>
   </section>
-  
+
   <section id="code-coverage-analysis.specifying-covered-methods">
     <title>Especificando métodos cobertos</title>
 
@@ -275,9 +275,9 @@ exit; // @codeCoverageIgnore
       <indexterm><primary>@covers</primary></indexterm>
 
       A anotação <literal>@covers</literal> (veja
-      <xref linkend="appendixes.annotations.covers.tables.annotations"/>) pode ser 
-      usada em um código de teste para especificar qual(is) método(s) um método de teste quer 
-      testar. Se fornecido, apenas a informação de cobertura de código para o(s) método(s) 
+      <xref linkend="appendixes.annotations.covers.tables.annotations"/>) pode ser
+      usada em um código de teste para especificar qual(is) método(s) um método de teste quer
+      testar. Se fornecido, apenas a informação de cobertura de código para o(s) método(s)
       especificado(s) será considerada.
       <xref linkend="code-coverage-analysis.specifying-covered-methods.examples.BankAccountTest.php"/>
       mostra um exemplo.
@@ -300,7 +300,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -313,7 +313,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -331,7 +331,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -346,11 +346,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -363,8 +363,8 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
       Também é possível especificar que um teste não deve cobrir
       <emphasis>qualquer</emphasis> método usando a anotação
       <literal>@coversNothing</literal> (veja
-      <xref linkend="appendixes.annotations.coversNothing"/>). Isso pode ser 
-      útil quando escrever testes de integração para certificar-se de que você só 
+      <xref linkend="appendixes.annotations.coversNothing"/>). Isso pode ser
+      útil quando escrever testes de integração para certificar-se de que você só
       gerará cobertura de código com testes unitários.
     </para>
 
@@ -388,14 +388,14 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
       </programlisting>
     </example>
   </section>
-  
+
   <section id="code-coverage-analysis.edge-cases">
     <title>Casos Extremos</title>
 

--- a/src/4.8/pt_br/database.xml
+++ b/src/4.8/pt_br/database.xml
@@ -3,59 +3,59 @@
 <chapter id="database">
   <title>Testando Bancos de Dados</title>
   <para>
-    Muitos exemplos de testes unitários iniciantes e intermediários em qualquer linguagem de 
-    programação sugerem que é perfeitamente fácil testar a lógica de sua aplicação 
-    com testes simples. Para aplicações centradas em bancos de dados isso está longe 
-    da realidade. Comece a usar Wordpress, TYPO3 ou Symfony com Doctrine ou Propel, 
-    por exemplo, e você vai experimentar facilmente problemas consideráveis com o 
+    Muitos exemplos de testes unitários iniciantes e intermediários em qualquer linguagem de
+    programação sugerem que é perfeitamente fácil testar a lógica de sua aplicação
+    com testes simples. Para aplicações centradas em bancos de dados isso está longe
+    da realidade. Comece a usar Wordpress, TYPO3 ou Symfony com Doctrine ou Propel,
+    por exemplo, e você vai experimentar facilmente problemas consideráveis com o
     PHPUnit: apenas porque o banco de dados é fortemente acoplado com essas bibliotecas.
   </para>
   <para>
-    Você provavelmente conhece esse cenário dos seus trabalhos e projetos diários, 
-    onde você quer colocar em prática suas habilidades (novas ou não) com PHPUnit 
+    Você provavelmente conhece esse cenário dos seus trabalhos e projetos diários,
+    onde você quer colocar em prática suas habilidades (novas ou não) com PHPUnit
     e acaba ficando preso por um dos seguintes problemas:
   </para>
   <orderedlist numeration="arabic">
     <listitem>
       <para>
-        O método que você quer testar executa uma operação JOIN muito grande e 
+        O método que você quer testar executa uma operação JOIN muito grande e
         usa os dados para calcular alguns resultados importantes.
       </para>
     </listitem>
     <listitem>
       <para>
-        Sua lógica de negócios faz uma mistura de declarações SELECT, INSERT, UPDATE 
+        Sua lógica de negócios faz uma mistura de declarações SELECT, INSERT, UPDATE
         e DELETE.
       </para>
     </listitem>
     <listitem>
       <para>
-        Você precisa definir os dados de teste em (provavelmente muito) mais de duas tabelas 
+        Você precisa definir os dados de teste em (provavelmente muito) mais de duas tabelas
         para conseguir dados iniciais razoáveis para os métodos que deseja testar.
       </para>
     </listitem>
   </orderedlist>
   <para>
-    A extensão DbUnit simplifica consideravelmente a configuração de um banco de dados 
-    para fins de teste e permite a você verificar os conteúdos de um banco de dados após 
+    A extensão DbUnit simplifica consideravelmente a configuração de um banco de dados
+    para fins de teste e permite a você verificar os conteúdos de um banco de dados após
     fazer uma série de operações.
   </para>
   <section id="database.supported-vendors-for-database-testing">
     <title>Fornecedores Suportados para Testes de Banco de Dados</title>
     <para>
-      DbUnit atualmente suporta MySQL, PostgreSQL, Oracle e SQLite. Através 
+      DbUnit atualmente suporta MySQL, PostgreSQL, Oracle e SQLite. Através
       das integrações <ulink url="http://framework.zend.com">Zend Framework</ulink> ou
       <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink>
-      ele tem acesso a outros sistemas como IBM DB2 ou 
+      ele tem acesso a outros sistemas como IBM DB2 ou
       Microsoft SQL Server.
     </para>
   </section>
   <section id="database.difficulties-in-database-testing">
     <title>Dificuldades em Testes de Bancos de Dados</title>
     <para>
-      Existe uma boa razão pela qual todos os exemplos de testes unitários não incluírem 
-      interações com bancos de dados: esses tipos de testes são complexos tanto em 
-      configuração quanto em manutenção. Enquanto testar contra seu banco de dados você 
+      Existe uma boa razão pela qual todos os exemplos de testes unitários não incluírem
+      interações com bancos de dados: esses tipos de testes são complexos tanto em
+      configuração quanto em manutenção. Enquanto testar contra seu banco de dados você
       precisará ter cuidado com as seguintes variáveis:
     </para>
     <itemizedlist>
@@ -81,8 +81,8 @@
       </listitem>
     </itemizedlist>
     <para>
-      Por causa de muitas APIs de bancos de dados como PDO, MySQLi ou OCI8 serem incômodos 
-      de usar e verbosas para escrever, fazer esses passos manualmente é um completo 
+      Por causa de muitas APIs de bancos de dados como PDO, MySQLi ou OCI8 serem incômodos
+      de usar e verbosas para escrever, fazer esses passos manualmente é um completo
       pesadelo.
     </para>
     <para>
@@ -91,24 +91,24 @@
     <itemizedlist>
       <listitem>
         <para>
-          Você não quer modificar uma considerável quantidade de código de teste por 
+          Você não quer modificar uma considerável quantidade de código de teste por
           pequenas mudanças em seu código de produção.
         </para>
       </listitem>
       <listitem>
         <para>
-          Você quer ser capaz de ler e entender o código de teste facilmente, 
+          Você quer ser capaz de ler e entender o código de teste facilmente,
           mesmo meses depois de tê-lo escrito.
         </para>
       </listitem>
     </itemizedlist>
     <para>
-      Adicionalmente você tem que perceber que o banco de dados é essencialmente 
-      uma variável global de entrada para seu código. Dois testes em sua suíte de testes 
-      podem executar contra o mesmo banco de dados, possivelmente reutilizando dados 
-      múltiplas vezes. Falhas em um teste podem facilmente afetar o resultado dos 
-      testes seguintes, fazendo sua experiência com os testes muito difícil. O 
-      passo de limpeza mencionado anteriormente é de maior importância 
+      Adicionalmente você tem que perceber que o banco de dados é essencialmente
+      uma variável global de entrada para seu código. Dois testes em sua suíte de testes
+      podem executar contra o mesmo banco de dados, possivelmente reutilizando dados
+      múltiplas vezes. Falhas em um teste podem facilmente afetar o resultado dos
+      testes seguintes, fazendo sua experiência com os testes muito difícil. O
+      passo de limpeza mencionado anteriormente é de maior importância
       para resolver o problema do <quote>banco de dados ser uma entrada global</quote>.
     </para>
     <para>
@@ -116,26 +116,26 @@
       forma elegante.
     </para>
     <para>
-      O PHPUnit só não pode ajudá-lo no fato de que testes de banco de dados 
-      são muito lentos comparados aos testes que não usam bancos de dados. Dependendo 
-      do tamanho das interações com seu banco de dados, seus testes 
-      podem levar um tempo considerável para executar. Porém se você mantiver pequena 
-      a quantidade de dados usados para cada teste e tentar testar o máximo possível 
-      sem usar testes com bancos de dados, você facilmente conseguirá tempos abaixo de um minuto, 
+      O PHPUnit só não pode ajudá-lo no fato de que testes de banco de dados
+      são muito lentos comparados aos testes que não usam bancos de dados. Dependendo
+      do tamanho das interações com seu banco de dados, seus testes
+      podem levar um tempo considerável para executar. Porém se você mantiver pequena
+      a quantidade de dados usados para cada teste e tentar testar o máximo possível
+      sem usar testes com bancos de dados, você facilmente conseguirá tempos abaixo de um minuto,
       mesmo para grandes suítes de teste.
     </para>
     <para>
-      A suíte de testes do <ulink url="http://www.doctrine-project.org">projeto 
-      Doctrine 2</ulink> por exemplo, atualmente tem uma suíte com 
-      cerca de 1000 testes onde aproximadamente a metade deles tem acesso ao banco 
-      de dados e ainda executa em 15 segundos contra um banco de dados MySQL em 
+      A suíte de testes do <ulink url="http://www.doctrine-project.org">projeto
+      Doctrine 2</ulink> por exemplo, atualmente tem uma suíte com
+      cerca de 1000 testes onde aproximadamente a metade deles tem acesso ao banco
+      de dados e ainda executa em 15 segundos contra um banco de dados MySQL em
       um computador desktop comum.
     </para>
   </section>
   <section id="database.the-four-stages-of-a-database-test">
     <title>Os quatro estágios dos testes com banco de dados</title>
     <para>
-      Em seu livro sobre Padrões de Teste xUnit, Gerard Meszaros lista os quatro 
+      Em seu livro sobre Padrões de Teste xUnit, Gerard Meszaros lista os quatro
       estágios de um teste unitário:
     </para>
     <orderedlist numeration="arabic">
@@ -165,45 +165,45 @@
         <emphasis role="strong">O que é um ambiente (fixture)?</emphasis>
       </para>
       <para>
-        Um ambiente (fixture) descreve o estado inicial em que sua aplicação e seu banco de dados 
+        Um ambiente (fixture) descreve o estado inicial em que sua aplicação e seu banco de dados
         estão ao executar um teste.
       </para>
     </blockquote>
     <para>
-      Testar o banco de dados exige que você utilize pelo menos o 
-      setup (configuração) e teardown (desmontagem) para limpar e escrever em suas tabelas 
-      os dados de ambiente exigidos. Porém a extensão do banco de dados tem uma boa razão para 
-      reverter esses quatro estágios em um teste de banco de dados para assemelhar o seguinte 
+      Testar o banco de dados exige que você utilize pelo menos o
+      setup (configuração) e teardown (desmontagem) para limpar e escrever em suas tabelas
+      os dados de ambiente exigidos. Porém a extensão do banco de dados tem uma boa razão para
+      reverter esses quatro estágios em um teste de banco de dados para assemelhar o seguinte
       fluxo de trabalho que é executado para cada teste:
     </para>
     <section id="database.clean-up-database">
       <title>1. Limpar o Banco de Dados</title>
       <para>
-        Já que sempre existe um primeiro teste que é executado contra o banco de dados, 
-        você não sabe exatamente se já existem dados nas tabelas. 
-        O PHPUnit vai executar um TRUNCATE contra todas as tabelas que 
+        Já que sempre existe um primeiro teste que é executado contra o banco de dados,
+        você não sabe exatamente se já existem dados nas tabelas.
+        O PHPUnit vai executar um TRUNCATE contra todas as tabelas que
         você especificou para redefinir seus estados para vazio.
       </para>
     </section>
     <section id="database.set-up-fixture">
       <title>2. Configurar o ambiente</title>
       <para>
-        O PHPUnit então vai iterar sobre todas as linhas do ambiente especificado e 
+        O PHPUnit então vai iterar sobre todas as linhas do ambiente especificado e
         inseri-las em suas respectivas tabelas.
       </para>
     </section>
     <section id="database.run-test-verify-outcome-and-teardown">
       <title>3–5. Executar Teste, Verificar resultado e Desmontar (Teardown)</title>
       <para>
-        Depois de redefinir o banco de dados e carregá-lo com seu estado inicial, 
-        o verdadeiro teste é executado pelo PHPUnit. Esta parte do código de teste 
-        não exige conhecimento sobre a Extensão do Banco de Dados, então você pode 
+        Depois de redefinir o banco de dados e carregá-lo com seu estado inicial,
+        o verdadeiro teste é executado pelo PHPUnit. Esta parte do código de teste
+        não exige conhecimento sobre a Extensão do Banco de Dados, então você pode
         prosseguir e testar o que quiser com seu código.
       </para>
       <para>
         Em seu teste use uma asserção especial chamada
-        <literal>assertDataSetsEqual()</literal> para fins de verificação, 
-        porém isso é totalmente opcional. Esta função será explicada 
+        <literal>assertDataSetsEqual()</literal> para fins de verificação,
+        porém isso é totalmente opcional. Esta função será explicada
         na seção <quote>Asserções em Bancos de Dados</quote>.
       </para>
     </section>
@@ -211,8 +211,8 @@
   <section id="database.configuration-of-a-phpunit-database-testcase">
     <title>Configuração de um Caso de Teste de Banco de Dados do PHPUnit</title>
     <para>
-      Ao usar o PHPUnit seus casos de teste vão estender a 
-      classe <literal>PHPUnit_Framework_TestCase</literal> da 
+      Ao usar o PHPUnit seus casos de teste vão estender a
+      classe <literal>PHPUnit_Framework_TestCase</literal> da
       seguinte forma:
     </para>
     <programlisting><![CDATA[<?php
@@ -220,13 +220,13 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
     <para>
-      Se você quer um código de teste que trabalha com a Extensão para Banco de Dados a 
-      configuração é um pouco mais complexa e você terá que estender um TestCase abstrato 
+      Se você quer um código de teste que trabalha com a Extensão para Banco de Dados a
+      configuração é um pouco mais complexa e você terá que estender um TestCase abstrato
       diferente, exigindo que você implemente dois métodos abstratos
       <literal>getConnection()</literal> e
       <literal>getDataSet()</literal>:
@@ -255,65 +255,65 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.implementing-getconnection">
       <title>Implementando getConnection()</title>
       <para>
-        Para permitir que a limpeza e o carregamento de funcionalidades do ambiente funcionem, 
-        a Extensão do Banco de Dados do PHPUnit exige acesso a uma conexão 
-        abstrata do banco de dados através dos fornecedores da biblioteca PDO. É 
-        importante notar que sua aplicação não precisa ser 
-        baseada em PDO para usar a Extensão para Banco de Dados do PHPUnit, pois a conexão é 
+        Para permitir que a limpeza e o carregamento de funcionalidades do ambiente funcionem,
+        a Extensão do Banco de Dados do PHPUnit exige acesso a uma conexão
+        abstrata do banco de dados através dos fornecedores da biblioteca PDO. É
+        importante notar que sua aplicação não precisa ser
+        baseada em PDO para usar a Extensão para Banco de Dados do PHPUnit, pois a conexão é
         meramente usada para limpeza e configuração de ambiente.
       </para>
       <para>
-        No exemplo anterior criamos uma conexão Sqlite na memória e 
+        No exemplo anterior criamos uma conexão Sqlite na memória e
         a passamos ao método <literal>createDefaultDBConnection</literal>
-        que embrulha a instância do PDO e o segundo parâmetro (o 
-        nome do banco de dados) em uma camada simples de abstração para conexões 
+        que embrulha a instância do PDO e o segundo parâmetro (o
+        nome do banco de dados) em uma camada simples de abstração para conexões
         do banco de dados do tipo
         <literal>PHPUnit_Extensions_Database_DB_IDatabaseConnection</literal>.
       </para>
       <para>
-        A seção <quote>Usando a Conexão de Banco de Dados</quote> explica 
+        A seção <quote>Usando a Conexão de Banco de Dados</quote> explica
         a API desta interface e como você pode usá-la da melhor forma possível.
       </para>
     </section>
     <section id="database.implementing-getdataset">
       <title>Implementando getDataSet()</title>
       <para>
-        O método <literal>getDataSet()</literal> define como deve ser o estado 
-        inicial do banco de dados antes de cada teste ser 
-        executado. O estado do banco de dados é abstraído através de 
-        conceitos DataSet (Conjunto de Dados) e DataTable (Tabela de Dados), ambos sendo representados 
+        O método <literal>getDataSet()</literal> define como deve ser o estado
+        inicial do banco de dados antes de cada teste ser
+        executado. O estado do banco de dados é abstraído através de
+        conceitos DataSet (Conjunto de Dados) e DataTable (Tabela de Dados), ambos sendo representados
         pelas interfaces
         <literal>PHPUnit_Extensions_Database_DataSet_IDataSet</literal> e
         <literal>PHPUnit_Extensions_Database_DataSet_IDataTable</literal>.
-        A próxima seção vai descrever em detalhes como esses conceitos trabalham 
+        A próxima seção vai descrever em detalhes como esses conceitos trabalham
         e quais os benefícios de usá-los nos testes com bancos de dados.
       </para>
       <para>
-        Para a implementação precisaremos apenas saber que o 
+        Para a implementação precisaremos apenas saber que o
         método <literal>getDataSet()</literal> é chamado uma vez durante o
-        <literal>setUp()</literal> para recuperar o conjunto de dados do ambiente e 
-        inseri-lo no banco de dados. No exemplo estamos usando um método de fábrica 
-        <literal>createFlatXMLDataSet($filename)</literal> que 
+        <literal>setUp()</literal> para recuperar o conjunto de dados do ambiente e
+        inseri-lo no banco de dados. No exemplo estamos usando um método de fábrica
+        <literal>createFlatXMLDataSet($filename)</literal> que
         representa um conjunto de dados através de uma representação XML.
       </para>
     </section>
     <section id="database.what-about-the-database-schema-ddl">
       <title>E quanto ao Esquema do Banco de Dados (DDL)?</title>
       <para>
-        O PHPUnit assume que o esquema do banco de dados com todas as suas tabelas, 
-        gatilhos, sequências e visualizações é criado antes que um teste seja executado. Isso 
-        quer dizer que você como desenvolvedor deve se certificar que o banco de dados está 
+        O PHPUnit assume que o esquema do banco de dados com todas as suas tabelas,
+        gatilhos, sequências e visualizações é criado antes que um teste seja executado. Isso
+        quer dizer que você como desenvolvedor deve se certificar que o banco de dados está
         corretamente configurado antes de executar a suíte.
       </para>
       <para>
-        Existem vários meios para realizar esta pré-condição para 
+        Existem vários meios para realizar esta pré-condição para
         testar bancos de dados.
       </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Se você está usando um banco de dados persistente (não Sqlite Memory) você pode 
-            facilmente configurar o banco de dados uma vez com ferramentas como phpMyAdmin para 
+            Se você está usando um banco de dados persistente (não Sqlite Memory) você pode
+            facilmente configurar o banco de dados uma vez com ferramentas como phpMyAdmin para
             MySQL e reutilizar o banco de dados para cada execução de teste.
           </para>
         </listitem>
@@ -322,8 +322,8 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
             Se você estiver usando bibliotecas como
             <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink> ou
             <ulink url="http://www.propelorm.org/">Propel</ulink>
-            você pode usar suas APIs para criar o esquema de banco de dados que 
-            precisa antes de rodar os testes. Você pode utilizar as capacidades de 
+            você pode usar suas APIs para criar o esquema de banco de dados que
+            precisa antes de rodar os testes. Você pode utilizar as capacidades de
             <ulink url="textui.html">Configuração e Bootstrap do PHPUnit</ulink>
             para executar esse código sempre que seus testes forem executados.
           </para>
@@ -333,12 +333,12 @@ class MyGuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.tip-use-your-own-abstract-database-testcase">
       <title>Dica: Use seu próprio Caso Abstrato de Teste de Banco de Dados</title>
       <para>
-        Do exemplo prévio de implementação você pode facilmente perceber que 
-        o método <literal>getConnection()</literal> é bastante estático e 
-        pode ser reutilizado em diferentes casos de teste de banco de dados. Adicionalmente para 
-        manter uma boa performance dos seus testes e pouca carga sobre seu banco de dados, você 
-        pode refatorar o código um pouco para obter um caso de teste abstrato genérico 
-        para sua aplicação, o que ainda permite a você especificar um 
+        Do exemplo prévio de implementação você pode facilmente perceber que
+        o método <literal>getConnection()</literal> é bastante estático e
+        pode ser reutilizado em diferentes casos de teste de banco de dados. Adicionalmente para
+        manter uma boa performance dos seus testes e pouca carga sobre seu banco de dados, você
+        pode refatorar o código um pouco para obter um caso de teste abstrato genérico
+        para sua aplicação, o que ainda permite a você especificar um
         ambiente de dados diferente para cada caso de teste:
       </para>
       <programlisting><![CDATA[<?php
@@ -364,12 +364,12 @@ abstract class MyApp_Tests_DatabaseTestCase extends PHPUnit_Extensions_Database_
 }
 ?>]]></programlisting>
       <para>
-        Entretanto, isso tem a conexão ao banco de dados codificada na conexão do PDO. 
-        O PHPUnit tem outra incrível característica que pode fazer este 
+        Entretanto, isso tem a conexão ao banco de dados codificada na conexão do PDO.
+        O PHPUnit tem outra incrível característica que pode fazer este
         caso de teste ainda mais genérico. Se você usar a
         <ulink url="appendixes.configuration.html#appendixes.configuration.php-ini-constants-variables">Configuração XML</ulink>
-        você pode tornar a conexão com o banco de dados configurável por execução de teste. 
-        Primeiro vamos criar um arquivo <quote>phpunit.xml</quote> em nosso diretório/de/teste 
+        você pode tornar a conexão com o banco de dados configurável por execução de teste.
+        Primeiro vamos criar um arquivo <quote>phpunit.xml</quote> em nosso diretório/de/teste
         da aplicação, de forma semelhante a isto:
       </para>
       <screen><![CDATA[
@@ -409,16 +409,16 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 }
 ?>]]></programlisting>
       <para>
-        Agora podemos executar a suíte de testes de banco de dados usando diferentes 
+        Agora podemos executar a suíte de testes de banco de dados usando diferentes
         configurações através da interface de linha-de-comando:
       </para>
       <screen><userinput>user@desktop> phpunit --configuration developer-a.xml MyTests/</userinput>
 <userinput>user@desktop> phpunit --configuration developer-b.xml MyTests/</userinput></screen>
       <para>
-        A possibilidade de executar facilmente os testes de banco de dados contra diferentes 
-        alvos é muito importante se você está desenvolvendo na 
-        máquina de desenvolvimento. Se vários desenvolvedores executarem os testes de banco 
-        de dados contra a mesma conexão de banco de dados você experimentará facilmente 
+        A possibilidade de executar facilmente os testes de banco de dados contra diferentes
+        alvos é muito importante se você está desenvolvendo na
+        máquina de desenvolvimento. Se vários desenvolvedores executarem os testes de banco
+        de dados contra a mesma conexão de banco de dados você experimentará facilmente
         falhas de testes devido à condição de execução.
       </para>
     </section>
@@ -426,36 +426,36 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
   <section id="database.understanding-datasets-and-datatables">
     <title>Entendendo Conjunto de Dados e Tabelas de Dados</title>
     <para>
-      Um conceito central da Extensão para Banco de Dados do PHPUnit são 
-      os Conjuntos de Dados e as Tabelas de Dados. Você deveria tentar entender este conceito simples para 
-      dominar os testes de banco de dados com PHPUnit. Conjunto de Dados e Tabela de Dados formam 
-      uma camada abstrata em torno das tabelas, linhas e 
-      colunas do seu banco de dados. Uma simples API esconde os conteúdos subjacentes do banco de dados em uma 
-      estrutura de objetos, que também podem ser implementada por outra 
+      Um conceito central da Extensão para Banco de Dados do PHPUnit são
+      os Conjuntos de Dados e as Tabelas de Dados. Você deveria tentar entender este conceito simples para
+      dominar os testes de banco de dados com PHPUnit. Conjunto de Dados e Tabela de Dados formam
+      uma camada abstrata em torno das tabelas, linhas e
+      colunas do seu banco de dados. Uma simples API esconde os conteúdos subjacentes do banco de dados em uma
+      estrutura de objetos, que também podem ser implementada por outra
       fonte que não seja um banco de dados.
     </para>
     <para>
-      Essa abstração é necessária para comparar os conteúdos reais de um 
-      banco de dados contra os conteúdos esperados. Expectativas podem ser 
-      representadas como arquivos XML, YAML, CSV ou vetores PHP, por exemplo. As 
-      interfaces DataSet (Conjunto de Dados) e DataTable (Tabela de Dados)  permitem a comparação dessas 
-      fontes conceitualmente diferentes, emulando o armazenamento de banco de dados 
+      Essa abstração é necessária para comparar os conteúdos reais de um
+      banco de dados contra os conteúdos esperados. Expectativas podem ser
+      representadas como arquivos XML, YAML, CSV ou vetores PHP, por exemplo. As
+      interfaces DataSet (Conjunto de Dados) e DataTable (Tabela de Dados)  permitem a comparação dessas
+      fontes conceitualmente diferentes, emulando o armazenamento de banco de dados
       relacional em uma abordagem semanticamente similar.
     </para>
     <para>
-      Um fluxo de trabalho para asserções em banco de dados em seus testes então consiste de 
+      Um fluxo de trabalho para asserções em banco de dados em seus testes então consiste de
       três passos simples:
     </para>
     <itemizedlist>
       <listitem>
         <para>
-          Especificar uma ou mais tabelas em seu banco de dados por nome de tabela (conjunto de dados 
+          Especificar uma ou mais tabelas em seu banco de dados por nome de tabela (conjunto de dados
           real)
         </para>
       </listitem>
       <listitem>
         <para>
-          Especificar o Conjunto de Dados esperado no seu formato preferido (YAML, XML, 
+          Especificar o Conjunto de Dados esperado no seu formato preferido (YAML, XML,
           ...)
         </para>
       </listitem>
@@ -466,10 +466,10 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
       </listitem>
     </itemizedlist>
     <para>
-      Asserções não são o único caso de uso para o Conjunto de Dados e a Tabela de Dados 
-      na Extensão para Banco de Dados do PHPUnit. Como mostrado na seção anterior, 
-      eles também descrevem os conteúdos iniciais de um banco de dados. Você é 
-      forçado a definir um conjunto de dados de ambiente pelo Caso de Teste de Banco de Dados, que 
+      Asserções não são o único caso de uso para o Conjunto de Dados e a Tabela de Dados
+      na Extensão para Banco de Dados do PHPUnit. Como mostrado na seção anterior,
+      eles também descrevem os conteúdos iniciais de um banco de dados. Você é
+      forçado a definir um conjunto de dados de ambiente pelo Caso de Teste de Banco de Dados, que
       então é usado para:
     </para>
     <itemizedlist>
@@ -507,17 +507,17 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
         </listitem>
       </itemizedlist>
       <para>
-        Os Conjuntos de Dados e Tabelas de Dados baseadas em arquivo são geralmente usados para o 
+        Os Conjuntos de Dados e Tabelas de Dados baseadas em arquivo são geralmente usados para o
         ambiente inicial e para descrever os estados esperados do banco de dados.
       </para>
       <section id="database.flat-xml-dataset">
         <title>Conjunto de Dados de XML Plano</title>
         <para>
-          O Conjunto de Dados mais comum é chamado XML Plano. É um formato xml simples 
+          O Conjunto de Dados mais comum é chamado XML Plano. É um formato xml simples
           onde uma tag dentro do nó-raiz
-          <literal><![CDATA[<dataset>]]></literal> representa exatamente uma linha no 
-          banco de dados. Os nomes das tags equivalem à tabela onde inserir a linha e 
-          um atributo representa a coluna. Um exemplo para uma simples aplicação de 
+          <literal><![CDATA[<dataset>]]></literal> representa exatamente uma linha no
+          banco de dados. Os nomes das tags equivalem à tabela onde inserir a linha e
+          um atributo representa a coluna. Um exemplo para uma simples aplicação de
           livro de visitas poderia se parecer com isto:
         </para>
         <screen><![CDATA[
@@ -529,7 +529,7 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 ]]></screen>
         <para>
           Isso é, obviamente, fácil de escrever. Aqui
-          <literal><![CDATA[<guestbook>]]></literal> é o nome da tabela onde duas linhas 
+          <literal><![CDATA[<guestbook>]]></literal> é o nome da tabela onde duas linhas
           são inseridas dentro de cada com quatro colunas <quote>id</quote>,
           <quote>content</quote>, <quote>user</quote> e
           <quote>created</quote> com seus respectivos valores.
@@ -538,9 +538,9 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
           Porém essa simplicidade tem um preço.
         </para>
         <para>
-          O exemplo anterior não deixa tão óbvio como você pode fazer para especificar uma 
-          tabela vazia. Você pode inserir uma tag sem atributos com o nome da 
-          tabela vazia. Um arquivo xml plano para uma tabela vazia do livro de visitas 
+          O exemplo anterior não deixa tão óbvio como você pode fazer para especificar uma
+          tabela vazia. Você pode inserir uma tag sem atributos com o nome da
+          tabela vazia. Um arquivo xml plano para uma tabela vazia do livro de visitas
           ficaria parecido com isso:
         </para>
         <screen><![CDATA[
@@ -550,13 +550,13 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 </dataset>
 ]]></screen>
         <para>
-          A manipulação de valores NULL com o xml plano é tedioso. Um 
-          valor NULL é diferente de uma string com valor vazio em quase todos 
-          os bancos de dados (Oracle é uma exceção), algo difícil 
-          de descrever no formato xml plano. Você pode representar um valor NULL 
-          omitindo o atributo da especificação da linha. Se nosso 
-          livro de visitas vai permitir entradas anônimas representadas por um valor NULL 
-          na coluna user, um estado hipotético para a tabela do livro de visitas 
+          A manipulação de valores NULL com o xml plano é tedioso. Um
+          valor NULL é diferente de uma string com valor vazio em quase todos
+          os bancos de dados (Oracle é uma exceção), algo difícil
+          de descrever no formato xml plano. Você pode representar um valor NULL
+          omitindo o atributo da especificação da linha. Se nosso
+          livro de visitas vai permitir entradas anônimas representadas por um valor NULL
+          na coluna user, um estado hipotético para a tabela do livro de visitas
           seria parecido com:
         </para>
         <screen><![CDATA[
@@ -567,47 +567,47 @@ abstract class Generic_Tests_DatabaseTestCase extends PHPUnit_Extensions_Databas
 </dataset>
 ]]></screen>
         <para>
-          Nesse caso a segunda entrada é postada anonimamente. Porém isso 
-          acarreta um problema sério no reconhecimento de colunas. Durante as asserções de igualdade 
-          do conjunto de dados, cada conjunto de dados tem que especificar quais colunas uma 
-          tabela possui. Se um atributo for NULL para todas as linhas de uma 
-          tabela de dados, como a Extensão para Banco de Dados vai saber que a coluna 
+          Nesse caso a segunda entrada é postada anonimamente. Porém isso
+          acarreta um problema sério no reconhecimento de colunas. Durante as asserções de igualdade
+          do conjunto de dados, cada conjunto de dados tem que especificar quais colunas uma
+          tabela possui. Se um atributo for NULL para todas as linhas de uma
+          tabela de dados, como a Extensão para Banco de Dados vai saber que a coluna
           deve ser parte da tabela?
         </para>
         <para>
-          O conjunto de dados em xml plano faz uma presunção crucial agora, definindo que 
-          os atributos na primeira linha definida de uma tabela define as 
+          O conjunto de dados em xml plano faz uma presunção crucial agora, definindo que
+          os atributos na primeira linha definida de uma tabela define as
           colunas dessa tabela. No exemplo anterior isso significaria que
           <quote>id</quote>, <quote>content</quote>, <quote>user</quote> e
-          <quote>created</quote> são colunas da tabela guestbook. Para a 
-          segunda linha, onde <quote>user</quote> não está definido, um NULL seria 
+          <quote>created</quote> são colunas da tabela guestbook. Para a
+          segunda linha, onde <quote>user</quote> não está definido, um NULL seria
           inserido no banco de dados.
         </para>
         <para>
           Quando a primeira entrada do guestbook for apagada do conjunto de dados, apenas
           <quote>id</quote>, <quote>content</quote> e
-          <quote>created</quote> seriam colunas da tabela guestbook, 
+          <quote>created</quote> seriam colunas da tabela guestbook,
           já que <quote>user</quote> não é especificado.
         </para>
         <para>
-          Para usar o Conjunto de Dados em XML Plano efetivamente, quando valores NULL forem 
-          relevantes, a primeira linha de cada tabela não deve conter qualquer valor NULL 
-          e apenas as linhas seguintes poderão omitir atributos. Isso 
-          pode parecer estranho, já que a ordem das linhas é um fator relevante 
+          Para usar o Conjunto de Dados em XML Plano efetivamente, quando valores NULL forem
+          relevantes, a primeira linha de cada tabela não deve conter qualquer valor NULL
+          e apenas as linhas seguintes poderão omitir atributos. Isso
+          pode parecer estranho, já que a ordem das linhas é um fator relevante
           para as asserções com bancos de dados.
         </para>
         <para>
-          Em troca, se você especificar apenas um subconjunto das colunas da tabela no 
-          Conjunto de Dados do XML Plano, todos os valores omitidos serão definidos para seus valores 
-          padrão. Isso vai induzir a erros se uma das colunas omitidas estiver 
+          Em troca, se você especificar apenas um subconjunto das colunas da tabela no
+          Conjunto de Dados do XML Plano, todos os valores omitidos serão definidos para seus valores
+          padrão. Isso vai induzir a erros se uma das colunas omitidas estiver
           definida como <quote>NOT NULL DEFAULT NULL</quote>.
         </para>
         <para>
-          Para concluir eu posso dizer que os conjuntos de dados XML Plano só devem ser usadas se você 
+          Para concluir eu posso dizer que os conjuntos de dados XML Plano só devem ser usadas se você
           não precisar de valores NULL.
         </para>
         <para>
-          Você pode criar uma instância de conjunto de dados xml plano de dentro de seu 
+          Você pode criar uma instância de conjunto de dados xml plano de dentro de seu
           Caso de Teste de Banco de Dados chamando o método
           <literal>createFlatXmlDataSet($filename)</literal>:
         </para>
@@ -624,13 +624,13 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
       <section id="database.xml-dataset">
         <title>Conjunto de Dados XML</title>
         <para>
-          Existe um outro Conjunto de Dados em XML mais estruturado, que é um pouco mais 
-          verboso para escrever mas evita os problemas do NULL nos conjuntos de dados em 
-          XML Plano. Dentro do nó-raiz <literal><![CDATA[<dataset>]]></literal> você 
+          Existe um outro Conjunto de Dados em XML mais estruturado, que é um pouco mais
+          verboso para escrever mas evita os problemas do NULL nos conjuntos de dados em
+          XML Plano. Dentro do nó-raiz <literal><![CDATA[<dataset>]]></literal> você
           pode especificar as tags <literal><![CDATA[<table>]]></literal>,
           <literal><![CDATA[<column>]]></literal>, <literal><![CDATA[<row>]]></literal>,
           <literal><![CDATA[<value>]]></literal> e
-          <literal><![CDATA[<null />]]></literal>. Um Conjunto de Dados equivalente ao 
+          <literal><![CDATA[<null />]]></literal>. Um Conjunto de Dados equivalente ao
           definido anteriormente no Guestbook em XML Plano seria como:
         </para>
         <screen><![CDATA[
@@ -657,19 +657,19 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
 </dataset>
 ]]></screen>
         <para>
-          Qualquer <literal><![CDATA[<table>]]></literal> definida tem um nome e requer 
-          uma definição de todas as colunas com seus nomes. Pode conter zero 
-          ou qualquer número positivo de elementos <literal><![CDATA[<row>]]></literal> 
-          aninhados. Não definir nenhum elemento <literal><![CDATA[<row>]]></literal> significa 
+          Qualquer <literal><![CDATA[<table>]]></literal> definida tem um nome e requer
+          uma definição de todas as colunas com seus nomes. Pode conter zero
+          ou qualquer número positivo de elementos <literal><![CDATA[<row>]]></literal>
+          aninhados. Não definir nenhum elemento <literal><![CDATA[<row>]]></literal> significa
           que a tabela está vazia. As tags <literal><![CDATA[<value>]]></literal> e
-          <literal><![CDATA[<null />]]></literal> têm que ser especificadas na 
-          ordem dos elementos fornecidos previamente em 
-          <literal><![CDATA[<column>]]></literal>. A tag <literal><![CDATA[<null />]]></literal> obviamente significa 
+          <literal><![CDATA[<null />]]></literal> têm que ser especificadas na
+          ordem dos elementos fornecidos previamente em
+          <literal><![CDATA[<column>]]></literal>. A tag <literal><![CDATA[<null />]]></literal> obviamente significa
           que o valor é NULL.
         </para>
         <para>
-          Você pode criar uma instância de conjunto de dados xml de dentro de seu 
-          Caso de Teste de Banco de Dados chamando o método 
+          Você pode criar uma instância de conjunto de dados xml de dentro de seu
+          Caso de Teste de Banco de Dados chamando o método
           <literal>createXmlDataSet($filename)</literal>:
         </para>
         <programlisting><![CDATA[<?php
@@ -687,12 +687,12 @@ class MyTestCase extends PHPUnit_Extensions_Database_TestCase
         <para>
           Este novo formato XML é específico para o
           <ulink url="http://www.mysql.com">servidor de banco de dados MySQL</ulink>.
-          O suporte para ele foi adicionado no PHPUnit 3.5. Arquivos nesse formato podem 
-          ser gerados usando o utilitário 
-          <ulink url="http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html"><literal>mysqldump</literal></ulink>. 
+          O suporte para ele foi adicionado no PHPUnit 3.5. Arquivos nesse formato podem
+          ser gerados usando o utilitário
+          <ulink url="http://dev.mysql.com/doc/refman/5.0/en/mysqldump.html"><literal>mysqldump</literal></ulink>.
           Diferente dos conjuntos de dados CSV, que o <literal>mysqldump</literal>
-          também suporta, um único arquivo neste formato XML pode conter dados 
-          para múltiplas tabelas. Você pode criar um arquivo nesse formato 
+          também suporta, um único arquivo neste formato XML pode conter dados
+          para múltiplas tabelas. Você pode criar um arquivo nesse formato
           invocando o <literal>mysqldump</literal> desta forma:
         </para>
         <screen><userinput>mysqldump --xml -t -u [username] --password=[password] [database] > /path/to/file.xml</userinput></screen>
@@ -729,13 +729,13 @@ guestbook:
     created: 2010-04-26 12:14:20
 ]]></screen>
         <para>
-          Isso é simples, conveniente E resolve o problema do NULL que o 
-          Conjunto de Dados similar do XML Plano tem. Um NULL em um YAML é apenas o nome 
+          Isso é simples, conveniente E resolve o problema do NULL que o
+          Conjunto de Dados similar do XML Plano tem. Um NULL em um YAML é apenas o nome
           da coluna sem nenhum valor especificado. Uma string vazia é especificada como
           <literal><![CDATA[column1: ""]]></literal>.
         </para>
         <para>
-          O Conjunto de Dados YAML atualmente não possui método fábrica no Caso de Teste 
+          O Conjunto de Dados YAML atualmente não possui método fábrica no Caso de Teste
           de Banco de Dados, então você tem que instanciar manualmente:
         </para>
         <programlisting><![CDATA[<?php
@@ -753,8 +753,8 @@ class YamlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.csv-dataset">
         <title>Conjunto de Dados CSV</title>
         <para>
-          Outro Conjunto de Dados baseado em arquivo, com arquivos CSV. Cada tabela do 
-          conjunto de dados é representada como um único arquivo CSV. Para nosso exemplo 
+          Outro Conjunto de Dados baseado em arquivo, com arquivos CSV. Cada tabela do
+          conjunto de dados é representada como um único arquivo CSV. Para nosso exemplo
           do guestbook, vamos definir um arquivo guestbook-table.csv:
         </para>
         <screen><![CDATA[
@@ -763,9 +763,9 @@ id,content,user,created
 2,"I like it!","nancy","2010-04-26 12:14:20"
 ]]></screen>
         <para>
-          Apesar disso ser muito conveniente para edição no Excel ou OpenOffice, 
-          você não pode especificar valores NULL em um Conjunto de Dados CSV. Uma coluna 
-          vazia levaria a um valor vazio padrão de banco de dados a ser inserido 
+          Apesar disso ser muito conveniente para edição no Excel ou OpenOffice,
+          você não pode especificar valores NULL em um Conjunto de Dados CSV. Uma coluna
+          vazia levaria a um valor vazio padrão de banco de dados a ser inserido
           na coluna.
         </para>
         <para>
@@ -786,8 +786,8 @@ class CsvGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.array-dataset">
         <title>Conjunto de Dados em Vetor</title>
         <para>
-          Desde a versão 1.3.2 da Extensão de Banco de dados do PHPUnit há um array 
-          baseado em Conjunto de dados. Nosso exemplo do guestbook 
+          Desde a versão 1.3.2 da Extensão de Banco de dados do PHPUnit há um array
+          baseado em Conjunto de dados. Nosso exemplo do guestbook
           deveria ficar parecido com:
         </para>
         <programlisting><![CDATA[<?php
@@ -805,7 +805,7 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
 }
 ?>]]></programlisting>
         <para>
-          Um Conjunto de Dados do PHP tem algumas vantagens óbvias sobre todas os outros 
+          Um Conjunto de Dados do PHP tem algumas vantagens óbvias sobre todas os outros
           conjuntos de dados baseados em arquivos:
         </para>
         <itemizedlist>
@@ -816,14 +816,14 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
           </listitem>
           <listitem>
             <para>
-              Você não precisa de arquivos adicionais para asserções e pode especificá-las diretamente 
+              Você não precisa de arquivos adicionais para asserções e pode especificá-las diretamente
               no Caso de Teste.
             </para>
           </listitem>
         </itemizedlist>
         <para>
-          Para este Conjunto de Dados, como nos Conjuntos de Dados em XML Plano, CSV e YAML, as chaves 
-          da primeira linha especificada definem os nomes das colunas das tabelas, que no 
+          Para este Conjunto de Dados, como nos Conjuntos de Dados em XML Plano, CSV e YAML, as chaves
+          da primeira linha especificada definem os nomes das colunas das tabelas, que no
           caso anterior seriam <quote>id</quote>,
           <quote>content</quote>, <quote>user</quote> e
           <quote>created</quote>.
@@ -832,8 +832,8 @@ class ArrayGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.query-sql-dataset">
         <title>Conjunto de Dados Query (SQL)</title>
         <para>
-          Para asserções de banco de dados você não precisa somente de conjuntos de dados baseados em arquivos, 
-          mas também de conjuntos de dados baseados em Query/SQL que contenha os conteúdos 
+          Para asserções de banco de dados você não precisa somente de conjuntos de dados baseados em arquivos,
+          mas também de conjuntos de dados baseados em Query/SQL que contenha os conteúdos
           reais do banco de dados. É aí que entra o Query DataSet:
         </para>
         <programlisting><![CDATA[<?php
@@ -841,7 +841,7 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook');
 ?>]]></programlisting>
         <para>
-          Adicionar uma tabela apenas por nome é um modo implícito de definir a 
+          Adicionar uma tabela apenas por nome é um modo implícito de definir a
           tabela de dados com a seguinte query:
         </para>
         <programlisting><![CDATA[<?php
@@ -849,8 +849,8 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook', 'SELECT * FROM guestbook');
 ?>]]></programlisting>
         <para>
-          Você pode fazer uso disso especificando queries arbitrárias para suas 
-          tabelas, por exemplo restringindo linhas, colunas, ou adicionando 
+          Você pode fazer uso disso especificando queries arbitrárias para suas
+          tabelas, por exemplo restringindo linhas, colunas, ou adicionando
           cláusulas <literal>ORDER BY</literal>:
         </para>
         <programlisting><![CDATA[<?php
@@ -858,22 +858,22 @@ $ds = new PHPUnit_Extensions_Database_DataSet_QueryDataSet($this->getConnection(
 $ds->addTable('guestbook', 'SELECT id, content FROM guestbook ORDER BY created DESC');
 ?>]]></programlisting>
         <para>
-          A seção nas Asserções de Banco de Dados mostrará mais alguns detalhes sobre 
+          A seção nas Asserções de Banco de Dados mostrará mais alguns detalhes sobre
           como fazer uso do Conjunto de Dados Query.
         </para>
       </section>
       <section id="database.database-db-dataset">
         <title>Conjunto de Dados de Banco de Dados (BD)</title>
         <para>
-          Acessando a Conexão de Teste você pode criar automaticamente um 
-          Conjunto de Dados que consiste de todas as tabelas com seus conteúdos no 
-          banco de dados especificado como segundo parâmetro ao método 
+          Acessando a Conexão de Teste você pode criar automaticamente um
+          Conjunto de Dados que consiste de todas as tabelas com seus conteúdos no
+          banco de dados especificado como segundo parâmetro ao método
           Fábrica de Conexões.
         </para>
         <para>
-          Você pode tanto criar um Conjunto de Dados para todo o banco de dados como mostrado 
-          em  <literal>testGuestbook()</literal>, ou restringi-lo a um conjunto de 
-          nomes específicos de tabelas com uma lista branca, como mostrado no 
+          Você pode tanto criar um Conjunto de Dados para todo o banco de dados como mostrado
+          em  <literal>testGuestbook()</literal>, ou restringi-lo a um conjunto de
+          nomes específicos de tabelas com uma lista branca, como mostrado no
           método <literal>testFilteredGuestbook()</literal>.
         </para>
         <programlisting><![CDATA[<?php
@@ -909,14 +909,14 @@ class MySqlGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.replacement-dataset">
         <title>Conjunto de Dados de Reposição</title>
         <para>
-          Eu tenho falado sobre problemas com NULL nos Conjunto de Dados XML Plano e 
-          CSV, mas existe uma alternativa um pouco complicada para fazer ambos 
+          Eu tenho falado sobre problemas com NULL nos Conjunto de Dados XML Plano e
+          CSV, mas existe uma alternativa um pouco complicada para fazer ambos
           funcionarem com NULLs.
         </para>
         <para>
-          O Conjunto de Dados de Reposição é um decorador para um Conjunto de Dados existente e 
-          permite que você substitua valores em qualquer coluna do conjunto de dados por outro 
-          valor de reposição. Para fazer nosso exemplo do guestbook funcionar com valores NULL 
+          O Conjunto de Dados de Reposição é um decorador para um Conjunto de Dados existente e
+          permite que você substitua valores em qualquer coluna do conjunto de dados por outro
+          valor de reposição. Para fazer nosso exemplo do guestbook funcionar com valores NULL
           devemos especificar o arquivo como:
         </para>
         <screen><![CDATA[
@@ -945,9 +945,9 @@ class ReplacementTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.dataset-filter">
         <title>Filtro de Conjunto de Dados</title>
         <para>
-          Se você tiver um arquivo grande de ambiente você pode usar o Filtro de Conjunto de Dados para 
-          as listas branca e negra das tabelas e colunas que deveriam estar 
-          contidas em um sub-conjunto de dados. Isso ajuda especialmente em combinação 
+          Se você tiver um arquivo grande de ambiente você pode usar o Filtro de Conjunto de Dados para
+          as listas branca e negra das tabelas e colunas que deveriam estar
+          contidas em um sub-conjunto de dados. Isso ajuda especialmente em combinação
           com o DB DataSet para filtrar as colunas dos conjuntos de dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -978,9 +978,9 @@ class DataSetFilterTest extends PHPUnit_Extensions_Database_TestCase
 ?>]]></programlisting>
         <blockquote>
           <para>
-            <emphasis role="strong">NOTA</emphasis> Você não pode usar ambos os 
-            filtros de coluna excluir e incluir na mesma tabela, apenas em tabelas 
-            diferentes. E mais: só é possível para a lista branca ou negra, 
+            <emphasis role="strong">NOTA</emphasis> Você não pode usar ambos os
+            filtros de coluna excluir e incluir na mesma tabela, apenas em tabelas
+            diferentes. E mais: só é possível para a lista branca ou negra,
             mas não para ambas.
           </para>
         </blockquote>
@@ -988,9 +988,9 @@ class DataSetFilterTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.composite-dataset">
         <title>Conjunto de Dados Composto</title>
         <para>
-          O Conjunto de Dados composto é muito útil para agregar vários 
-          conjuntos de dados já existentes em um único Conjunto de Dados. Quando vários 
-          conjuntos de dados contém as mesmas tabelas, as linhas são anexadas na 
+          O Conjunto de Dados composto é muito útil para agregar vários
+          conjuntos de dados já existentes em um único Conjunto de Dados. Quando vários
+          conjuntos de dados contém as mesmas tabelas, as linhas são anexadas na
           ordem especificada. Por exemplo se tivermos dois conjuntos de dados
           <emphasis>fixture1.xml</emphasis>:
         </para>
@@ -1033,18 +1033,18 @@ class CompositeTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.beware-of-foreign-keys">
       <title>Cuidado com Chaves Estrangeiras</title>
       <para>
-        Durante a Configuração do Ambiente a Extensão para Banco de Dados do PHPUnit insere as linhas 
-        no banco de dados na ordem que são especificadas em seu ambiente. 
-        Se seu esquema de banco de dados usa chaves estrangeiras isso significa que você tem que 
-        especificar as tabelas em uma ordem que não faça as restrições das chaves estrangeiras 
+        Durante a Configuração do Ambiente a Extensão para Banco de Dados do PHPUnit insere as linhas
+        no banco de dados na ordem que são especificadas em seu ambiente.
+        Se seu esquema de banco de dados usa chaves estrangeiras isso significa que você tem que
+        especificar as tabelas em uma ordem que não faça as restrições das chaves estrangeiras
         falharem.
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
       <title>Implementando seus próprios Conjuntos de Dados/ Tabelas de Dados</title>
       <para>
-        Para entender os interiores dos Conjuntos de Dados e Tabelas de Dados, vamos dar uma 
-        olhada na interface de um Conjunto de Dados. Você pode pular esta parte se você 
+        Para entender os interiores dos Conjuntos de Dados e Tabelas de Dados, vamos dar uma
+        olhada na interface de um Conjunto de Dados. Você pode pular esta parte se você
         não planeja implementar seu próprio Conjunto de Dados ou Tabela de Dados.
       </para>
       <programlisting><![CDATA[<?php
@@ -1060,18 +1060,18 @@ interface PHPUnit_Extensions_Database_DataSet_IDataSet extends IteratorAggregate
 ?>]]></programlisting>
       <para>
         A interface pública é usada internamente pela asserção
-        <literal>assertDataSetsEqual()</literal> no Caso de Teste de 
+        <literal>assertDataSetsEqual()</literal> no Caso de Teste de
         Banco de Dados para verificar a qualidade do conjunto de dados. Da interface
-        <literal>IteratorAggregate</literal> o IDataSet 
-        herda o método <literal>getIterator()</literal> para iterar 
-        sobre todas as tabelas do conjunto de dados. O iterador reverso permite o PHPUnit 
-        truncar corretamente as tabelas em ordem reversa à que foi criada para satisfazer 
+        <literal>IteratorAggregate</literal> o IDataSet
+        herda o método <literal>getIterator()</literal> para iterar
+        sobre todas as tabelas do conjunto de dados. O iterador reverso permite o PHPUnit
+        truncar corretamente as tabelas em ordem reversa à que foi criada para satisfazer
         as restrições de chaves estrangeiras.
       </para>
       <para>
-        Dependendo da implementação, diferentes abordagens são usadas para 
-        adicionar instâncias de tabela a um Conjunto de Dados. Por exemplo, tabelas são adicionadas 
-        internamente durante a construção a partir de um arquivo fonte em todos 
+        Dependendo da implementação, diferentes abordagens são usadas para
+        adicionar instâncias de tabela a um Conjunto de Dados. Por exemplo, tabelas são adicionadas
+        internamente durante a construção a partir de um arquivo fonte em todos
         os conjuntos de dados baseados em arquivo como <literal>YamlDataSet</literal>,
         <literal>XmlDataSet</literal> ou <literal>FlatXmlDataSet</literal>.
       </para>
@@ -1089,14 +1089,14 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
 }
 ?>]]></programlisting>
       <para>
-        Com exceção do método <literal>getTableMetaData()</literal> isso é 
-        bastante auto-explicativo. Os métodos usados são todos requeridos para 
-        as diferentes asserções da Extensão para Banco de Dados que são 
+        Com exceção do método <literal>getTableMetaData()</literal> isso é
+        bastante auto-explicativo. Os métodos usados são todos requeridos para
+        as diferentes asserções da Extensão para Banco de Dados que são
         explicados no próximo capítulo. O método
-        <literal>getTableMetaData()</literal> deve retornar uma 
+        <literal>getTableMetaData()</literal> deve retornar uma
         implementação da interface
         <literal>PHPUnit_Extensions_Database_DataSet_ITableMetaData</literal>
-        que descreve a estrutura da tabela. Possui informações 
+        que descreve a estrutura da tabela. Possui informações
         sobre:
       </para>
       <itemizedlist>
@@ -1107,7 +1107,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
         </listitem>
         <listitem>
           <para>
-            Um vetor de nomes de coluna da tabela, ordenado por suas aparições 
+            Um vetor de nomes de coluna da tabela, ordenado por suas aparições
             nos conjuntos de resultados.
           </para>
         </listitem>
@@ -1118,8 +1118,8 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
         </listitem>
       </itemizedlist>
       <para>
-        Essa interface também tem uma asserção que verifica se duas instâncias 
-        de Metadados de Tabela se equivalem, o que é usado pela asserção de igualdade 
+        Essa interface também tem uma asserção que verifica se duas instâncias
+        de Metadados de Tabela se equivalem, o que é usado pela asserção de igualdade
         do conjunto de dados.
       </para>
     </section>
@@ -1127,7 +1127,7 @@ interface PHPUnit_Extensions_Database_DataSet_ITable
   <section id="database.the-connection-api">
     <title>A API de Conexão</title>
     <para>
-      Existem três métodos interessantes na interface Connection 
+      Existem três métodos interessantes na interface Connection
       que devem ser retornados do método
       <literal>getConnection()</literal> no Caso de Teste de Banco de Dados:
     </para>
@@ -1144,7 +1144,7 @@ interface PHPUnit_Extensions_Database_DB_IDatabaseConnection
     <orderedlist numeration="arabic">
       <listitem>
         <para>
-          O método <literal>createDataSet()</literal> cria um Conjunto de Dados 
+          O método <literal>createDataSet()</literal> cria um Conjunto de Dados
           de Banco de Dados (BD) como descrito na seção de implementações de Conjunto de Dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1160,10 +1160,10 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
       </listitem>
       <listitem>
         <para>
-          O método <literal>createQueryTable()</literal> pode ser usado para 
-          criar instâncias de uma QueryTable, dado um nome de resultado e uma query 
+          O método <literal>createQueryTable()</literal> pode ser usado para
+          criar instâncias de uma QueryTable, dado um nome de resultado e uma query
           SQL. Este é um método conveniente quando se fala sobre asserções de resultado/tabela
-          como será mostrado na próxima seção de API de Asserções 
+          como será mostrado na próxima seção de API de Asserções
           de Banco de Dados.
         </para>
         <programlisting><![CDATA[<?php
@@ -1179,9 +1179,9 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
       </listitem>
       <listitem>
         <para>
-          O método <literal>getRowCount()</literal> é uma forma conveniente de 
-          acessar o número de linhas em uma tabela, opcionalmente filtradas por uma 
-          cláusula where adicional. Isso pode ser usado com uma simples asserção 
+          O método <literal>getRowCount()</literal> é uma forma conveniente de
+          acessar o número de linhas em uma tabela, opcionalmente filtradas por uma
+          cláusula where adicional. Isso pode ser usado com uma simples asserção
           de igualdade:
         </para>
         <programlisting><![CDATA[<?php
@@ -1189,7 +1189,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -1199,19 +1199,19 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
   <section id="database.database-assertions-api">
     <title>API de Asserções de Banco de Dados</title>
     <para>
-      Para uma ferramenta de testes, a Extensão para Banco de Dados certamente fornece algumas 
-      asserções que você pode usar para verificar o estado atual do banco de dados, 
-      tabelas e a contagem de linhas de tabelas. Esta seção 
+      Para uma ferramenta de testes, a Extensão para Banco de Dados certamente fornece algumas
+      asserções que você pode usar para verificar o estado atual do banco de dados,
+      tabelas e a contagem de linhas de tabelas. Esta seção
       descreve essa funcionalidade em detalhes:
     </para>
     <section id="database.asserting-the-row-count-of-a-table">
       <title>Asseverado a contagem de linhas de uma Tabela</title>
       <para>
-        Às vezes ajuda verificar se uma tabela contém uma quantidade específica 
-        de linhas. Você pode conseguir isso facilmente sem colar códigos adicionais 
-        usando a API de Conexão. Suponha que queiramos verificar se após a 
-        inserção de uma linha em nosso guestbook não apenas temos as duas entradas 
-        iniciais que nos acompanharam em todos os exemplos 
+        Às vezes ajuda verificar se uma tabela contém uma quantidade específica
+        de linhas. Você pode conseguir isso facilmente sem colar códigos adicionais
+        usando a API de Conexão. Suponha que queiramos verificar se após a
+        inserção de uma linha em nosso guestbook não apenas temos as duas entradas
+        iniciais que nos acompanharam em todos os exemplos
         anteriores, mas uma terceira:
       </para>
       <programlisting><![CDATA[<?php
@@ -1219,12 +1219,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -1232,14 +1232,14 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Asseverando o Estado de uma Tabela</title>
       <para>
-       A asserção anterior ajuda, mas certamente queremos verificar os 
-        conteúdos reais da tabela para verificar se todos os valores foram 
-        escritos nas colunas corretas. Isso pode ser conseguido com uma 
+       A asserção anterior ajuda, mas certamente queremos verificar os
+        conteúdos reais da tabela para verificar se todos os valores foram
+        escritos nas colunas corretas. Isso pode ser conseguido com uma
         asserção de tabela.
       </para>
       <para>
-        Para isso vamos definir uma instância de Tabela Query que deriva seu 
-        conteúdo de um nome de tabela e de uma query SQL e compara isso a um 
+        Para isso vamos definir uma instância de Tabela Query que deriva seu
+        conteúdo de um nome de tabela e de uma query SQL e compara isso a um
         Conjunto de Dados baseado em Arquivo/Vetor:
       </para>
       <programlisting><![CDATA[<?php
@@ -1255,12 +1255,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
       <para>
-        Agora temos que escrever o arquivo XML Plano <emphasis>expectedBook.xml</emphasis> 
+        Agora temos que escrever o arquivo XML Plano <emphasis>expectedBook.xml</emphasis>
         para esta asserção:
       </para>
       <screen><![CDATA[
@@ -1272,15 +1272,15 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 </dataset>
 ]]></screen>
       <para>
-        Apesar disso, esta asserção só vai passar em exatamente um segundo 
-        do universo, em <emphasis>2010–05–01 21:47:08</emphasis>. Datas 
-        possuem um problema especial nos testes de bancos de dados e podemos circundar 
-        a falha omitindo a coluna <quote>created</quote> 
+        Apesar disso, esta asserção só vai passar em exatamente um segundo
+        do universo, em <emphasis>2010–05–01 21:47:08</emphasis>. Datas
+        possuem um problema especial nos testes de bancos de dados e podemos circundar
+        a falha omitindo a coluna <quote>created</quote>
         da asserção.
       </para>
       <para>
-        O arquivo ajustado <emphasis>expectedBook.xml</emphasis> em XML Plano 
-        provavelmente vai ficar parecido com o seguinte para fazer a 
+        O arquivo ajustado <emphasis>expectedBook.xml</emphasis> em XML Plano
+        provavelmente vai ficar parecido com o seguinte para fazer a
         asserção passar:
       </para>
       <screen><![CDATA[
@@ -1303,8 +1303,8 @@ $queryTable = $this->getConnection()->createQueryTable(
     <section id="database.asserting-the-result-of-a-query">
       <title>Asseverando o Resultado de uma Query</title>
       <para>
-        Você também pode asseverar o resultado de querys complexas com a abordagem 
-        da Tabela Query, apenas especificando um nome de resultado com uma query e 
+        Você também pode asseverar o resultado de querys complexas com a abordagem
+        da Tabela Query, apenas especificando um nome de resultado com uma query e
         comparando isso a um conjunto de dados:
       </para>
       <programlisting><![CDATA[<?php
@@ -1317,7 +1317,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -1325,14 +1325,14 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-multiple-tables">
       <title>Asseverando o Estado de Múltiplas Tabelas</title>
       <para>
-        Certamente você pode asseverar o estado de múltiplas tabelas de uma vez e 
-        comparar um conjunto de dados de query contra um conjunto de dados baseado em arquivo. Existem duas 
+        Certamente você pode asseverar o estado de múltiplas tabelas de uma vez e
+        comparar um conjunto de dados de query contra um conjunto de dados baseado em arquivo. Existem duas
         formas diferentes de asserções de Conjuntos de Dados.
       </para>
       <orderedlist numeration="arabic">
         <listitem>
           <para>
-            Você pode usar o Database (Banco de Dados - DB) e o DataSet (Conjunto de Dados) da Connection (Conexão) e 
+            Você pode usar o Database (Banco de Dados - DB) e o DataSet (Conjunto de Dados) da Connection (Conexão) e
             compará-lo com um Conjunto de Dados Baseado em Arquivo.
           </para>
           <programlisting><![CDATA[<?php
@@ -1342,7 +1342,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1360,7 +1360,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -1371,33 +1371,33 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
   <section id="database.frequently-asked-questions">
     <title>Perguntas Mais Frequentes</title>
     <section id="database.will-phpunit-re-create-the-database-schema-for-each-test">
-      <title>O PHPUnit vai (re)criar o esquema do banco de dados para cada 
+      <title>O PHPUnit vai (re)criar o esquema do banco de dados para cada
              teste?</title>
       <para>
-        Não, o PHPUnit exige que todos os objetos do banco de dados estejam disponíveis quando a 
-        suíte começar os testes. O Banco de Dados, tabelas, sequências, gatilhos e 
+        Não, o PHPUnit exige que todos os objetos do banco de dados estejam disponíveis quando a
+        suíte começar os testes. O Banco de Dados, tabelas, sequências, gatilhos e
         visualizações devem ser criadas antes que você execute a suíte de testes.
       </para>
       <para>
         <ulink url="http://www.doctrine-project.org">Doctrine 2</ulink> ou
-        <ulink url="http://www.ezcomponents.org">eZ Components</ulink> possuem 
-        ferramentas poderosas que permitem a você criar o esquema de banco de dados através 
-        de estruturas de dados pré-definidas, porém devem ser ligados à 
-        extensão do PHPUnit para permitir a recriação automática de banco de dados 
+        <ulink url="http://www.ezcomponents.org">eZ Components</ulink> possuem
+        ferramentas poderosas que permitem a você criar o esquema de banco de dados através
+        de estruturas de dados pré-definidas, porém devem ser ligados à
+        extensão do PHPUnit para permitir a recriação automática de banco de dados
         antes que a suíte de testes completa seja executada.
       </para>
       <para>
-        Já que cada teste limpa completamente o banco de dados, você nem sequer é 
-        forçado a recriar o banco de dados para cada execução de teste. Um banco de dados 
+        Já que cada teste limpa completamente o banco de dados, você nem sequer é
+        forçado a recriar o banco de dados para cada execução de teste. Um banco de dados
         permanentemente disponível funciona perfeitamente.
       </para>
     </section>
     <section id="database.am-i-required-to-use-pdo-in-my-application-for-the-database-extension-to-work">
-      <title>Sou forçado a usar PDO em minha aplicação para que a Extensão para 
+      <title>Sou forçado a usar PDO em minha aplicação para que a Extensão para
              Banco de Dados funcione?</title>
       <para>
-        Não, PDO só é exigido para limpeza e configuração do ambiente e para 
-        asserções. Você pode usar qualquer abstração de banco de dados que quiser 
+        Não, PDO só é exigido para limpeza e configuração do ambiente e para
+        asserções. Você pode usar qualquer abstração de banco de dados que quiser
         dentro de seu próprio código.
       </para>
     </section>
@@ -1405,24 +1405,24 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
       <title>O que posso fazer quando recebo um Erro
              <quote>Too much Connections</quote>?</title>
       <para>
-        Se você não armazena em cache a instância de PDO que é criada a partir do 
-        método do Caso de Teste <literal>getConnection()</literal> o número de 
-        conexões ao banco de dados é aumentado em um ou mais com cada 
-        teste do banco de dados. Com a configuração padrão o MySQL só permite 100 
-        conexões concorrentes e outros fornecedores também têm um limite máximo 
+        Se você não armazena em cache a instância de PDO que é criada a partir do
+        método do Caso de Teste <literal>getConnection()</literal> o número de
+        conexões ao banco de dados é aumentado em um ou mais com cada
+        teste do banco de dados. Com a configuração padrão o MySQL só permite 100
+        conexões concorrentes e outros fornecedores também têm um limite máximo
         de conexões.
       </para>
       <para>
         A Sub-seção
-        <quote>Use seu próprio Caso Abstrato de Teste de Banco de Dados</quote> mostra como 
-        você pode prevenir o acontecimento desse erro usando uma instância única armazenada 
+        <quote>Use seu próprio Caso Abstrato de Teste de Banco de Dados</quote> mostra como
+        você pode prevenir o acontecimento desse erro usando uma instância única armazenada
         em cache do PDO em todos os seus testes.
       </para>
     </section>
     <section id="database.how-to-handle-null-with-flat-xml-csv-datasets">
       <title>Como lidar com NULL usando Conjuntos de Dados XML Plano / CSV?</title>
       <para>
-        Não faça isso. Em vez disso, você deveria usar Conjuntos de Dados ou 
+        Não faça isso. Em vez disso, você deveria usar Conjuntos de Dados ou
         XML ou YAML.
       </para>
     </section>

--- a/src/4.8/pt_br/fixtures.xml
+++ b/src/4.8/pt_br/fixtures.xml
@@ -6,21 +6,21 @@
   <para>
     <indexterm><primary>Ambientes</primary></indexterm>
 
-    Uma das partes que mais consomem tempo ao se escrever testes é escrever o 
-    código para ajustar o ambiente para um estado conhecido e então retorná-lo ao seu 
-    estado original quando o teste está completo. Esse estado conhecido é chamado 
+    Uma das partes que mais consomem tempo ao se escrever testes é escrever o
+    código para ajustar o ambiente para um estado conhecido e então retorná-lo ao seu
+    estado original quando o teste está completo. Esse estado conhecido é chamado
     de <emphasis>ambiente</emphasis> do teste.
   </para>
 
   <para>
-    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" />, o 
+    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" />, o
     ambiente era simplesmente o vetor que está guardado na variável <literal>$stack</literal>.
-    Na maior parte do tempo, porém, o ambiente será mais complexo 
-    que um simples vetor, e a quantidade de código necessária para defini-lo aumentará 
-    na mesma proporção. O conteúdo real do teste se perde na bagunça 
-    da configuração do ambiente. Esse problema piora ainda mais quando você escreve 
-    vários testes com ambientes similares. Sem alguma ajuda do framework de teste, 
-    teríamos que duplicar o código que define o ambiente 
+    Na maior parte do tempo, porém, o ambiente será mais complexo
+    que um simples vetor, e a quantidade de código necessária para defini-lo aumentará
+    na mesma proporção. O conteúdo real do teste se perde na bagunça
+    da configuração do ambiente. Esse problema piora ainda mais quando você escreve
+    vários testes com ambientes similares. Sem alguma ajuda do framework de teste,
+    teríamos que duplicar o código que define o ambiente
     para cada teste que escrevermos.
   </para>
 
@@ -29,25 +29,25 @@
     <indexterm><primary>setUp()</primary></indexterm>
     <indexterm><primary>tearDown()</primary></indexterm>
 
-    O PHPUnit suporta compartilhamento do código de configuração. Antes que um método seja executado, um 
+    O PHPUnit suporta compartilhamento do código de configuração. Antes que um método seja executado, um
     método modelo chamado <literal>setUp()</literal> é invocado.
-    <literal>setUp()</literal> é onde você cria os objetos que serão 
-    alvo dos testes. Uma vez que o método de teste tenha terminado sua execução, seja 
+    <literal>setUp()</literal> é onde você cria os objetos que serão
+    alvo dos testes. Uma vez que o método de teste tenha terminado sua execução, seja
     bem-sucedido ou falho, outro método modelo chamado
     <literal>tearDown()</literal> é invocado. <literal>tearDown()</literal>
     é onde você limpa os objetos que foram alvo dos testes.
   </para>
 
   <para>
-    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> usamos 
-    a relação produtor-consumidor entre testes para compartilhar ambientes. Isso 
+    Em <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> usamos
+    a relação produtor-consumidor entre testes para compartilhar ambientes. Isso
     nem sempre é desejável, ou mesmo possível. <xref linkend="fixtures.examples.StackTest.php"/>
-    mostra como podemos escrever os testes do <literal>StackTest</literal> de forma 
-    que o próprio ambiente não é reutilizado, mas o código que o cria. 
-    Primeiro declaramos a variável de instância <literal>$stack</literal>, que 
-    usaremos no lugar de uma variável do método local. Então colocamos a 
+    mostra como podemos escrever os testes do <literal>StackTest</literal> de forma
+    que o próprio ambiente não é reutilizado, mas o código que o cria.
+    Primeiro declaramos a variável de instância <literal>$stack</literal>, que
+    usaremos no lugar de uma variável do método local. Então colocamos a
     criação do ambiente <literal>vetor</literal> dentro do método
-    <literal>setUp()</literal>. Finalmente, removemos o código redundante 
+    <literal>setUp()</literal>. Finalmente, removemos o código redundante
     dos métodos de teste e usamos a nova variável de instância,
     <literal>$this->stack</literal>, em vez da variável de método local
     <literal>$stack</literal> com o método de asserção <literal>assertEquals()</literal>.
@@ -67,21 +67,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -94,8 +94,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>tearDown()</primary></indexterm>
     <indexterm><primary>tearDownAfterClass()</primary></indexterm>
 
-    Os métodos-modelo <literal>setUp()</literal> e <literal>tearDown()</literal> 
-    são executados uma vez para cada método de teste (e em novas instâncias) da 
+    Os métodos-modelo <literal>setUp()</literal> e <literal>tearDown()</literal>
+    são executados uma vez para cada método de teste (e em novas instâncias) da
     classe do caso de teste.
   </para>
 
@@ -110,15 +110,15 @@ class StackTest extends PHPUnit_Framework_TestCase
     <indexterm><primary>onNotSuccessfulTest()</primary></indexterm>
 
     Além disso, os métodos-modelo <literal>setUpBeforeClass()</literal> e
-    <literal>tearDownAfterClass()</literal> são chamados antes 
-    do primeiro teste da classe do caso de teste ser executado e após o último teste da 
+    <literal>tearDownAfterClass()</literal> são chamados antes
+    do primeiro teste da classe do caso de teste ser executado e após o último teste da
     classe do caso de teste ser executado, respectivamente.
   </para>
 
   <para>
     <indexterm><primary>Método Modelo</primary></indexterm>
 
-    O exemplo abaixo mostra todos os métodos-modelo que estão disponíveis em uma classe 
+    O exemplo abaixo mostra todos os métodos-modelo que estão disponíveis em uma classe
     de casos de teste.
   </para>
 
@@ -145,13 +145,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()
@@ -209,15 +209,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Mais setUp() que tearDown()</title>
 
     <para>
-      <literal>setUp()</literal> e <literal>tearDown()</literal> são bastante 
-      simétricos em teoria, mas não na prática. Na prática, você só precisa 
-      implementar <literal>tearDown()</literal> se você tiver alocado 
+      <literal>setUp()</literal> e <literal>tearDown()</literal> são bastante
+      simétricos em teoria, mas não na prática. Na prática, você só precisa
+      implementar <literal>tearDown()</literal> se você tiver alocado
       recursos externos como arquivos ou sockets no <literal>setUp()</literal>.
-      Se seu <literal>setUp()</literal> apenas cria objetos planos do PHP, você 
-      pode geralmente ignorar o <literal>tearDown()</literal>. Porém, se você 
-      criar muitos objetos em seu <literal>setUp()</literal>, você pode querer 
+      Se seu <literal>setUp()</literal> apenas cria objetos planos do PHP, você
+      pode geralmente ignorar o <literal>tearDown()</literal>. Porém, se você
+      criar muitos objetos em seu <literal>setUp()</literal>, você pode querer
       <literal>unset()</literal> as variáveis que apontam para aqueles objetos
-      em seu <literal>tearDown()</literal> para que eles possam ser coletados como lixo. 
+      em seu <literal>tearDown()</literal> para que eles possam ser coletados como lixo.
       A coleta de lixo dos objetos dos casos de teste não é previsível.
     </para>
   </section>
@@ -226,23 +226,23 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variações</title>
 
     <para>
-      O que acontece quando você tem dois testes com definições (setups) ligeiramente diferentes? 
+      O que acontece quando você tem dois testes com definições (setups) ligeiramente diferentes?
       Existem duas possibilidades:
     </para>
 
     <itemizedlist>
       <listitem>
         <para>
-          Se o código <literal>setUp()</literal> diferir só um pouco, mova 
-          o código que difere do código do <literal>setUp()</literal> para 
+          Se o código <literal>setUp()</literal> diferir só um pouco, mova
+          o código que difere do código do <literal>setUp()</literal> para
           o método de teste.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          Se você tiver um <literal>setUp()</literal> realmente diferente, você precisará 
-          de uma classe de caso de teste diferente. Nomeie a classe após a diferença 
+          Se você tiver um <literal>setUp()</literal> realmente diferente, você precisará
+          de uma classe de caso de teste diferente. Nomeie a classe após a diferença
           na configuração.
         </para>
       </listitem>
@@ -253,15 +253,15 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Compartilhando Ambientes</title>
 
     <para>
-      Existem algumas boas razões para compartilhar ambientes entre testes, mas na maioria 
-        dos casos a necessidade de compartilhar um ambiente entre testes deriva de um problema 
+      Existem algumas boas razões para compartilhar ambientes entre testes, mas na maioria
+        dos casos a necessidade de compartilhar um ambiente entre testes deriva de um problema
         de design não resolvido.
     </para>
 
     <para>
-      Um bom exemplo de um ambiente que faz sentido compartilhar através de vários 
-        testes é a conexão ao banco de dados: você loga no banco de dados uma vez e 
-        reutiliza essa conexão em vez de criar uma nova conexão para cada 
+      Um bom exemplo de um ambiente que faz sentido compartilhar através de vários
+        testes é a conexão ao banco de dados: você loga no banco de dados uma vez e
+        reutiliza essa conexão em vez de criar uma nova conexão para cada
         teste. Isso faz seus testes serem executados mais rápido.
     </para>
 
@@ -271,8 +271,8 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
 
       <xref linkend="fixtures.sharing-fixture.examples.DatabaseTest.php" />
       usa os métodos-modelo <literal>setUpBeforeClass()</literal> e
-      <literal>tearDownAfterClass()</literal> para conectar ao 
-      banco de dados antes do primeiro teste da classe de casos de teste e para desconectar do 
+      <literal>tearDownAfterClass()</literal> para conectar ao
+      banco de dados antes do primeiro teste da classe de casos de teste e para desconectar do
       banco de dados após o último teste dos casos de teste, respectivamente.
     </para>
 
@@ -297,12 +297,12 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Não dá pra enfatizar o suficiente o quanto o compartilhamento de ambientes entre testes 
-      reduz o custo dos testes. O problema de design subjacente é 
-      que objetos não são de baixo acoplamento. Você vai conseguir 
-      melhores resultados resolvendo o problema de design subjacente e então escrevendo testes 
-      usando pontas (veja <xref linkend="test-doubles" />), do que criando 
-      dependências entre os testes em tempo de execução e ignorando a oportunidade 
+      Não dá pra enfatizar o suficiente o quanto o compartilhamento de ambientes entre testes
+      reduz o custo dos testes. O problema de design subjacente é
+      que objetos não são de baixo acoplamento. Você vai conseguir
+      melhores resultados resolvendo o problema de design subjacente e então escrevendo testes
+      usando pontas (veja <xref linkend="test-doubles" />), do que criando
+      dependências entre os testes em tempo de execução e ignorando a oportunidade
       de melhorar seu design.
     </para>
   </section>
@@ -312,8 +312,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     <para>
       <ulink url="http://googletesting.blogspot.com/2008/05/tott-using-dependancy-injection-to.html">É difícil testar um código que usa singletons (instâncias únicas de objetos).</ulink>
-      Isso também vale para os códigos que usam variáveis globais. Tipicamente, o código 
-      que você quer testar é fortemente acoplado com uma variável global e você não pode 
+      Isso também vale para os códigos que usam variáveis globais. Tipicamente, o código
+      que você quer testar é fortemente acoplado com uma variável global e você não pode
       controlar sua criação. Um problema adicional é o fato de que uma alteração em uma
       variável global para um teste pode quebrar um outro teste.
     </para>
@@ -330,7 +330,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </itemizedlist>
 
     <para>
-      Além das variáveis globais, atributos estáticos de classes também são parte do 
+      Além das variáveis globais, atributos estáticos de classes também são parte do
       estado global.
     </para>
 
@@ -338,24 +338,24 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary>Isolamento de Testes</primary></indexterm>
 
-      Por padrão, o PHPUnit executa seus testes de forma que mudanças às 
+      Por padrão, o PHPUnit executa seus testes de forma que mudanças às
       variáveis globais ou super-globais (<literal>$GLOBALS</literal>,
       <literal>$_ENV</literal>, <literal>$_POST</literal>,
       <literal>$_GET</literal>, <literal>$_COOKIE</literal>,
       <literal>$_SERVER</literal>, <literal>$_FILES</literal>,
-      <literal>$_REQUEST</literal>) não afetem outros testes. Opcionalmente, este 
+      <literal>$_REQUEST</literal>) não afetem outros testes. Opcionalmente, este
       isolamento pode ser estendido a atributos estáticos de classes.
     </para>
 
     <note>
       <para>
-        A operações de cópia de segurança e restauração para variáveis globais e atributos 
+        A operações de cópia de segurança e restauração para variáveis globais e atributos
         estáticos de classes usa <literal>serialize()</literal> e
         <literal>unserialize()</literal>.
       </para>
       <para>
-        Objetos de algumas classes (e.g., <literal>PDO</literal>) não podem ser 
-        serializadas e a operação de cópia de segurança vai quebrar quando esse tipo de objeto 
+        Objetos de algumas classes (e.g., <literal>PDO</literal>) não podem ser
+        serializadas e a operação de cópia de segurança vai quebrar quando esse tipo de objeto
         for guardado no vetor <literal>$GLOBALS</literal>, por exemplo.
       </para>
     </note>
@@ -365,9 +365,9 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
       <indexterm><primary><literal>$backupGlobalsBlacklist</literal></primary></indexterm>
 
       A anotação <literal>@backupGlobals</literal> que é discutida na
-      <xref linkend="appendixes.annotations.backupGlobals"/> pode ser usada para 
-      controlar as operações de cópia de segurança e restauração para variáveis globais. 
-      Alternativamente, você pode fornecer uma lista-negra de variáveis globais que deverão 
+      <xref linkend="appendixes.annotations.backupGlobals"/> pode ser usada para
+      controlar as operações de cópia de segurança e restauração para variáveis globais.
+      Alternativamente, você pode fornecer uma lista-negra de variáveis globais que deverão
       ser excluídas das operações de backup e restauração como esta:
       <programlisting>class MyTest extends PHPUnit_Framework_TestCase
 {
@@ -379,7 +379,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        Definir a propriedade <literal>$backupGlobalsBlacklist</literal> dentro 
+        Definir a propriedade <literal>$backupGlobalsBlacklist</literal> dentro
         do método <literal>setUp()</literal>, por exemplo, não tem efeito.
       </para>
     </note>
@@ -387,39 +387,39 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary><literal>@backupStaticAttributes</literal></primary></indexterm>
       <indexterm><primary><literal>$backupStaticAttributesBlacklist</literal></primary></indexterm>
-      
+
       A anotação <literal>@backupStaticAttributes</literal> que é discutida na
-      <xref linkend="appendixes.annotations.backupStaticAttributes"/> 
-      pode ser usado para fazer backup de todos os valores de propriedades estáticas em todas as classes declaradas 
+      <xref linkend="appendixes.annotations.backupStaticAttributes"/>
+      pode ser usado para fazer backup de todos os valores de propriedades estáticas em todas as classes declaradas
       antes de cada teste e restaurá-los depois.
     </para>
-    
+
     <para>
-      Ele processa todas as classes que são declaradas no momento que um teste começa, 
-      não só a classe de teste. Ele só se aplica a propriedades da classe estática, 
+      Ele processa todas as classes que são declaradas no momento que um teste começa,
+      não só a classe de teste. Ele só se aplica a propriedades da classe estática,
       e não variáveis estáticas dentro de funções.
     </para>
 
     <note>
       <para>
-        A operação <literal>@backupStaticAttributes</literal> é executada 
-        antes de um método de teste, mas somente se ele está habilitado. Se um valor estático foi 
-        alterado por um teste executado anteriormente que não 
-        tinha ativado <literal>@backupStaticAttributes</literal>, esse valor então será 
-        feito o backup e restaurado - não o valor padrão originalmente declarado. 
-        O PHP não registra o valor padrão originalmente declarado de nenhuma variável 
+        A operação <literal>@backupStaticAttributes</literal> é executada
+        antes de um método de teste, mas somente se ele está habilitado. Se um valor estático foi
+        alterado por um teste executado anteriormente que não
+        tinha ativado <literal>@backupStaticAttributes</literal>, esse valor então será
+        feito o backup e restaurado - não o valor padrão originalmente declarado.
+        O PHP não registra o valor padrão originalmente declarado de nenhuma variável
         estática.
       </para>
       <para>
-        O mesmo se aplica a propriedades estáticas de classes que foram 
-        recém-carregadas/declaradas dentro de um teste. Elas não podem ser redefinidas para o seu valor 
-        padrão originalmente declarado após o teste, uma vez que esse valor é desconhecido. 
+        O mesmo se aplica a propriedades estáticas de classes que foram
+        recém-carregadas/declaradas dentro de um teste. Elas não podem ser redefinidas para o seu valor
+        padrão originalmente declarado após o teste, uma vez que esse valor é desconhecido.
         Qualquer que seja o valor definido irá vazar para testes subsequentes.
       </para>
       <para>
-        Para testes de unidade, recomenda-se redefinir explicitamente os valores das 
-        propriedades estáticas em teste em seu código <literal>setUp()</literal> 
-        ao invés (e, idealmente, também <literal>tearDown()</literal>, de modo a não 
+        Para testes de unidade, recomenda-se redefinir explicitamente os valores das
+        propriedades estáticas em teste em seu código <literal>setUp()</literal>
+        ao invés (e, idealmente, também <literal>tearDown()</literal>, de modo a não
         afetar os testes posteriormente executados).
       </para>
     </note>

--- a/src/4.8/pt_br/incomplete-and-skipped-tests.xml
+++ b/src/4.8/pt_br/incomplete-and-skipped-tests.xml
@@ -7,17 +7,17 @@
     <title>Testes Incompletos</title>
 
     <para>
-      Quando você está trabalhando em uma nova classe de caso de teste, você pode querer começar 
+      Quando você está trabalhando em uma nova classe de caso de teste, você pode querer começar
       a escrever métodos de teste vazios, como: <programlisting>public function testSomething()
 {
-}</programlisting> para manter o controle sobre os testes que você já escreveu. O 
-      problema com os métodos de teste vazios é que eles são interpretados como 
-      bem-sucedidos pelo framework do PHPUnit. Esse erro de interpretação leva à 
-      inutilização dos relatórios de testes -- você não pode ver se um teste foi 
-      realmente bem-sucedido ou simplesmente ainda não foi implementado. Chamar 
-      <literal>$this->fail()</literal> no teste não implementado 
-      não ajuda em nada, já que o teste será interpretado como uma 
-      falha. Isso seria tão errado quanto interpretar um teste não implementado 
+}</programlisting> para manter o controle sobre os testes que você já escreveu. O
+      problema com os métodos de teste vazios é que eles são interpretados como
+      bem-sucedidos pelo framework do PHPUnit. Esse erro de interpretação leva à
+      inutilização dos relatórios de testes -- você não pode ver se um teste foi
+      realmente bem-sucedido ou simplesmente ainda não foi implementado. Chamar
+      <literal>$this->fail()</literal> no teste não implementado
+      não ajuda em nada, já que o teste será interpretado como uma
+      falha. Isso seria tão errado quanto interpretar um teste não implementado
       como bem-sucedido.
     </para>
 
@@ -26,22 +26,22 @@
       <indexterm><primary>PHPUnit_Framework_IncompleteTest</primary></indexterm>
       <indexterm><primary>PHPUnit_Framework_IncompleteTestError</primary></indexterm>
 
-      Se imaginarmos que um teste bem-sucedido é uma luz verde e um teste mal-sucedido (falho) 
-      é uma luz vermelha, precisaremos de uma luz amarela adicional para marcar um teste 
-      como incompleto ou ainda não implementado. 
-      O <literal>PHPUnit_Framework_IncompleteTest</literal> é uma interface 
-      marcadora para marcar uma exceção que surge de um método de teste como 
-      resultado do teste ser incompleto ou atualmente não implementado. 
-      O <literal>PHPUnit_Framework_IncompleteTestError</literal> é a 
+      Se imaginarmos que um teste bem-sucedido é uma luz verde e um teste mal-sucedido (falho)
+      é uma luz vermelha, precisaremos de uma luz amarela adicional para marcar um teste
+      como incompleto ou ainda não implementado.
+      O <literal>PHPUnit_Framework_IncompleteTest</literal> é uma interface
+      marcadora para marcar uma exceção que surge de um método de teste como
+      resultado do teste ser incompleto ou atualmente não implementado.
+      O <literal>PHPUnit_Framework_IncompleteTestError</literal> é a
       implementação padrão dessa interface.
     </para>
 
     <para>
       O <xref linkend="incomplete-and-skipped-tests.incomplete-tests.examples.SampleTest.php" />
-      mostra uma classe de caso de teste, <literal>SampleTest</literal>, que contém um método 
-      de teste, <literal>testSomething()</literal>. Chamando o método de conveniência 
-      <literal>markTestIncomplete()</literal> (que automaticamente 
-      traz uma exceção <literal>PHPUnit_Framework_IncompleteTestError</literal>) 
+      mostra uma classe de caso de teste, <literal>SampleTest</literal>, que contém um método
+      de teste, <literal>testSomething()</literal>. Chamando o método de conveniência
+      <literal>markTestIncomplete()</literal> (que automaticamente
+      traz uma exceção <literal>PHPUnit_Framework_IncompleteTestError</literal>)
       no método de teste, marcamos o teste como sendo incompleto.
     </para>
 
@@ -53,7 +53,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // Opcional: Teste alguma coisa aqui, se quiser
-        $this->assertTrue(TRUE, 'This should already work.');
+        self::assertTrue(TRUE, 'This should already work.');
 
         // Pare aqui e marque este teste como incompleto.
         $this->markTestIncomplete(
@@ -65,8 +65,8 @@ class SampleTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Um teste incompleto é denotado por um <literal>I</literal> na saída 
-      do executor de testes em linha-de-comando do PHPUnit, como mostrado no exemplo 
+      Um teste incompleto é denotado por um <literal>I</literal> na saída
+      do executor de testes em linha-de-comando do PHPUnit, como mostrado no exemplo
       abaixo:
     </para>
 
@@ -119,18 +119,18 @@ Tests: 1, Assertions: 1, Incomplete: 1.</screen>
     <title>Pulando Testes</title>
 
     <para>
-      Nem todos os testes podem ser executados em qualquer ambiente. Considere, por exemplo, 
+      Nem todos os testes podem ser executados em qualquer ambiente. Considere, por exemplo,
       uma camada de abstração de banco de dados contendo vários drivers para os diversos
-      sistemas de banco de dados que suporta. Os testes para o driver MySQL podem ser 
+      sistemas de banco de dados que suporta. Os testes para o driver MySQL podem ser
       executados apenas, é claro, se um servidor MySQL estiver disponível.
     </para>
 
     <para>
       O <xref linkend="incomplete-and-skipped-tests.skipping-tests.examples.DatabaseTest.php" />
-      mostra uma classe de caso de teste, <literal>DatabaseTest</literal>, que contém um método 
-      de teste, <literal>testConnection()</literal>. No método-modelo <literal>setUp()</literal> 
-      da classe de caso de teste, verificamos se a extensão MySQLi 
-      está disponível e usamos o método <literal>markTestSkipped()</literal> 
+      mostra uma classe de caso de teste, <literal>DatabaseTest</literal>, que contém um método
+      de teste, <literal>testConnection()</literal>. No método-modelo <literal>setUp()</literal>
+      da classe de caso de teste, verificamos se a extensão MySQLi
+      está disponível e usamos o método <literal>markTestSkipped()</literal>
       para pular o teste caso contrário.
     </para>
 
@@ -157,8 +157,8 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Um teste que tenha sido pulado é denotado por um <literal>S</literal> na 
-      saída do executor de testes em linha-de-comando do PHPUnit, como mostrado 
+      Um teste que tenha sido pulado é denotado por um <literal>S</literal> na
+      saída do executor de testes em linha-de-comando do PHPUnit, como mostrado
       no seguinte exemplo:
     </para>
 
@@ -211,7 +211,7 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
     <title>Pulando Testes usando @requires</title>
 
     <para>
-      Além do método acima também é possível usar a 
+      Além do método acima também é possível usar a
       anotação <literal>@requires</literal> para expressar pré-condições comuns para um caso de teste.
     </para>
 
@@ -283,7 +283,7 @@ class DatabaseTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Se você está usando uma sintaxe que não compila com uma certa versão do PHP, procure dentro da configuração 
+      Se você está usando uma sintaxe que não compila com uma certa versão do PHP, procure dentro da configuração
       xml por includes dependentes de versão na <xref linkend="appendixes.configuration.testsuites" />.
     </para>
   </section>

--- a/src/4.8/pt_br/selenium.xml
+++ b/src/4.8/pt_br/selenium.xml
@@ -9,21 +9,21 @@
     <para>
       <indexterm><primary>Servidor Selenium</primary></indexterm>
 
-      <ulink url="http://seleniumhq.org/">Servidor Selenium</ulink> é uma 
-      ferramenta de testes que permite a você escrever testes automatizados de interface de usuário para 
-      aplicações web em qualquer linguagem de programação contra qualquer website HTTP 
-      usando um dos principais navegadores. Ele realiza tarefas automatizadas no navegador 
-      guiando seu processo através do sistema operacional. 
-      O Selenium executa os testes diretamente em um navegador, exatamente como os usuários reais fazem. Esses 
+      <ulink url="http://seleniumhq.org/">Servidor Selenium</ulink> é uma
+      ferramenta de testes que permite a você escrever testes automatizados de interface de usuário para
+      aplicações web em qualquer linguagem de programação contra qualquer website HTTP
+      usando um dos principais navegadores. Ele realiza tarefas automatizadas no navegador
+      guiando seu processo através do sistema operacional.
+      O Selenium executa os testes diretamente em um navegador, exatamente como os usuários reais fazem. Esses
       testes podem ser usados para ambos <emphasis>testes de aceitação</emphasis>
-      (realizando testes de alto-nível no sistema integrado em vez de 
-      apenas testar cada unidade do sistema independentemente) e 
-      <emphasis>testes de compatibilidade de navegador</emphasis> (testando a aplicação web em 
+      (realizando testes de alto-nível no sistema integrado em vez de
+      apenas testar cada unidade do sistema independentemente) e
+      <emphasis>testes de compatibilidade de navegador</emphasis> (testando a aplicação web em
       diferentes sistemas operacionais e navegadores).
     </para>
-    
+
     <para>
-      O único cenário suportado do PHPUnit_Selenium é o do servidor Selenium 2.x. 
+      O único cenário suportado do PHPUnit_Selenium é o do servidor Selenium 2.x.
       O servidor pode ser acessado através da Api clássica Selenium RC, já presente no 1.x, ou com a API WebDriver (parcialmente implementada) do PHPUnit_Selenium 1.2.
     </para>
     <para>
@@ -44,17 +44,17 @@
       <listitem>Descompacte o arquivo de distribuição e copie o <filename>selenium-server-standalone-2.9.0.jar</filename> (verifique o sufixo da versão) para <filename>/usr/local/bin</filename>, por exemplo.</listitem>
       <listitem>Inicie o Servidor Selenium executando <userinput>java -jar /usr/local/bin/selenium-server-standalone-2.9.0.jar</userinput>.</listitem>
     </orderedlist>
-    
+
     <para>
-      O pacote PHPUnit_Selenium está incluso na distribuição PHAR 
+      O pacote PHPUnit_Selenium está incluso na distribuição PHAR
       do PHPUnit. Ele pode ser instalado através do Composer, adicionando a seguinte
       dependência <literal>"require-dev"</literal>:
     </para>
-    
+
     <screen><userinput>"phpunit/phpunit-selenium": ">=1.2"</userinput></screen>
 
     <para>
-      Agora podemos enviar comandos para o Servidor Selenium usando seu protocolo 
+      Agora podemos enviar comandos para o Servidor Selenium usando seu protocolo
       cliente/servidor.
     </para>
   </section>
@@ -69,9 +69,9 @@
     </para>
 
     <para>
-      <xref linkend="selenium.selenium2testcase.examples.WebTest.php" /> mostra 
+      <xref linkend="selenium.selenium2testcase.examples.WebTest.php" /> mostra
       como testar os conteúdos do elemento <literal><![CDATA[<title>]]></literal>
-      do site 
+      do site
       <systemitem role="URL">http://www.example.com/</systemitem>.
     </para>
     <example id="selenium.selenium2testcase.examples.WebTest.php">
@@ -88,7 +88,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -126,15 +126,15 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen></example>
     <para>
       <indexterm><primary><literal>PHPUnit_Extensions_SeleniumTestCase</literal></primary></indexterm>
 
-      A extensão de caso de teste <literal>PHPUnit_Extensions_SeleniumTestCase</literal> 
-      implementa o protocolo cliente/servidor para conversar com o Servidor Selenium assim como 
+      A extensão de caso de teste <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
+      implementa o protocolo cliente/servidor para conversar com o Servidor Selenium assim como
       métodos de asserção especializados para testes web.
     </para>
 
     <para>
-      O <xref linkend="selenium.seleniumtestcase.examples.WebTest.php" /> mostra 
+      O <xref linkend="selenium.seleniumtestcase.examples.WebTest.php" /> mostra
       como testar os conteúdos do elemento <literal><![CDATA[<title>]]></literal>
-      para o site 
+      para o site
       <systemitem role="URL">http://www.exemplo.com/</systemitem>.
     </para>
 
@@ -154,7 +154,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -180,8 +180,8 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 
     <para>
       Diferente da classe <literal>PHPUnit_Framework_TestCase</literal>,
-      classes de caso de teste que estendem o <literal>PHPUnit_Extensions_SeleniumTestCase</literal> 
-      têm que fornecer um método <literal>setUp()</literal>. Esse método é usado 
+      classes de caso de teste que estendem o <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
+      têm que fornecer um método <literal>setUp()</literal>. Esse método é usado
       para configurar a sessão do Servidor Selenium. Veja
       <xref linkend="selenium.seleniumtestcase.tables.seleniumrc-api.setup" />
       para uma lista de métodos que estão disponíveis para isso.
@@ -227,7 +227,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </table>
 
     <para>
-      O PHPUnit pode opcionalmente capturar a tela quando um teste do Selenium falha. Para 
+      O PHPUnit pode opcionalmente capturar a tela quando um teste do Selenium falha. Para
       habilitar isso, configure <literal>$captureScreenshotOnFailure</literal>,
       <literal>$screenshotPath</literal> e <literal>$screenshotUrl</literal>
       em sua classe de caso de teste como mostrado em
@@ -254,7 +254,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -280,12 +280,12 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 
     <para>
       Você pode executar cada teste usando um conjunto de navegadores: Em vez de usar
-      <literal>setBrowser()</literal> para configurar um navegador, você pode declarar um 
+      <literal>setBrowser()</literal> para configurar um navegador, você pode declarar um
       vetor <literal>public static</literal> chamado <literal>$browsers</literal>
-      em sua classe de caso de testes. Cada item nesse vetor descreve uma configuração 
-      de navegador. Cada um desses navegadores pode ser hospedado em diferentes 
+      em sua classe de caso de testes. Cada item nesse vetor descreve uma configuração
+      de navegador. Cada um desses navegadores pode ser hospedado em diferentes
       Servidores Selenium.
-      O <xref linkend="selenium.seleniumtestcase.examples.WebTest3.php" /> mostra 
+      O <xref linkend="selenium.seleniumtestcase.examples.WebTest3.php" /> mostra
       um exemplo.
     </para>
 
@@ -335,14 +335,14 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      <literal>PHPUnit_Extensions_SeleniumTestCase</literal> pode coletar a 
+      <literal>PHPUnit_Extensions_SeleniumTestCase</literal> pode coletar a
       informação de cobertura de código para execução de testes através do Selenium:
     </para>
 
@@ -353,7 +353,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </orderedlist>
 
     <para>
-      <xref linkend="selenium.seleniumtestcase.tables.assertions" /> lista os 
+      <xref linkend="selenium.seleniumtestcase.tables.assertions" /> lista os
       vários métodos de asserção que o <literal>PHPUnit_Extensions_SeleniumTestCase</literal>
       fornece.
     </para>
@@ -422,7 +422,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      <xref linkend="selenium.seleniumtestcase.tables.template-methods" /> mostra 
+      <xref linkend="selenium.seleniumtestcase.tables.template-methods" /> mostra
       o método modelo de <literal>PHPUnit_Extensions_SeleniumTestCase</literal>:
     </para>
 
@@ -446,7 +446,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </table>
 
     <para>
-      Por favor, verifique a <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentação dos comandos do Selenium</ulink> 
+      Por favor, verifique a <ulink url="http://release.seleniumhq.org/selenium-core/1.0.1/reference.html">documentação dos comandos do Selenium</ulink>
       para uma referência de todos os comandos disponíveis e como eles são utilizados.
     </para>
     <para>
@@ -454,13 +454,13 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     </para>
 
     <para>
-      Usando o método <literal>runSelenese($filename)</literal> você também pode 
-      executar um teste Selenium a partir de sua especificação Selenese/HTML. Além disso, 
-      usando o atributo estático <literal>$seleneseDirectory</literal>, você pode 
-      criar automaticamente objetos de teste a partir de um diretório que contenha 
-      arquivos Selenese/HTML. O diretório especificado é pesquisado recursivamente por 
+      Usando o método <literal>runSelenese($filename)</literal> você também pode
+      executar um teste Selenium a partir de sua especificação Selenese/HTML. Além disso,
+      usando o atributo estático <literal>$seleneseDirectory</literal>, você pode
+      criar automaticamente objetos de teste a partir de um diretório que contenha
+      arquivos Selenese/HTML. O diretório especificado é pesquisado recursivamente por
       arquivos <literal>.htm</literal> que possam conter Selenese/HTML.
-     O <xref linkend="selenium.seleniumtestcase.examples.WebTest4.php" /> mostra um 
+     O <xref linkend="selenium.seleniumtestcase.examples.WebTest4.php" /> mostra um
      exemplo.
     </para>
 
@@ -477,8 +477,8 @@ class SeleneseTests extends PHPUnit_Extensions_SeleniumTestCase
     </example>
 
     <para>
-    Desde o Selenium 1.1.1, um recurso experimental foi incluído para permitir ao usuário compartilhar a sessão entre testes. O único caso suportado é compartilhar a sessão entre todos os testes quando um único navegador é usado. 
-    Chame <literal>PHPUnit_Extensions_SeleniumTestCase::shareSession(true)</literal> em seu arquivo bootstrap para habilitar o compartilhamento de sessão. 
+    Desde o Selenium 1.1.1, um recurso experimental foi incluído para permitir ao usuário compartilhar a sessão entre testes. O único caso suportado é compartilhar a sessão entre todos os testes quando um único navegador é usado.
+    Chame <literal>PHPUnit_Extensions_SeleniumTestCase::shareSession(true)</literal> em seu arquivo bootstrap para habilitar o compartilhamento de sessão.
     A sessão será reiniciada no caso de testes mal-sucedidos (falhos ou incompletos); cabe ao usuário evitar interações entre testes seja resetando cookies ou deslogando da aplicação sob teste (com um método tearDown()).
     </para>
   </section>

--- a/src/4.8/pt_br/test-doubles.xml
+++ b/src/4.8/pt_br/test-doubles.xml
@@ -13,11 +13,11 @@
     <para>
       <indexterm><primary>Sistema Sob Teste</primary></indexterm>
 
-      Às vezes é muito difícil testar o sistema sob teste (SST - em inglês: system under test - SUT) 
-      porque isso depende de outros ambientes que não podem ser usados no ambiente 
-      de testes. Isso pode ser porque não estão disponíveis, não retornarão 
-      os resultados necessários para o teste, ou porque executá-los 
-      causaria efeitos colaterais indesejáveis. Em outros casos, nossa estratégia de testes requer 
+      Às vezes é muito difícil testar o sistema sob teste (SST - em inglês: system under test - SUT)
+      porque isso depende de outros ambientes que não podem ser usados no ambiente
+      de testes. Isso pode ser porque não estão disponíveis, não retornarão
+      os resultados necessários para o teste, ou porque executá-los
+      causaria efeitos colaterais indesejáveis. Em outros casos, nossa estratégia de testes requer
       que tenhamos mais controle ou visibilidade do comportamento interno do SST.
     </para>
 
@@ -25,27 +25,27 @@
       <indexterm><primary>Componente Dependente</primary></indexterm>
       <indexterm><primary>Dublê de Teste</primary></indexterm>
 
-      Quando estamos escrevendo um teste no qual não podemos (ou decidimos não) usar um componente 
-      dependente (depended-on component - DOC) real, podemos substitui-lo por um Dublê de Teste. O 
-      Dublê de Teste não precisa se comportar exatamente como o DOC real; apenas precisa 
-      fornecer a mesma API como o real, de forma que o SST pense que é 
+      Quando estamos escrevendo um teste no qual não podemos (ou decidimos não) usar um componente
+      dependente (depended-on component - DOC) real, podemos substitui-lo por um Dublê de Teste. O
+      Dublê de Teste não precisa se comportar exatamente como o DOC real; apenas precisa
+      fornecer a mesma API como o real, de forma que o SST pense que é
       o real!
     </para>
   </blockquote>
 
   <para>
-    O método <literal>getMockBuilder($type)</literal> fornecido pelo PHPUnit pode 
-    ser usado em um teste para gerar automaticamente um objeto que possa atuar como um dublê 
-    de teste para a classe original especificada. Esse objeto de 
-    dublê de teste pode ser usado em cada contexto onde um objeto da classe original 
+    O método <literal>getMockBuilder($type)</literal> fornecido pelo PHPUnit pode
+    ser usado em um teste para gerar automaticamente um objeto que possa atuar como um dublê
+    de teste para a classe original especificada. Esse objeto de
+    dublê de teste pode ser usado em cada contexto onde um objeto da classe original
     é esperado ou requerido.
   </para>
 
   <para>
-    Por padrão, todos os métodos da classe original são substituídos com uma implementação 
-    simulada que apenas retorna <literal>null</literal> (sem chamar 
-    o método original). Usando o método <literal>will($this->returnValue())</literal>, 
-    por exemplo, você pode configurar essas implementações simuladas para 
+    Por padrão, todos os métodos da classe original são substituídos com uma implementação
+    simulada que apenas retorna <literal>null</literal> (sem chamar
+    o método original). Usando o método <literal>will($this->returnValue())</literal>,
+    por exemplo, você pode configurar essas implementações simuladas para
     retornar um valor quando chamadas.
   </para>
 
@@ -54,8 +54,8 @@
 
     <para>
       Por favor, note que os métodos <literal>final</literal>, <literal>private</literal>
-      e <literal>static</literal> não podem ser esboçados (stubbed) ou falsificados (mocked). Eles 
-      são ignorados pela funcionalidade de dublê de teste do PHPUnit e mantêm seus 
+      e <literal>static</literal> não podem ser esboçados (stubbed) ou falsificados (mocked). Eles
+      são ignorados pela funcionalidade de dublê de teste do PHPUnit e mantêm seus
       comportamentos originais.
     </para>
   </note>
@@ -64,7 +64,7 @@
     <title>Aviso</title>
 
     <para>
-        Por favor atente para o fato de que a gestão de parâmetros foi mudada. 
+        Por favor atente para o fato de que a gestão de parâmetros foi mudada.
         A implementação anterior clona todos os parâmetros de objetos. Isso não permite verificar se o mesmo objeto foi passado para um método ou não.
         <xref linkend="test-doubles.mock-objects.examples.clone-object-parameters-usecase.php" /> mostra onde a nova implementação pode ser útil.
         <xref linkend="test-doubles.mock-objects.examples.enable-clone-object-parameters.php" /> mostra como voltar para o comportamento anterior.
@@ -77,27 +77,27 @@
     <para>
       <indexterm><primary>Esboço</primary></indexterm>
 
-      A prática de substituir um objeto por um dublê de teste que (opcionalmente) 
+      A prática de substituir um objeto por um dublê de teste que (opcionalmente)
       retorna valores de retorno configurados é chamada de
-      <emphasis>delineamento</emphasis>. Você pode usar um <emphasis>esboço</emphasis> para 
-      "substituir um componente real do qual o SST depende de modo que o teste tenha um 
-      ponto de controle para as entradas indiretas do SST. Isso permite ao teste 
+      <emphasis>delineamento</emphasis>. Você pode usar um <emphasis>esboço</emphasis> para
+      "substituir um componente real do qual o SST depende de modo que o teste tenha um
+      ponto de controle para as entradas indiretas do SST. Isso permite ao teste
       forçar o SST através de caminhos que não seriam executáveis de outra forma".
     </para>
 
     <para>
       <indexterm><primary>Interface Fluente</primary></indexterm>
 
-      <xref linkend="test-doubles.stubs.examples.StubTest.php" /> mostra como 
-      esboçar chamadas de método e configurar valores de retorno. Primeiro usamos o 
-      método <literal>getMockBuilder()</literal> que é fornecido pela 
-      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um esboço 
+      <xref linkend="test-doubles.stubs.examples.StubTest.php" /> mostra como
+      esboçar chamadas de método e configurar valores de retorno. Primeiro usamos o
+      método <literal>getMockBuilder()</literal> que é fornecido pela
+      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um esboço
       de objeto que parece com um objeto de <literal>SomeClass</literal>
-      (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). Então 
+      (<xref linkend="test-doubles.stubs.examples.SomeClass.php" />). Então
       usamos a <ulink url="http://martinfowler.com/bliki/FluentInterface.html">Interface Fluente</ulink>
-      que o PHPUnit fornece para especificar o comportamento para o esboço. Essencialmente, 
-      isso significa que você não precisa criar vários objetos temporários e 
-      uni-los depois. Em vez disso, você encadeia chamadas de método como mostrado no 
+      que o PHPUnit fornece para especificar o comportamento para o esboço. Essencialmente,
+      isso significa que você não precisa criar vários objetos temporários e
+      uni-los depois. Em vez disso, você encadeia chamadas de método como mostrado no
       exemplo. Isso leva a códigos mais legíveis e "fluentes".
     </para>
 
@@ -134,22 +134,22 @@ class StubTest extends PHPUnit_Framework_TestCase
         $stub->method('doSomething')
              ->willReturn('foo');
 
-        // Chamando $esboco->fazAlgumaCoisa() agora vai retornar 
+        // Chamando $esboco->fazAlgumaCoisa() agora vai retornar
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      "Atrás dos bastidores" o PHPUnit automaticamente gera uma nova classe PHP que 
+      "Atrás dos bastidores" o PHPUnit automaticamente gera uma nova classe PHP que
       implementa o comportamento desejado quando o método <literal>getMock()</literal>
       é usado.
     </para>
 
     <para>
-      <xref linkend="test-doubles.stubs.examples.StubTest2.php"/> mostra um 
+      <xref linkend="test-doubles.stubs.examples.StubTest2.php"/> mostra um
       exemplo de como usar a interface fluente do Mock Builder para configurar a
       criação do dublê de teste.
     </para>
@@ -177,7 +177,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
         // Chamar $stub->doSomething() agora vai retornar
         // 'foo'.
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -195,18 +195,18 @@ class StubTest extends PHPUnit_Framework_TestCase
       <listitem><para><literal>disableOriginalClone()</literal> pode ser usado para desabilitar a chamada ao construtor do clone da classe original.</para></listitem>
       <listitem><para><literal>disableAutoload()</literal> pode ser usado para desabilitar o <literal>__autoload()</literal> durante a geração da classe de dublê de teste.</para></listitem>
     </itemizedlist>
-    
+
     <para>
       Nos exemplos até agora temos retornado valores simples usando
-      <literal>willReturn($value)</literal>. Essa sintaxe curta é o mesmo que 
-      <literal>will($this->returnValue($value))</literal>. Podemos usar variações 
+      <literal>willReturn($value)</literal>. Essa sintaxe curta é o mesmo que
+      <literal>will($this->returnValue($value))</literal>. Podemos usar variações
       desta sintaxe longa para alcançar mais comportamento de esboço complexo.
     </para>
 
     <para>
-      Às vezes você quer retornar um dos argumentos de uma chamada de método 
+      Às vezes você quer retornar um dos argumentos de uma chamada de método
       (inalterada) como o resultado de uma chamada ao método esboçado.
-      <xref linkend="test-doubles.stubs.examples.StubTest3.php"/> mostra como você 
+      <xref linkend="test-doubles.stubs.examples.StubTest3.php"/> mostra como você
       pode conseguir isso usando <literal>returnArgument()</literal> em vez de
       <literal>returnValue()</literal>.
     </para>
@@ -233,19 +233,19 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // $stub->doSomething('foo') retorna 'foo'.
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') retorna 'bar'.
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Ao testar uma interface fluente, às vezes é útil fazer um método 
+      Ao testar uma interface fluente, às vezes é útil fazer um método
       esboçado retornar uma referência ao objeto esboçado.
-      <xref linkend="test-doubles.stubs.examples.StubTest4.php"/> mostra como você 
+      <xref linkend="test-doubles.stubs.examples.StubTest4.php"/> mostra como você
       pode usar <literal>returnSelf()</literal> para conseguir isso.
     </para>
 
@@ -271,18 +271,18 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() retorna $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Algumas vezes um método esboçado deveria retornar valores diferentes dependendo de 
+      Algumas vezes um método esboçado deveria retornar valores diferentes dependendo de
       uma lista predefinida de argumentos. Você pode usar
-      <literal>returnValueMap()</literal> para criar um mapa que associa 
+      <literal>returnValueMap()</literal> para criar um mapa que associa
       argumentos com valores de retorno correspondentes. Veja
-      <xref linkend="test-doubles.stubs.examples.StubTest5.php"/> para 
+      <xref linkend="test-doubles.stubs.examples.StubTest5.php"/> para
       ter um exemplo.
     </para>
 
@@ -313,20 +313,20 @@ class StubTest extends PHPUnit_Framework_TestCase
         $stub->method('doSomething')
              ->will($this->returnValueMap($map));
 
-        // $stub->doSomething() retorna diferentes valores dependendo do 
+        // $stub->doSomething() retorna diferentes valores dependendo do
         // argumento fornecido.
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Quando a chamada ao método esboçado deve retornar um valor calculado em vez de 
-      um fixo (veja <literal>returnValue()</literal>) ou um argumento (inalterado) 
+      Quando a chamada ao método esboçado deve retornar um valor calculado em vez de
+      um fixo (veja <literal>returnValue()</literal>) ou um argumento (inalterado)
       (veja <literal>returnArgument()</literal>), você pode usar
-      <literal>returnCallback()</literal> para que o método esboçado retorne o 
+      <literal>returnCallback()</literal> para que o método esboçado retorne o
       resultado da função ou método callback. Veja
       <xref linkend="test-doubles.stubs.examples.StubTest6.php"/> para ter um exemplo.
     </para>
@@ -353,17 +353,17 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) retorna str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      Uma alternativa mais simples para configurar um método callback pode ser 
-      especificar uma lista de valores de retorno desejados. Você pode fazer isso com 
+      Uma alternativa mais simples para configurar um método callback pode ser
+      especificar uma lista de valores de retorno desejados. Você pode fazer isso com
       o método <literal>onConsecutiveCalls()</literal>. Veja
-      <xref linkend="test-doubles.stubs.examples.StubTest7.php"/> para 
+      <xref linkend="test-doubles.stubs.examples.StubTest7.php"/> para
       ter um exemplo.
     </para>
 
@@ -372,7 +372,7 @@ class StubTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>will()</primary></indexterm>
       <indexterm><primary>onConsecutiveCalls()</primary></indexterm>
-      <title>Esboçando uma chamada de método para retornar uma lista de valores na 
+      <title>Esboçando uma chamada de método para retornar uma lista de valores na
       ordem especificada</title>
       <programlisting><![CDATA[<?php
 require_once 'SomeClass.php';
@@ -390,9 +390,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() retorna um valor diferente em cada vez
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -400,7 +400,7 @@ class StubTest extends PHPUnit_Framework_TestCase
 
 
     <para>
-      Em vez de retornar um valor, um método esboçado também pode causar uma 
+      Em vez de retornar um valor, um método esboçado também pode causar uma
       exceção. <xref linkend="test-doubles.stubs.examples.StubTest8.php"/>
       mostra como usar <literal>throwException()</literal> para fazer isso.
     </para>
@@ -434,23 +434,23 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      Alternativamente, você mesmo pode escrever um esboço enquanto melhora 
-      o design. Recursos amplamente utilizados são acessados através de uma única fachada, 
-      então você pode substituir facilmente o recurso pelo esboço. Por exemplo, 
-      em vez de ter chamadas diretas ao banco de dados espalhadas pelo código, 
-      você tem um único objeto <literal>Database</literal> que implementa a interface 
-      <literal>IDatabase</literal>. Então, você pode criar um esboço 
-      de implementação da <literal>IDatabase</literal> e usá-la em seus 
-      testes. Você pode até criar uma opção para executar os testes com o 
-      esboço do banco de dados ou com o banco de dados real, então você pode usar seus testes tanto 
-      para testes locais durante o desenvolvimento quanto para integração dos testes com o 
+      Alternativamente, você mesmo pode escrever um esboço enquanto melhora
+      o design. Recursos amplamente utilizados são acessados através de uma única fachada,
+      então você pode substituir facilmente o recurso pelo esboço. Por exemplo,
+      em vez de ter chamadas diretas ao banco de dados espalhadas pelo código,
+      você tem um único objeto <literal>Database</literal> que implementa a interface
+      <literal>IDatabase</literal>. Então, você pode criar um esboço
+      de implementação da <literal>IDatabase</literal> e usá-la em seus
+      testes. Você pode até criar uma opção para executar os testes com o
+      esboço do banco de dados ou com o banco de dados real, então você pode usar seus testes tanto
+      para testes locais durante o desenvolvimento quanto para integração dos testes com o
       banco de dados real.
     </para>
 
     <para>
-      Funcionalidades que precisam ser esboçadas tendem a se agrupar no mesmo 
-      objeto, aumentando a coesão. Por apresentar a funcionalidade com uma 
-      interface única e coerente, você reduz o acoplamento com o resto do 
+      Funcionalidades que precisam ser esboçadas tendem a se agrupar no mesmo
+      objeto, aumentando a coesão. Por apresentar a funcionalidade com uma
+      interface única e coerente, você reduz o acoplamento com o resto do
       sistema.
     </para>
   </section>
@@ -459,20 +459,20 @@ class StubTest extends PHPUnit_Framework_TestCase
     <title>Objetos Falsos</title>
 
     <para>
-      A prática de substituir um objeto por um dublê de teste que verifica 
-      expectativas, por exemplo asseverando que um método foi chamado, é 
+      A prática de substituir um objeto por um dublê de teste que verifica
+      expectativas, por exemplo asseverando que um método foi chamado, é
       conhecido como <emphasis>falsificação (mocking)</emphasis>.
     </para>
 
     <para>
       <indexterm><primary>Objeto Falso</primary></indexterm>
 
-      Você pode usar um <emphasis>objeto falso</emphasis> "como um ponto de observação 
-      que é usado para verificar as saídas indiretas do SST durante seu exercício. 
-      Tipicamente, o objeto falso também inclui a funcionalidade de um esboço de teste 
-      que deve retornar valores para o SST se ainda não tiver falhado 
-      nos testes, mas a ênfase está na verificação das saídas indiretas. 
-      Portanto, um objeto falso é muito mais que apenas um esboço de testes mais 
+      Você pode usar um <emphasis>objeto falso</emphasis> "como um ponto de observação
+      que é usado para verificar as saídas indiretas do SST durante seu exercício.
+      Tipicamente, o objeto falso também inclui a funcionalidade de um esboço de teste
+      que deve retornar valores para o SST se ainda não tiver falhado
+      nos testes, mas a ênfase está na verificação das saídas indiretas.
+      Portanto, um objeto falso é muito mais que apenas um esboço de testes mais
       asserções; é utilizado de uma forma fundamentalmente diferente".
     </para>
 
@@ -481,15 +481,15 @@ class StubTest extends PHPUnit_Framework_TestCase
 
       <para>
         Somente objetos falsos gerados no escopo de um teste irá ser verificado
-        automaticamente pelo PHPUnit. Objetos falsos gerados em provedores de dados, por 
+        automaticamente pelo PHPUnit. Objetos falsos gerados em provedores de dados, por
         exemplo, não serão verificados pelo PHPUnit.
       </para>
     </note>
-    
+
     <para>
       Aqui está um exemplo: suponha que queiramos testar se o método correto,
-      <literal>update()</literal> em nosso exemplo, é chamado em um objeto que 
-      observa outro objeto. <xref linkend="test-doubles.mock-objects.examples.SUT.php"/> 
+      <literal>update()</literal> em nosso exemplo, é chamado em um objeto que
+      observa outro objeto. <xref linkend="test-doubles.mock-objects.examples.SUT.php"/>
       mostra o código para as classes <literal>Subject</literal> e <literal>Observer</literal>
       que são parte do Sistema Sob Teste (SST).
     </para>
@@ -565,21 +565,21 @@ class Observer
       <indexterm><primary>Objeto Falso</primary></indexterm>
 
       <xref linkend="test-doubles.mock-objects.examples.SubjectTest.php" />
-      mostra como usar um objeto falso para testar a interação entre 
+      mostra como usar um objeto falso para testar a interação entre
       os objetos <literal>Subject</literal> e <literal>Observer</literal>.
     </para>
 
     <para>
-      Primeiro usamos o método <literal>getMock()</literal> que é fornecido pela 
-      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um objeto 
-      falso para ser o <literal>Observer</literal>. Já que fornecemos um vetor como 
-      segundo parâmetro (opcional) para o método <literal>getMock()</literal>, 
-      apenas o método <literal>update()</literal> da classe 
+      Primeiro usamos o método <literal>getMock()</literal> que é fornecido pela
+      classe <literal>PHPUnit_Framework_TestCase</literal> para configurar um objeto
+      falso para ser o <literal>Observer</literal>. Já que fornecemos um vetor como
+      segundo parâmetro (opcional) para o método <literal>getMock()</literal>,
+      apenas o método <literal>update()</literal> da classe
       <literal>Observer</literal> é substituído por uma implementação falsificada.
     </para>
 
     <para>
-      Porque estamos interessados em verificar se um método foi chamado, e com quais 
+      Porque estamos interessados em verificar se um método foi chamado, e com quais
       argumentos ele foi chamado, introduzimos os métodos <literal>expects()</literal> e
       <literal>with()</literal> para especificar como essa interação deve considerar.
     </para>
@@ -619,14 +619,14 @@ class SubjectTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      O método <literal>with()</literal> pode receber qualquer número de 
-      argumentos, correspondendo ao número de argumentos 
-      sendo falsos. Você pode especificar restrições mais avançadas 
+      O método <literal>with()</literal> pode receber qualquer número de
+      argumentos, correspondendo ao número de argumentos
+      sendo falsos. Você pode especificar restrições mais avançadas
       do que uma simples igualdade no argumento do método.
     </para>
 
     <example id="test-doubles.mock-objects.examples.MultiParameterTest.php">
-      <title>Testando se um método é chamado com um número de 
+      <title>Testando se um método é chamado com um número de
       argumentos restringidos de formas diferentes</title>
       <programlisting><![CDATA[<?php
 class SubjectTest extends PHPUnit_Framework_TestCase
@@ -657,11 +657,11 @@ class SubjectTest extends PHPUnit_Framework_TestCase
 }
 ?>]]></programlisting>
     </example>
-    
+
     <para>
-      O método <literal>withConsecutive()</literal> pode receber qualquer número de 
+      O método <literal>withConsecutive()</literal> pode receber qualquer número de
       vetores de argumentos, dependendo das chamados que você quer testar contra.
-      Cada vetor é uma lista de restrições correspondentes para os argumentos do 
+      Cada vetor é uma lista de restrições correspondentes para os argumentos do
       método falsificado, como em <literal>with()</literal>.
     </para>
 
@@ -692,9 +692,9 @@ class FooTest extends PHPUnit_Framework_TestCase
 
     <para>
       A restrição <literal>callback()</literal> pode ser usada para verificação de argumento
-      mais complexa. Essa restrição recebe um callback PHP como seu único 
-      argumento. O callback PHP receberá o argumento a ser verificado como 
-      seu único argumento e deverá retornar <literal>TRUE</literal> se o 
+      mais complexa. Essa restrição recebe um callback PHP como seu único
+      argumento. O callback PHP receberá o argumento a ser verificado como
+      seu único argumento e deverá retornar <literal>TRUE</literal> se o
       argumento passou a verificação e <literal>FALSE</literal> caso contrário.
     </para>
 
@@ -778,7 +778,7 @@ class FooTest extends PHPUnit_Framework_TestCase
       <xref linkend="appendixes.assertions.assertThat.tables.constraints"/>
       mostra as restrições que podem ser aplicadas aos argumentos do método e
       <xref linkend="test-doubles.mock-objects.tables.matchers"/>
-      mostra os comparados que estão disponíveis para especificar o número de 
+      mostra os comparados que estão disponíveis para especificar o número de
       invocações.
     </para>
 
@@ -824,22 +824,22 @@ class FooTest extends PHPUnit_Framework_TestCase
     <note>
       <para>
         O parâmetro <literal>$index</literal> para o comparador <literal>at()</literal>
-        se refere ao índice, iniciando em zero, em <emphasis>todas invocações 
-        de métodos</emphasis> para um objeto falsificado fornecido. Tenha cuidado ao 
-        usar este comparador, pois pode levar a testes frágeis que são muito 
+        se refere ao índice, iniciando em zero, em <emphasis>todas invocações
+        de métodos</emphasis> para um objeto falsificado fornecido. Tenha cuidado ao
+        usar este comparador, pois pode levar a testes frágeis que são muito
         intimamente ligados a detalhes de implementação específicos.
       </para>
     </note>
   </section>
-  
+
   <section id="test-doubles.prophecy">
     <title>Profecia</title>
 
     <para>
       <ulink url="https://github.com/phpspec/prophecy">Prophecy</ulink> é um
-      "framework PHP de falsificação de objetos muito poderoso e flexível, porém 
-      altamente opcional. Embora inicialmente criado para atender as necessidades do phpspec2, ele é 
-      flexível o suficiente para ser usado dentro de qualquer framework de teste por aí, com 
+      "framework PHP de falsificação de objetos muito poderoso e flexível, porém
+      altamente opcional. Embora inicialmente criado para atender as necessidades do phpspec2, ele é
+      flexível o suficiente para ser usado dentro de qualquer framework de teste por aí, com
       o mínimo de esforço".
     </para>
 
@@ -847,7 +847,7 @@ class FooTest extends PHPUnit_Framework_TestCase
       O PHPUnit tem suporte nativo para uso do Prophecy para criar dublês de testes
       desde a versão 4.5. <xref linkend="test-doubles.prophecy.examples.SubjectTest.php"/>
       mostra como o mesmo teste mostrado no <xref linkend="test-doubles.mock-objects.examples.SubjectTest.php"/>
-      pode ser expressado usando a filosofia do Prophecy de profecias e 
+      pode ser expressado usando a filosofia do Prophecy de profecias e
       revelações:
     </para>
 
@@ -895,7 +895,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>getMockForTrait()</primary></indexterm>
 
       O método <literal>getMockForTrait()</literal> retorna um objeto falsificado
-      que usa uma trait especificada. Todos métodos abstratos de uma dada trait 
+      que usa uma trait especificada. Todos métodos abstratos de uma dada trait
       são falsificados. Isto permite testar os métodos concretos de uma trait.
     </para>
 
@@ -922,18 +922,18 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
     </example>
-    
+
     <para>
       <indexterm><primary>getMockForAbstractClass()</primary></indexterm>
 
-      O método <literal>getMockForAbstractClass()</literal> retorna um objeto 
-      falso para uma classe abstrata. Todos os métodos abstratos da classe abstrata fornecida 
-      são falsificados. Isto permite testar os métodos concretos de uma 
+      O método <literal>getMockForAbstractClass()</literal> retorna um objeto
+      falso para uma classe abstrata. Todos os métodos abstratos da classe abstrata fornecida
+      são falsificados. Isto permite testar os métodos concretos de uma
       classe abstrata.
     </para>
 
@@ -960,7 +960,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -973,18 +973,18 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>getMockFromWsdl()</primary></indexterm>
 
-      Quando sua aplicação interage com um serviço web você quer testá-lo 
-      sem realmente interagir com o serviço web. Para tornar mais fáceis o esboço 
+      Quando sua aplicação interage com um serviço web você quer testá-lo
+      sem realmente interagir com o serviço web. Para tornar mais fáceis o esboço
       e falsificação dos serviços web, o <literal>getMockFromWsdl()</literal>
-      pode ser usado da mesma forma que o <literal>getMock()</literal> (veja acima). A única 
-      diferença é que <literal>getMockFromWsdl()</literal> retorna um esboço ou 
+      pode ser usado da mesma forma que o <literal>getMock()</literal> (veja acima). A única
+      diferença é que <literal>getMockFromWsdl()</literal> retorna um esboço ou
       falsificação baseado em uma descrição de um serviço web em WSDL e <literal>getMock()</literal>
       retorna um esboço ou falsificação baseado em uma classe ou interface PHP.
     </para>
 
     <para>
       <xref linkend="test-doubles.stubbing-and-mocking-web-services.examples.GoogleTest.php"/>
-      mostra como <literal>getMockFromWsdl()</literal> pode ser usado para esboçar, por 
+      mostra como <literal>getMockFromWsdl()</literal> pode ser usado para esboçar, por
       exemplo, o serviço web descrito em <filename>GoogleSearch.wsdl</filename>.
     </para>
 
@@ -1035,7 +1035,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() will now return a stubbed result and
          * the web service's doGoogleSearch() method will not be invoked.
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -1063,15 +1063,15 @@ class GoogleTest extends PHPUnit_Framework_TestCase
       <ulink url="https://github.com/mikey179/vfsStream">vfsStream</ulink>
       é um <ulink url="http://www.php.net/streams">stream wrapper</ulink> para um
       <ulink url="http://en.wikipedia.org/wiki/Virtual_file_system">sistema de arquivos virtual
-      </ulink> que pode ser útil em testes unitários para falsificar um sistema 
+      </ulink> que pode ser útil em testes unitários para falsificar um sistema
       de arquivos real.
     </para>
 
     <para>
-      Simplesmente adicione a dependência <literal>mikey179/vfsStream</literal> ao seu 
+      Simplesmente adicione a dependência <literal>mikey179/vfsStream</literal> ao seu
       arquivo <literal>composer.json</literal> do projeto se você usa o
-      <ulink url="https://getcomposer.org/">Composer</ulink> para gerenciar as 
-      dependências do seu projeto. Aqui é um exemplo simplório de um arquivo 
+      <ulink url="https://getcomposer.org/">Composer</ulink> para gerenciar as
+      dependências do seu projeto. Aqui é um exemplo simplório de um arquivo
       <literal>composer.json</literal> que apenas define uma dependência em ambiente de
       desenvolvimento para o PHPUnit 4.8 e vfsStream:
     </para>
@@ -1113,8 +1113,8 @@ class Example
     </example>
 
     <para>
-      Sem um sistema de arquivos virtual tal como o vfsStream não poderíamos testar o 
-      método <literal>setDirectory()</literal> isolado de influências 
+      Sem um sistema de arquivos virtual tal como o vfsStream não poderíamos testar o
+      método <literal>setDirectory()</literal> isolado de influências
       externas (veja <xref
       linkend="test-doubles.mocking-the-filesystem.examples.ExampleTest.php"/>).
     </para>
@@ -1136,10 +1136,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -1164,7 +1164,7 @@ class ExampleTest extends PHPUnit_Framework_TestCase
 
     <para>
       <xref linkend="test-doubles.mocking-the-filesystem.examples.ExampleTest2.php"/>
-      mostra como o vfsStream pode ser usado para falsificar o sistema de arquivos em um teste para uma 
+      mostra como o vfsStream pode ser usado para falsificar o sistema de arquivos em um teste para uma
       classe que interage com o sistema de arquivos.
     </para>
 
@@ -1185,10 +1185,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/pt_br/textui.xml
+++ b/src/4.8/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -401,7 +401,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict</literal></term>
         <listitem>
@@ -601,7 +601,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -612,7 +612,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -623,18 +623,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -644,7 +644,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -672,7 +672,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -681,7 +681,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -704,17 +704,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -730,16 +730,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -798,14 +798,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -817,7 +817,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -842,7 +842,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/4.8/pt_br/writing-tests-for-phpunit.xml
+++ b/src/4.8/pt_br/writing-tests-for-phpunit.xml
@@ -6,9 +6,9 @@
   <para>
     <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
-    <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" /> mostra 
-    como podemos escrever testes usando o PHPUnit que exercita operações de vetor do PHP. 
-    O exemplo introduz as convenções básicas e passos para escrever testes 
+    <xref linkend="writing-tests-for-phpunit.examples.StackTest.php" /> mostra
+    como podemos escrever testes usando o PHPUnit que exercita operações de vetor do PHP.
+    O exemplo introduz as convenções básicas e passos para escrever testes
     com o PHPUnit:
   </para>
 
@@ -27,14 +27,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -43,8 +43,8 @@ class StackTest extends PHPUnit_Framework_TestCase
   <blockquote>
     <attribution>Martin Fowler</attribution>
     <para>
-      Sempre que você estiver tentado a escrever algo em uma 
-      declaração <literal>print</literal> ou uma expressão depuradora, escreva 
+      Sempre que você estiver tentado a escrever algo em uma
+      declaração <literal>print</literal> ou uma expressão depuradora, escreva
       como um teste em vez disso.
     </para>
   </blockquote>
@@ -55,13 +55,13 @@ class StackTest extends PHPUnit_Framework_TestCase
     <blockquote>
       <attribution>Adrian Kuhn et. al.</attribution>
       <para>
-        Testes Unitários são primeiramente escritos como uma boa prática para ajudar desenvolvedores 
-        a identificar e corrigir defeitos, refatorar o código e servir como documentação 
-        para uma unidade de programa sob teste. Para conseguir esses benefícios, testes unitários 
-        idealmente deveriam cobrir todos os caminhos possíveis em um programa. Um teste unitário 
-        geralmente cobre um caminho específico em uma função ou método. Porém um 
-        método de teste não é necessariamente uma entidade encapsulada e independente. Às vezes 
-        existem dependências implícitas entre métodos de teste, escondidas no 
+        Testes Unitários são primeiramente escritos como uma boa prática para ajudar desenvolvedores
+        a identificar e corrigir defeitos, refatorar o código e servir como documentação
+        para uma unidade de programa sob teste. Para conseguir esses benefícios, testes unitários
+        idealmente deveriam cobrir todos os caminhos possíveis em um programa. Um teste unitário
+        geralmente cobre um caminho específico em uma função ou método. Porém um
+        método de teste não é necessariamente uma entidade encapsulada e independente. Às vezes
+        existem dependências implícitas entre métodos de teste, escondidas no
         cenário de implementação de um teste.
       </para>
     </blockquote>
@@ -69,9 +69,9 @@ class StackTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>Dependências de Testes</primary></indexterm>
 
-      O PHPUnit suporta a declaração explícita de dependências entre métodos de teste. 
-      Tais dependências não definem a ordem em que os métodos de teste 
-      devem ser executados, mas permitem o retorno de uma instância do 
+      O PHPUnit suporta a declaração explícita de dependências entre métodos de teste.
+      Tais dependências não definem a ordem em que os métodos de teste
+      devem ser executados, mas permitem o retorno de uma instância do
       ambiente do teste por um produtor e a passagem dele para os consumidores dependentes.
     </para>
 
@@ -84,8 +84,8 @@ class StackTest extends PHPUnit_Framework_TestCase
       <indexterm><primary>Anotação</primary></indexterm>
       <indexterm><primary>@depends</primary></indexterm>
 
-      <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> mostra 
-      como usar a anotação <literal>@depends</literal> para expressar 
+      <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php" /> mostra
+      como usar a anotação <literal>@depends</literal> para expressar
       dependências entre métodos de teste.
     </para>
 
@@ -97,7 +97,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -108,8 +108,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -119,16 +119,16 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
     </example>
 
     <para>
-      No exemplo acima, o primeiro teste, <literal>testEmpty()</literal>, 
-      cria um novo vetor e assegura que o mesmo é vazio. O teste então retorna 
+      No exemplo acima, o primeiro teste, <literal>testEmpty()</literal>,
+      cria um novo vetor e assegura que o mesmo é vazio. O teste então retorna
       o ambiente como resultado. O segundo teste, <literal>testPush()</literal>,
       depende de <literal>testEmpty()</literal> e lhe é passado o resultado do qual
       ele depende como um argumento. Finalmente, <literal>testPop()</literal>
@@ -138,9 +138,9 @@ class StackTest extends PHPUnit_Framework_TestCase
     <para>
       <indexterm><primary>Localização de Defeitos</primary></indexterm>
 
-      Para localizar defeitos rapidamente, queremos nossa atenção focada nas 
-      falhas relevantes dos testes. É por isso que o PHPUnit pula a execução de um teste 
-      quando um teste do qual ele depende falha. Isso melhora a localização de defeitos por 
+      Para localizar defeitos rapidamente, queremos nossa atenção focada nas
+      falhas relevantes dos testes. É por isso que o PHPUnit pula a execução de um teste
+      quando um teste do qual ele depende falha. Isso melhora a localização de defeitos por
       explorar as dependências entre os testes como mostrado em
       <xref linkend="writing-tests-for-phpunit.examples.DependencyFailureTest.php" />.
     </para>
@@ -152,7 +152,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -163,7 +163,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
     }
 }
 ?>]]></programlisting>
-    
+
       <screen><userinput>phpunit --verbose DependencyFailureTest</userinput><![CDATA[
 PHPUnit 4.8.0 by Sebastian Bergmann and contributors.
 
@@ -189,19 +189,19 @@ Tests: 1, Assertions: 1, Failures: 1, Skipped: 1.]]></screen>
     </example>
 
     <para>
-      Um teste pode ter mais de uma anotação <literal>@depends</literal>. 
-      O PHPUnit não muda a ordem em que os testes são executados, portanto você deve 
-      se certificar de que as dependências de um teste podem realmente ser encontradas antes de 
+      Um teste pode ter mais de uma anotação <literal>@depends</literal>.
+      O PHPUnit não muda a ordem em que os testes são executados, portanto você deve
+      se certificar de que as dependências de um teste podem realmente ser encontradas antes de
       executar o teste.
     </para>
-    
+
     <para>
       Um teste que tem mais de uma anotação <literal>@depends</literal>
-      vai obter um ambiente a partir do primeiro produtor como o primeiro argumento, um ambiente 
+      vai obter um ambiente a partir do primeiro produtor como o primeiro argumento, um ambiente
       a partir do segundo produtor como o segundo argumento, e assim por diante.
       Veja <xref linkend="writing-tests-for-phpunit.examples.MultipleDependencies.php" />
     </para>
-    
+
     <example id="writing-tests-for-phpunit.examples.MultipleDependencies.php">
       <title>Teste com múltiplas dependências</title>
       <programlisting><![CDATA[<?php
@@ -209,13 +209,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -225,7 +225,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -250,18 +250,18 @@ OK (3 tests, 3 assertions)]]></screen>
     <para>
       <indexterm><primary>Anotação</primary></indexterm>
       <indexterm><primary>@dataProvider</primary></indexterm>
-      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser 
+      Um método de teste pode aceitar argumentos arbitrários. Esses argumentos devem ser
       fornecidos por um método provedor de dados (<literal>additionProvider()</literal> em
       <xref linkend="writing-tests-for-phpunit.data-providers.examples.DataTest.php" />).
-      O método provedor de dados a ser usado é especificado usando a 
+      O método provedor de dados a ser usado é especificado usando a
       anotação <literal>@dataProvider</literal>.
     </para>
 
     <para>
-      Um método provedor de dados deve ser <literal>public</literal> e ou retornar 
-      um vetor de vetores ou um objeto que implementa a interface <literal>Iterator</literal> 
-      e produz um vetor para cada passo da iteração. Para cada vetor que 
-      é parte da coleção o método de teste será chamado com os conteúdos 
+      Um método provedor de dados deve ser <literal>public</literal> e ou retornar
+      um vetor de vetores ou um objeto que implementa a interface <literal>Iterator</literal>
+      e produz um vetor para cada passo da iteração. Para cada vetor que
+      é parte da coleção o método de teste será chamado com os conteúdos
       do vetor como seus argumentos.
     </para>
 
@@ -275,7 +275,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -320,7 +320,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -396,13 +396,13 @@ class CsvFileIterator implements Iterator {
       <indexterm><primary>@depends</primary></indexterm>
 
       Quando um teste recebe uma entrada tanto de um método <literal>@dataProvider</literal>
-      quanto de um ou mais testes dos quais ele <literal>@depends</literal>, os 
-      argumentos do provedor de dados virão antes daqueles dos quais ele 
-      é dependente. Os argumentos dos quais o teste depende serão os 
+      quanto de um ou mais testes dos quais ele <literal>@depends</literal>, os
+      argumentos do provedor de dados virão antes daqueles dos quais ele
+      é dependente. Os argumentos dos quais o teste depende serão os
       mesmos para cada conjunto de dados.
       Veja <xref linkend="writing-tests-for-phpunit.data-providers.examples.DependencyAndDataProviderCombo.php"/>
     </para>
-    
+
     <example id="writing-tests-for-phpunit.data-providers.examples.DependencyAndDataProviderCombo.php">
       <title>Combinação de @depends e @dataProvider no mesmo teste</title>
       <programlisting><![CDATA[<?php
@@ -415,13 +415,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -432,7 +432,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -473,9 +473,9 @@ Tests: 4, Assertions: 4, Failures: 1.
         <indexterm><primary>@dataProvider</primary></indexterm>
         <indexterm><primary>@depends</primary></indexterm>
 
-        Quando um teste depende de um teste que usa provedores de dados, o teste dependente 
-        será executado quando o teste do qual ele depende for bem sucedido em pelo 
-        menos um conjunto de dados. O resultado de um teste que usa provedores de dados não pode 
+        Quando um teste depende de um teste que usa provedores de dados, o teste dependente
+        será executado quando o teste do qual ele depende for bem sucedido em pelo
+        menos um conjunto de dados. O resultado de um teste que usa provedores de dados não pode
         ser injetado dentro de um teste dependente.
       </para>
     </note>
@@ -488,8 +488,8 @@ Tests: 4, Assertions: 4, Failures: 1.
 
         Todos provedores de dados são executados antes da chamada ao método estático <literal>setUpBeforeClass</literal>
         e a primeira chamada ao método <literal>setUp</literal>.
-        Por isso você não pode acessar quaisquer variáveis que criar 
-        ali de dentro de um provedor de dados. Isto é necessário para que o PHPUnit seja capaz 
+        Por isso você não pode acessar quaisquer variáveis que criar
+        ali de dentro de um provedor de dados. Isto é necessário para que o PHPUnit seja capaz
         de calcular o número total de testes.
       </para>
     </note>
@@ -503,7 +503,7 @@ Tests: 4, Assertions: 4, Failures: 1.
       <indexterm><primary>@expectedException</primary></indexterm>
 
       <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest.php" />
-      mostra como usar a anotação <literal>@expectedException</literal> para 
+      mostra como usar a anotação <literal>@expectedException</literal> para
       testar se uma exceção é lançada dentro do código de teste.
     </para>
 
@@ -547,7 +547,7 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       Adicionalmente, você pode usar <literal>@expectedExceptionMessage</literal>,
       <literal>@expectedExceptionMessageRegExp</literal> e
       <literal>@expectedExceptionCode</literal> em combinação com
-      <literal>@expectedException</literal> para testar a mensagem de exceção e 
+      <literal>@expectedException</literal> para testar a mensagem de exceção e
       o código de exceção como mostrado em
       <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest2.php" />.
     </para>
@@ -615,16 +615,16 @@ Tests: 3, Assertions: 6, Failures: 3.]]></screen>
     <para>
       Mais exemplos de <literal>@expectedExceptionMessage</literal>,
       <literal>@expectedExceptionMessageRegExp</literal> e
-      <literal>@expectedExceptionCode</literal> são mostrados em 
+      <literal>@expectedExceptionCode</literal> são mostrados em
       <xref linkend="appendixes.annotations.expectedExceptionMessage"/>,
       <xref linkend="appendixes.annotations.expectedExceptionMessageRegExp"/> e
       <xref linkend="appendixes.annotations.expectedExceptionCode"/> respectivamente.
     </para>
-    
+
 
     <para>
       Alternativamente, você pode usar o método <literal>setExpectedException()</literal> ou
-      <literal>setExpectedExceptionRegExp()</literal> para definir a exceção esperada 
+      <literal>setExpectedExceptionRegExp()</literal> para definir a exceção esperada
       como mostrado em <xref linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest3.php" />.
     </para>
 
@@ -750,8 +750,8 @@ class ExceptionTest extends PHPUnit_Framework_TestCase {
       Se o código que deve lançar uma exceção no <xref
       linkend="writing-tests-for-phpunit.exceptions.examples.ExceptionTest4.php" />
       não lançá-la, a chamada subsequente ao
-      <literal>fail()</literal> vai parar o teste e sinalizar um problema com o 
-      teste. Se a exceção esperada é lançada, o bloco <literal>catch</literal> 
+      <literal>fail()</literal> vai parar o teste e sinalizar um problema com o
+      teste. Se a exceção esperada é lançada, o bloco <literal>catch</literal>
       será executado, e o teste terminará com sucesso.
     </para>
   </section>
@@ -765,21 +765,21 @@ class ExceptionTest extends PHPUnit_Framework_TestCase {
       <indexterm><primary>PHP Warning</primary></indexterm>
       <indexterm><primary>PHPUnit_Framework_Error</primary></indexterm>
 
-      Por padrão, o PHPUnit converte os erros, avisos e notificações do PHP que são 
-      disparados durante a execução de um teste para uma exceção. Usando essas 
-      exceções, você pode, por exemplo, esperar que um teste dispare um erro PHP como 
+      Por padrão, o PHPUnit converte os erros, avisos e notificações do PHP que são
+      disparados durante a execução de um teste para uma exceção. Usando essas
+      exceções, você pode, por exemplo, esperar que um teste dispare um erro PHP como
       mostrado no <xref linkend="writing-tests-for-phpunit.exceptions.examples.ErrorTest.php" />.
     </para>
 
     <note>
       <para>
         A configuração em tempo de execução <literal>error_reporting</literal> do PHP pode
-        limitar quais erros o PHPUnit irá converter para exceções. Se você 
+        limitar quais erros o PHPUnit irá converter para exceções. Se você
         está tendo problemas com essa funcionalidade, certifique-se que o PHP não está configurado para
         suprimir os tipos de erros que você esta testando.
       </para>
     </note>
-    
+
     <example id="writing-tests-for-phpunit.exceptions.examples.ErrorTest.php">
       <title>Esperando um erro PHP usando @expectedException</title>
       <programlisting><![CDATA[<?php
@@ -809,14 +809,14 @@ OK (1 test, 1 assertion)</screen>
       <indexterm><primary>PHPUnit_Framework_Error_Warning</primary></indexterm>
 
       <literal>PHPUnit_Framework_Error_Notice</literal> e
-      <literal>PHPUnit_Framework_Error_Warning</literal> representam notificações 
+      <literal>PHPUnit_Framework_Error_Warning</literal> representam notificações
       e avisos do PHP, respectivamente.
     </para>
 
     <note>
       <para>
-        Você deve ser o mais específico possível quando testar exceções. Testar 
-        por classes que são muito genéricas pode causar efeitos colaterais 
+        Você deve ser o mais específico possível quando testar exceções. Testar
+        por classes que são muito genéricas pode causar efeitos colaterais
         indesejáveis. Da mesma forma, testar para a classe <literal>Exception</literal>
         com <literal>@expectedException</literal> ou
         <literal>setExpectedException()</literal> não é mais permitido.
@@ -825,8 +825,8 @@ OK (1 test, 1 assertion)</screen>
 
     <para>
         Ao testar com funções que dependem de funções php que disparam erros como
-        <literal>fopen</literal> pode ser útil algumas vezes usar a supressão de 
-        erros enquanto testa. Isso permite a você verificar os valores retornados por 
+        <literal>fopen</literal> pode ser útil algumas vezes usar a supressão de
+        erros enquanto testa. Isso permite a você verificar os valores retornados por
         suprimir notificações que levariam a uma
         <literal>PHPUnit_Framework_Error_Notice</literal> phpunit.
         <example id="writing-tests-for-phpunit.exceptions.examples.TriggerErrorReturnValue.php">
@@ -837,7 +837,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -872,19 +872,19 @@ OK (1 test, 1 assertion)</screen>
     <title>Testando Saídas</title>
 
     <para>
-      Às vezes você quer assegurar que a execução de um método, por 
-      exemplo, gere uma saída esperada (via <literal>echo</literal> ou 
-      <literal>print</literal>, por exemplo). A 
+      Às vezes você quer assegurar que a execução de um método, por
+      exemplo, gere uma saída esperada (via <literal>echo</literal> ou
+      <literal>print</literal>, por exemplo). A
       classe <literal>PHPUnit_Framework_TestCase</literal> usa a funcionalidade
       <ulink url="http://www.php.net/manual/en/ref.outcontrol.php">Output
-      Buffering</ulink> do PHP para fornecer a funcionalidade que é 
+      Buffering</ulink> do PHP para fornecer a funcionalidade que é
       necessária para isso.
     </para>
 
     <para>
       <xref linkend="writing-tests-for-phpunit.output.examples.OutputTest.php" />
-      mostra como usar o método <literal>expectOutputString()</literal> para 
-      definir a saída esperada. Se essa saída esperada não for gerada, o 
+      mostra como usar o método <literal>expectOutputString()</literal> para
+      definir a saída esperada. Se essa saída esperada não for gerada, o
       teste será contado como uma falha.
     </para>
 
@@ -971,7 +971,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     <title>Saída de Erro</title>
 
     <para>
-      Sempre que um teste falha o PHPUnit faz o melhor para fornecer a você o 
+      Sempre que um teste falha o PHPUnit faz o melhor para fornecer a você o
       máximo possível de conteúdo que possa ajudar a identificar o problema.
     </para>
 
@@ -981,7 +981,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -1018,12 +1018,12 @@ FAILURES!
 Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     </example>
     <para>
-      Neste exemplo apenas um dos valores dos vetores diferem e os outros valores 
+      Neste exemplo apenas um dos valores dos vetores diferem e os outros valores
       são exibidos para fornecer o contexto onde o erro ocorreu.
     </para>
 
     <para>
-      Quando a saída gerada for longa demais para ler o PHPUnit vai quebrá-la 
+      Quando a saída gerada for longa demais para ler o PHPUnit vai quebrá-la
       e fornecer algumas linhas de contexto ao redor de cada diferença.
     </para>
     <example id="writing-tests-for-phpunit.error-output.examples.LongArrayDiffTest.php">
@@ -1032,7 +1032,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -1071,8 +1071,8 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Casos Extremos</title>
 
       <para>
-        Quando uma comparação falha o PHPUnit cria uma representação textual da 
-        entrada de valores e as compara. Devido a essa implementação uma diferenciação 
+        Quando uma comparação falha o PHPUnit cria uma representação textual da
+        entrada de valores e as compara. Devido a essa implementação uma diferenciação
         pode mostrar mais problemas do que realmente existem.
       </para>
 
@@ -1087,7 +1087,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );
@@ -1128,7 +1128,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       </example>
       <para>
         Neste exemplo a diferença no primeiro índice entre
-        <literal>1</literal> e <literal>'1'</literal> é 
+        <literal>1</literal> e <literal>'1'</literal> é
         relatada ainda que o assertEquals considere os valores como uma combinação.
       </para>
 

--- a/src/4.8/zh_cn/assertions.xml
+++ b/src/4.8/zh_cn/assertions.xml
@@ -19,7 +19,7 @@ class ArrayHasKeyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertArrayHasKey('foo', array('bar' => 'baz'));
+        self::assertArrayHasKey('foo', array('bar' => 'baz'));
     }
 }
 ?>]]></programlisting>
@@ -56,7 +56,7 @@ class ClassHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasAttribute('foo', 'stdClass');
+        self::assertClassHasAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -93,7 +93,7 @@ class ClassHasStaticAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertClassHasStaticAttribute('foo', 'stdClass');
+        self::assertClassHasStaticAttribute('foo', 'stdClass');
     }
 }
 ?>]]></programlisting>
@@ -133,7 +133,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains(4, array(1, 2, 3));
+        self::assertContains(4, array(1, 2, 3));
     }
 }
 ?>]]></programlisting>
@@ -165,7 +165,7 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('baz', 'foobar');
+        self::assertContains('baz', 'foobar');
     }
 }
 ?>]]></programlisting>
@@ -194,12 +194,12 @@ class ContainsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContains('foo', 'FooBar');
+        self::assertContains('foo', 'FooBar');
     }
 
     public function testOK()
     {
-        $this->assertContains('foo', 'FooBar', '', true);
+        self::assertContains('foo', 'FooBar', '', true);
     }
 }
 ?>]]></programlisting>
@@ -240,7 +240,7 @@ class ContainsOnlyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnly('string', array('1', '2', 3));
+        self::assertContainsOnly('string', array('1', '2', 3));
     }
 }
 ?>]]></programlisting>
@@ -278,7 +278,7 @@ class ContainsOnlyInstancesOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
+        self::assertContainsOnlyInstancesOf('Foo', array(new Foo(), new Bar(), new Foo()));
     }
 }
 ?>]]></programlisting>
@@ -314,7 +314,7 @@ class CountTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertCount(0, array('foo'));
+        self::assertCount(0, array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -354,7 +354,7 @@ class EmptyTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEmpty(array('foo'));
+        self::assertEmpty(array('foo'));
     }
 }
 ?>]]></programlisting>
@@ -392,7 +392,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $expected = new DOMElement('foo');
         $actual = new DOMElement('bar');
 
-        $this->assertEqualXMLStructure($expected, $actual);
+        self::assertEqualXMLStructure($expected, $actual);
     }
 
     public function testFailureWithDifferentNodeAttributes()
@@ -403,7 +403,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo/>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild, TRUE
         );
     }
@@ -416,7 +416,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><bar/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -429,7 +429,7 @@ class EqualXMLStructureTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<foo><baz/><baz/><baz/></foo>');
 
-        $this->assertEqualXMLStructure(
+        self::assertEqualXMLStructure(
           $expected->firstChild, $actual->firstChild
         );
     }
@@ -498,17 +498,17 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(1, 0);
+        self::assertEquals(1, 0);
     }
 
     public function testFailure2()
     {
-        $this->assertEquals('bar', 'baz');
+        self::assertEquals('bar', 'baz');
     }
 
     public function testFailure3()
     {
-        $this->assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
+        self::assertEquals("foo\nbar\nbaz\n", "foo\nbah\nbaz\n");
     }
 }
 ?>]]></programlisting>
@@ -565,12 +565,12 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testSuccess()
     {
-        $this->assertEquals(1.0, 1.1, '', 0.2);
+        self::assertEquals(1.0, 1.1, '', 0.2);
     }
 
     public function testFailure()
     {
-        $this->assertEquals(1.0, 1.1);
+        self::assertEquals(1.0, 1.1);
     }
 }
 ?>]]></programlisting>
@@ -607,7 +607,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual = new DOMDocument;
         $actual->loadXML('<bar><foo/></bar>');
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -656,7 +656,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
         $actual->foo = 'bar';
         $actual->baz = 'bar';
 
-        $this->assertEquals($expected, $actual);
+        self::assertEquals($expected, $actual);
     }
 }
 ?>]]></programlisting>
@@ -697,7 +697,7 @@ class EqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
+        self::assertEquals(array('a', 'b', 'c'), array('a', 'c', 'd'));
     }
 }
 ?>]]></programlisting>
@@ -743,7 +743,7 @@ class FalseTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFalse(TRUE);
+        self::assertFalse(TRUE);
     }
 }
 ?>]]></programlisting>
@@ -780,7 +780,7 @@ class FileEqualsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileEquals('/home/sb/expected', '/home/sb/actual');
+        self::assertFileEquals('/home/sb/expected', '/home/sb/actual');
     }
 }
 ?>]]></programlisting>
@@ -823,7 +823,7 @@ class FileExistsTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertFileExists('/path/to/file');
+        self::assertFileExists('/path/to/file');
     }
 }
 ?>]]></programlisting>
@@ -860,7 +860,7 @@ class GreaterThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThan(2, 1);
+        self::assertGreaterThan(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -897,7 +897,7 @@ class GreatThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertGreaterThanOrEqual(2, 1);
+        self::assertGreaterThanOrEqual(2, 1);
     }
 }
 ?>]]></programlisting>
@@ -937,7 +937,7 @@ class InstanceOfTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInstanceOf('RuntimeException', new Exception);
+        self::assertInstanceOf('RuntimeException', new Exception);
     }
 }
 ?>]]></programlisting>
@@ -977,7 +977,7 @@ class InternalTypeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertInternalType('string', 42);
+        self::assertInternalType('string', 42);
     }
 }
 ?>]]></programlisting>
@@ -1013,7 +1013,7 @@ class JsonFileEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonFileEqualsJsonFile(
+        self::assertJsonFileEqualsJsonFile(
           'path/to/fixture/file', 'path/to/actual/file');
     }
 }
@@ -1050,7 +1050,7 @@ class JsonStringEqualsJsonFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonFile(
+        self::assertJsonStringEqualsJsonFile(
           'path/to/fixture/file', json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1088,7 +1088,7 @@ class JsonStringEqualsJsonStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertJsonStringEqualsJsonString(
+        self::assertJsonStringEqualsJsonString(
           json_encode(array("Mascott" => "Tux")), json_encode(array("Mascott" => "ux"))
         );
     }
@@ -1134,7 +1134,7 @@ class LessThanTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThan(1, 2);
+        self::assertLessThan(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1171,7 +1171,7 @@ class LessThanOrEqualTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertLessThanOrEqual(1, 2);
+        self::assertLessThanOrEqual(1, 2);
     }
 }
 ?>]]></programlisting>
@@ -1208,7 +1208,7 @@ class NullTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertNull('foo');
+        self::assertNull('foo');
     }
 }
 ?>]]></programlisting>
@@ -1245,7 +1245,7 @@ class ObjectHasAttributeTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertObjectHasAttribute('foo', new stdClass);
+        self::assertObjectHasAttribute('foo', new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1282,7 +1282,7 @@ class RegExpTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertRegExp('/foo/', 'bar');
+        self::assertRegExp('/foo/', 'bar');
     }
 }
 ?>]]></programlisting>
@@ -1319,7 +1319,7 @@ class StringMatchesFormatTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormat('%i', 'foo');
+        self::assertStringMatchesFormat('%i', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1370,7 +1370,7 @@ class StringMatchesFormatFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
+        self::assertStringMatchesFormatFile('/path/to/expected.txt', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1411,7 +1411,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame('2204', 2204);
+        self::assertSame('2204', 2204);
     }
 }
 ?>]]></programlisting>
@@ -1443,7 +1443,7 @@ class SameTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertSame(new stdClass, new stdClass);
+        self::assertSame(new stdClass, new stdClass);
     }
 }
 ?>]]></programlisting>
@@ -1480,7 +1480,7 @@ class StringEndsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEndsWith('suffix', 'foo');
+        self::assertStringEndsWith('suffix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1517,7 +1517,7 @@ class StringEqualsFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringEqualsFile('/home/sb/expected', 'actual');
+        self::assertStringEqualsFile('/home/sb/expected', 'actual');
     }
 }
 ?>]]></programlisting>
@@ -1560,7 +1560,7 @@ class StringStartsWithTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertStringStartsWith('prefix', 'foo');
+        self::assertStringStartsWith('prefix', 'foo');
     }
 }
 ?>]]></programlisting>
@@ -1601,7 +1601,7 @@ class BiscuitTest extends PHPUnit_Framework_TestCase
         $theBiscuit = new Biscuit('Ginger');
         $myBiscuit  = new Biscuit('Ginger');
 
-        $this->assertThat(
+        self::assertThat(
           $theBiscuit,
           $this->logicalNot(
             $this->equalTo($myBiscuit)
@@ -1794,7 +1794,7 @@ class TrueTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 }
 ?>]]></programlisting>
@@ -1831,7 +1831,7 @@ class XmlFileEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlFileEqualsXmlFile(
+        self::assertXmlFileEqualsXmlFile(
           '/home/sb/expected.xml', '/home/sb/actual.xml');
     }
 }
@@ -1877,7 +1877,7 @@ class XmlStringEqualsXmlFileTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlFile(
+        self::assertXmlStringEqualsXmlFile(
           '/home/sb/expected.xml', '<foo><baz/></foo>');
     }
 }
@@ -1923,7 +1923,7 @@ class XmlStringEqualsXmlStringTest extends PHPUnit_Framework_TestCase
 {
     public function testFailure()
     {
-        $this->assertXmlStringEqualsXmlString(
+        self::assertXmlStringEqualsXmlString(
           '<foo><bar/></foo>', '<foo><baz/></foo>');
     }
 }

--- a/src/4.8/zh_cn/code-coverage-analysis.xml
+++ b/src/4.8/zh_cn/code-coverage-analysis.xml
@@ -175,7 +175,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testBalanceIsInitiallyZero()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 
     /**
@@ -188,7 +188,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -206,7 +206,7 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
         }
 
         catch (BankAccountException $e) {
-            $this->assertEquals(0, $this->ba->getBalance());
+            self::assertEquals(0, $this->ba->getBalance());
 
             return;
         }
@@ -221,11 +221,11 @@ class BankAccountTest extends PHPUnit_Framework_TestCase
      */
     public function testDepositWithdrawMoney()
     {
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
         $this->ba->depositMoney(1);
-        $this->assertEquals(1, $this->ba->getBalance());
+        self::assertEquals(1, $this->ba->getBalance());
         $this->ba->withdrawMoney(1);
-        $this->assertEquals(0, $this->ba->getBalance());
+        self::assertEquals(0, $this->ba->getBalance());
     }
 }
 ?>]]></programlisting>
@@ -255,7 +255,7 @@ class GuestbookIntegrationTest extends PHPUnit_Extensions_Database_TestCase
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
 
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]>
@@ -286,6 +286,6 @@ if (false) {
     this_call_will_never_show_up_as_covered();
 }
 ?>]]></programlisting>
-    </example>      
+    </example>
   </section>
 </chapter>

--- a/src/4.8/zh_cn/database.xml
+++ b/src/4.8/zh_cn/database.xml
@@ -98,7 +98,7 @@ class MyTest extends PHPUnit_Framework_TestCase
 {
     public function testCalculate()
     {
-        $this->assertEquals(2, 1 + 1);
+        self::assertEquals(2, 1 + 1);
     }
 }
 ?>]]></programlisting>
@@ -671,7 +671,7 @@ class ConnectionTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testGetRowCount()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'));
     }
 }
 ?>]]></programlisting>
@@ -689,12 +689,12 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
 {
     public function testAddEntry()
     {
-        $this->assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
+        self::assertEquals(2, $this->getConnection()->getRowCount('guestbook'), "Pre-Condition");
 
         $guestbook = new Guestbook();
         $guestbook->addEntry("suzy", "Hello world!");
 
-        $this->assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
+        self::assertEquals(3, $this->getConnection()->getRowCount('guestbook'), "Inserting failed");
     }
 }
 ?>]]></programlisting>
@@ -716,7 +716,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("expectedBook.xml")
                               ->getTable("guestbook");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -759,7 +759,7 @@ class ComplexQueryTest extends PHPUnit_Extensions_Database_TestCase
         );
         $expectedTable = $this->createFlatXmlDataSet("complexQueryAssertion.xml")
                               ->getTable("myComplexQuery");
-        $this->assertTablesEqual($expectedTable, $queryTable);
+        self::assertTablesEqual($expectedTable, $queryTable);
     }
 }
 ?>]]></programlisting>
@@ -777,7 +777,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
     {
         $dataSet = $this->getConnection()->createDataSet(array('guestbook'));
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>
@@ -793,7 +793,7 @@ class DataSetAssertionsTest extends PHPUnit_Extensions_Database_TestCase
         $dataSet->addTable('guestbook', 'SELECT id, content, user FROM guestbook'); // additional tables
         $expectedDataSet = $this->createFlatXmlDataSet('guestbook.xml');
 
-        $this->assertDataSetsEqual($expectedDataSet, $dataSet);
+        self::assertDataSetsEqual($expectedDataSet, $dataSet);
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/zh_cn/fixtures.xml
+++ b/src/4.8/zh_cn/fixtures.xml
@@ -29,21 +29,21 @@ class StackTest extends PHPUnit_Framework_TestCase
 
     public function testEmpty()
     {
-        $this->assertTrue(empty($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 
     public function testPush()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', $this->stack[count($this->stack)-1]);
-        $this->assertFalse(empty($this->stack));
+        self::assertEquals('foo', $this->stack[count($this->stack)-1]);
+        self::assertFalse(empty($this->stack));
     }
 
     public function testPop()
     {
         array_push($this->stack, 'foo');
-        $this->assertEquals('foo', array_pop($this->stack));
-        $this->assertTrue(empty($this->stack));
+        self::assertEquals('foo', array_pop($this->stack));
+        self::assertTrue(empty($this->stack));
     }
 }
 ?>]]></programlisting>
@@ -92,13 +92,13 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
     public function testOne()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(TRUE);
+        self::assertTrue(TRUE);
     }
 
     public function testTwo()
     {
         fwrite(STDOUT, __METHOD__ . "\n");
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     protected function assertPostConditions()

--- a/src/4.8/zh_cn/incomplete-and-skipped-tests.xml
+++ b/src/4.8/zh_cn/incomplete-and-skipped-tests.xml
@@ -26,7 +26,7 @@ class SampleTest extends PHPUnit_Framework_TestCase
     public function testSomething()
     {
         // 可选：如果愿意，在这里随便测试点什么。
-        $this->assertTrue(TRUE, '这应该已经是能正常工作的。');
+        self::assertTrue(TRUE, '这应该已经是能正常工作的。');
 
         // 在这里停止，并将此测试标记为未完成。
         $this->markTestIncomplete(

--- a/src/4.8/zh_cn/selenium.xml
+++ b/src/4.8/zh_cn/selenium.xml
@@ -10,12 +10,12 @@
       <indexterm><primary>Selenium Server</primary></indexterm>
 
       <ulink url="http://seleniumhq.org/">Selenium Server</ulink>是一个测试工具，它允许用任意主流浏览器为任意 HTTP 网站上的用任意编程语言开发的 web 应用程序编写自动用户界面测试。它通过操作系统来驱动浏览器进程来执行自动测试。Selenium 测试直接运行于某个浏览器中，就和真实用户一样。这些测试既可以用于 <emphasis>验收测试</emphasis>（通过在集成好的系统中执行较高层面的测试而非仅对系统的各个单元分别单独测试。）也可以用于<emphasis>浏览器兼容性测试</emphasis>（通过在不同的操作系统与浏览器上对 web 应用程序进行测试）。</para>
-    
+
     <para>PHPUnit_Selenium 只支持 Selenium 2.x 服务器的脚本。服务器可以通过从 1.x 就提供的传统 Selenium RC API 访问，也可以从 PHPUnit_Selenium 1.2 用 WebDriver API（部分实现）访问。</para>
     <para>这个决定的原因是 Selenium 2 是向后兼容的，而 Selenium RC 已经不再维护了。</para>
 
   </section>
-  
+
   <section id="selenium.installation">
     <title>安装</title>
 
@@ -56,7 +56,7 @@ class WebTest extends PHPUnit_Extensions_Selenium2TestCase
     public function testTitle()
     {
         $this->url('http://www.example.com/');
-        $this->assertEquals('Example WWW Page', $this->title());
+        self::assertEquals('Example WWW Page', $this->title());
     }
 
 }
@@ -111,7 +111,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -198,7 +198,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example WWW Page');
+        self::assertTitle('Example WWW Page');
     }
 }
 ?>]]></programlisting>
@@ -270,7 +270,7 @@ class WebTest extends PHPUnit_Extensions_SeleniumTestCase
     public function testTitle()
     {
         $this->open('http://www.example.com/');
-        $this->assertTitle('Example Web Page');
+        self::assertTitle('Example Web Page');
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/zh_cn/test-doubles.xml
+++ b/src/4.8/zh_cn/test-doubles.xml
@@ -76,7 +76,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->willReturn('foo');
 
         // 现在调用 $stub->doSomething() 将返回 'foo'。
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -109,7 +109,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->willReturn('foo');
 
         // 现在调用 $stub->doSomething() 将返回 'foo'。
-        $this->assertEquals('foo', $stub->doSomething());
+        self::assertEquals('foo', $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -152,10 +152,10 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnArgument(0));
 
         // stub->doSomething('foo') 返回 'foo'
-        $this->assertEquals('foo', $stub->doSomething('foo'));
+        self::assertEquals('foo', $stub->doSomething('foo'));
 
         // $stub->doSomething('bar') 返回 'bar'
-        $this->assertEquals('bar', $stub->doSomething('bar'));
+        self::assertEquals('bar', $stub->doSomething('bar'));
     }
 }
 ?>]]></programlisting>
@@ -185,7 +185,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnSelf());
 
         // $stub->doSomething() 返回 $stub
-        $this->assertSame($stub, $stub->doSomething());
+        self::assertSame($stub, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -221,8 +221,8 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnValueMap($map));
 
         // $stub->doSomething() 根据提供的参数返回不同的值。
-        $this->assertEquals('d', $stub->doSomething('a', 'b', 'c'));
-        $this->assertEquals('h', $stub->doSomething('e', 'f', 'g'));
+        self::assertEquals('d', $stub->doSomething('a', 'b', 'c'));
+        self::assertEquals('h', $stub->doSomething('e', 'f', 'g'));
     }
 }
 ?>]]></programlisting>
@@ -252,7 +252,7 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->returnCallback('str_rot13'));
 
         // $stub->doSomething($argument) 返回 str_rot13($argument)
-        $this->assertEquals('fbzrguvat', $stub->doSomething('something'));
+        self::assertEquals('fbzrguvat', $stub->doSomething('something'));
     }
 }
 ?>]]></programlisting>
@@ -282,9 +282,9 @@ class StubTest extends PHPUnit_Framework_TestCase
              ->will($this->onConsecutiveCalls(2, 3, 5, 7));
 
         // $stub->doSomething() 每次返回值都不同
-        $this->assertEquals(2, $stub->doSomething());
-        $this->assertEquals(3, $stub->doSomething());
-        $this->assertEquals(5, $stub->doSomething());
+        self::assertEquals(2, $stub->doSomething());
+        self::assertEquals(3, $stub->doSomething());
+        self::assertEquals(5, $stub->doSomething());
     }
 }
 ?>]]></programlisting>
@@ -440,7 +440,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
         $subject->attach($observer);
 
         // 在 $subject 对象上调用 doSomething() 方法，
-        // 预期将以字符串 'something' 为参数调用 
+        // 预期将以字符串 'something' 为参数调用
         // Observer 仿件对象的 update() 方法。
         $subject->doSomething();
     }
@@ -659,7 +659,7 @@ class SubjectTest extends PHPUnit_Framework_TestCase
         $subject->attach($observer->reveal());
 
         // 在 $subject 对象上调用 doSomething() 方法，
-        // 预期将以字符串 'something' 为参数调用 
+        // 预期将以字符串 'something' 为参数调用
         // Observer 仿件对象的 update() 方法。
         $subject->doSomething();
     }
@@ -699,7 +699,7 @@ class TraitClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($mock->concreteMethod());
+        self::assertTrue($mock->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -731,7 +731,7 @@ class AbstractClassTest extends PHPUnit_Framework_TestCase
              ->method('abstractMethod')
              ->will($this->returnValue(TRUE));
 
-        $this->assertTrue($stub->concreteMethod());
+        self::assertTrue($stub->concreteMethod());
     }
 }
 ?>]]></programlisting>
@@ -794,7 +794,7 @@ class GoogleTest extends PHPUnit_Framework_TestCase
          * $googleSearch->doGoogleSearch() 将会返回上桩的结果，
          * web 服务的 doGoogleSearch() 方法不会被调用。
          */
-        $this->assertEquals(
+        self::assertEquals(
           $result,
           $googleSearch->doGoogleSearch(
             '00000000000000000000000000000000',
@@ -876,10 +876,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(file_exists(dirname(__FILE__) . '/id'));
+        self::assertFalse(file_exists(dirname(__FILE__) . '/id'));
 
         $example->setDirectory(dirname(__FILE__));
-        $this->assertTrue(file_exists(dirname(__FILE__) . '/id'));
+        self::assertTrue(file_exists(dirname(__FILE__) . '/id'));
     }
 
     protected function tearDown()
@@ -920,10 +920,10 @@ class ExampleTest extends PHPUnit_Framework_TestCase
     public function testDirectoryIsCreated()
     {
         $example = new Example('id');
-        $this->assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertFalse(vfsStreamWrapper::getRoot()->hasChild('id'));
 
         $example->setDirectory(vfsStream::url('exampleDir'));
-        $this->assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
+        self::assertTrue(vfsStreamWrapper::getRoot()->hasChild('id'));
     }
 }
 ?>]]></programlisting>

--- a/src/4.8/zh_cn/textui.xml
+++ b/src/4.8/zh_cn/textui.xml
@@ -285,7 +285,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
      */
     public function testMethod($data)
     {
-        $this->assertTrue($data);
+        self::assertTrue($data);
     }
 
     public function provider()

--- a/src/4.8/zh_cn/writing-tests-for-phpunit.xml
+++ b/src/4.8/zh_cn/writing-tests-for-phpunit.xml
@@ -23,14 +23,14 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPushAndPop()
     {
         $stack = array();
-        $this->assertEquals(0, count($stack));
+        self::assertEquals(0, count($stack));
 
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertEquals(1, count($stack));
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertEquals(1, count($stack));
 
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEquals(0, count($stack));
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEquals(0, count($stack));
     }
 }
 ?>]]></programlisting>
@@ -71,7 +71,7 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testEmpty()
     {
         $stack = array();
-        $this->assertEmpty($stack);
+        self::assertEmpty($stack);
 
         return $stack;
     }
@@ -82,8 +82,8 @@ class StackTest extends PHPUnit_Framework_TestCase
     public function testPush(array $stack)
     {
         array_push($stack, 'foo');
-        $this->assertEquals('foo', $stack[count($stack)-1]);
-        $this->assertNotEmpty($stack);
+        self::assertEquals('foo', $stack[count($stack)-1]);
+        self::assertNotEmpty($stack);
 
         return $stack;
     }
@@ -93,8 +93,8 @@ class StackTest extends PHPUnit_Framework_TestCase
      */
     public function testPop(array $stack)
     {
-        $this->assertEquals('foo', array_pop($stack));
-        $this->assertEmpty($stack);
+        self::assertEquals('foo', array_pop($stack));
+        self::assertEmpty($stack);
     }
 }
 ?>]]></programlisting>
@@ -112,7 +112,7 @@ class DependencyFailureTest extends PHPUnit_Framework_TestCase
 {
     public function testOne()
     {
-        $this->assertTrue(FALSE);
+        self::assertTrue(FALSE);
     }
 
     /**
@@ -160,13 +160,13 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
 {
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -176,7 +176,7 @@ class MultipleDependenciesTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('first', 'second'),
             func_get_args()
         );
@@ -214,7 +214,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -259,7 +259,7 @@ class DataTest extends PHPUnit_Framework_TestCase
      */
     public function testAdd($a, $b, $expected)
     {
-        $this->assertEquals($expected, $a + $b);
+        self::assertEquals($expected, $a + $b);
     }
 
     public function additionProvider()
@@ -347,13 +347,13 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
 
     public function testProducerFirst()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'first';
     }
 
     public function testProducerSecond()
     {
-        $this->assertTrue(true);
+        self::assertTrue(true);
         return 'second';
     }
 
@@ -364,7 +364,7 @@ class DependencyAndDataProviderComboTest extends PHPUnit_Framework_TestCase
      */
     public function testConsumer()
     {
-        $this->assertEquals(
+        self::assertEquals(
             array('provider1', 'first', 'second'),
             func_get_args()
         );
@@ -691,7 +691,7 @@ class ErrorSuppressionTest extends PHPUnit_Framework_TestCase
 {
     public function testFileWriting() {
         $writer = new FileWriter;
-        $this->assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
+        self::assertFalse(@$writer->write('/is-not-writeable/file', 'stuff'));
     }
 }
 class FileWriter
@@ -811,7 +811,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
 class ArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1,2,3 ,4,5,6),
             array(1,2,33,4,5,6)
         );
@@ -856,7 +856,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class LongArrayDiffTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,3 ,4,5,6),
             array(0,0,0,0,0,0,0,0,0,0,0,0,1,2,33,4,5,6)
         );
@@ -904,7 +904,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
 class ArrayWeakComparisonTest extends PHPUnit_Framework_TestCase
 {
     public function testEquality() {
-        $this->assertEquals(
+        self::assertEquals(
             array(1  ,2,3 ,4,5,6),
             array('1',2,33,4,5,6)
         );


### PR DESCRIPTION
Although it is technically fine to call static methods non-statically an official manual should not promote this as a kind-of best-pratice.

The change was made with a simple search-and-replace and was only performed on the 3 versions stable (4.6), beta (4.7) and alpha (4.8)