### PR TITLE
Recovering missing --color pieces from textui docs

### DIFF
--- a/src/4.8/en/textui.xml
+++ b/src/4.8/en/textui.xml
@@ -657,13 +657,13 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
               </listitem>
               <listitem>
                 <para>
-                  <literal>auto</literal>: displays colors in the output unless the current terminal doesn't supports colors,
+                  <literal>auto</literal>: displays colors in the output unless the current terminal doesn't support colors,
                   or if the output is piped to a command or redirected to a file.
                 </para>
               </listitem>
               <listitem>
                 <para>
-                  <literal>always</literal>: always displays colors in the output even when the current terminal doesn't supports colors,
+                  <literal>always</literal>: always displays colors in the output even when the current terminal doesn't support colors,
                   or when the output is piped to a command or redirected to a file.
                 </para>
               </listitem>

--- a/src/4.8/en/textui.xml
+++ b/src/4.8/en/textui.xml
@@ -596,18 +596,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Run tests in strict mode (same as using <literal>--report-useless-tests</literal>,
-            <literal>--strict-coverage</literal>, <literal>--disallow-test-output</literal>,
-            and <literal>--enforce-time-limit</literal>). See <xref
-            linkend="risky-tests" /> for details.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <indexterm><primary>Process Isolation</primary></indexterm>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--process-isolation</literal></term>

--- a/src/4.8/en/textui.xml
+++ b/src/4.8/en/textui.xml
@@ -159,7 +159,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -646,6 +646,39 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           <para>
             Use colors in output.
             On Windows, use <ulink url="https://github.com/adoxa/ansicon">ANSICON</ulink> or <ulink url="https://github.com/Maximus5/ConEmu">ConEmu</ulink>.
+          </para>
+          <para>
+            There are three possible values for this option:
+            <itemizedlist>
+              <listitem>
+                <para>
+                  <literal>never</literal>: never displays colors in the output. This is the default value when <literal>--colors</literal> option is not used.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <literal>auto</literal>: displays colors in the output unless the current terminal doesn't supports colors,
+                  or if the output is piped to a command or redirected to a file.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <literal>always</literal>: always displays colors in the output even when the current terminal doesn't supports colors,
+                  or when the output is piped to a command or redirected to a file.
+                </para>
+              </listitem>
+            </itemizedlist>
+            When <literal>--colors</literal> is used without any value, <literal>auto</literal> is the chosen value.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><literal>--columns</literal></term>
+        <listitem>
+          <para>
+            Defines the number of columns to use for progress output.
+            If <literal>max</literal> is defined as value, the number of columns will be maximum of the current terminal.
           </para>
         </listitem>
       </varlistentry>

--- a/src/4.8/fr/textui.xml
+++ b/src/4.8/fr/textui.xml
@@ -134,10 +134,10 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --enforce-time-limit      Enforce time limit based on test size.
   --disallow-todo-tests     Disallow @todo-annotated tests.
-  --strict                  Run tests in strict mode (enables all of the above).
 
   --process-isolation       Run each test in a separate PHP process.
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
@@ -486,15 +486,6 @@ Miscellaneous Options:
         <listitem>
           <para>
             Arrête l'exécution au premier test incomplet.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Exécute les tests en mode strict.
           </para>
         </listitem>
       </varlistentry>

--- a/src/4.8/ja/textui.xml
+++ b/src/4.8/ja/textui.xml
@@ -592,18 +592,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            テストを strict モードで実行します (<literal>--report-useless-tests</literal>、
-            <literal>--strict-coverage</literal>、<literal>--disallow-test-output</literal>、
-            そして <literal>--enforce-time-limit</literal> を指定するのと同じ動きです)。詳細は <xref
-            linkend="risky-tests" /> を参照ください。
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <indexterm><primary>Process Isolation</primary></indexterm>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--process-isolation</literal></term>

--- a/src/4.8/ja/textui.xml
+++ b/src/4.8/ja/textui.xml
@@ -160,7 +160,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.

--- a/src/4.8/pt_br/textui.xml
+++ b/src/4.8/pt_br/textui.xml
@@ -591,18 +591,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
       
       <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Executa os testes em modo estrito (mesmo que usar <literal>--report-useless-tests</literal>,
-            <literal>--strict-coverage</literal>, <literal>--disallow-test-output</literal>,
-            e <literal>--enforce-time-limit</literal>). Veja <xref
-            linkend="risky-tests" /> para detalhes.
-          </para>
-        </listitem>
-      </varlistentry>
-      
-      <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
         <term><literal>--process-isolation</literal></term>

--- a/src/4.8/pt_br/textui.xml
+++ b/src/4.8/pt_br/textui.xml
@@ -113,7 +113,7 @@ OK (2 tests, 2 assertions)</screen>
     </para>
 
     <screen><userinput>phpunit --help</userinput>
-<![CDATA[PHPUnit 4.7.0 by Sebastian Bergmann and contributors.
+<![CDATA[PHPUnit 4.8.0 by Sebastian Bergmann and contributors.
 
 Usage: phpunit [options] UnitTest [UnitTest.php]
        phpunit [options] <directory>
@@ -159,7 +159,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.

--- a/src/4.8/zh_cn/textui.xml
+++ b/src/4.8/zh_cn/textui.xml
@@ -119,7 +119,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.

--- a/src/4.8/zh_cn/textui.xml
+++ b/src/4.8/zh_cn/textui.xml
@@ -434,13 +434,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>以严格模式运行测试（效果的功能等同于同时使用 <literal>--report-useless-tests</literal>、<literal>--strict-coverage</literal>、<literal>--disallow-test-output</literal> 和 <literal>--enforce-time-limit</literal>）。详情参见<xref linkend="risky-tests"/>。</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <indexterm><primary>Process Isolation （进程隔离）</primary></indexterm>
         <indexterm><primary>Test Isolation （测试隔离）</primary></indexterm>
         <term><literal>--process-isolation</literal></term>

--- a/src/5.0/en/textui.xml
+++ b/src/5.0/en/textui.xml
@@ -159,7 +159,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -596,18 +596,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Run tests in strict mode (same as using <literal>--report-useless-tests</literal>,
-            <literal>--strict-coverage</literal>, <literal>--disallow-test-output</literal>,
-            and <literal>--enforce-time-limit</literal>). See <xref
-            linkend="risky-tests" /> for details.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <indexterm><primary>Process Isolation</primary></indexterm>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--process-isolation</literal></term>
@@ -646,6 +634,39 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           <para>
             Use colors in output.
             On Windows, use <ulink url="https://github.com/adoxa/ansicon">ANSICON</ulink> or <ulink url="https://github.com/Maximus5/ConEmu">ConEmu</ulink>.
+          </para>
+          <para>
+            There are three possible values for this option:
+            <itemizedlist>
+              <listitem>
+                <para>
+                  <literal>never</literal>: never displays colors in the output. This is the default value when <literal>--colors</literal> option is not used.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <literal>auto</literal>: displays colors in the output unless the current terminal doesn't supports colors,
+                  or if the output is piped to a command or redirected to a file.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <literal>always</literal>: always displays colors in the output even when the current terminal doesn't supports colors,
+                  or when the output is piped to a command or redirected to a file.
+                </para>
+              </listitem>
+            </itemizedlist>
+            When <literal>--colors</literal> is used without any value, <literal>auto</literal> is the chosen value.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><literal>--columns</literal></term>
+        <listitem>
+          <para>
+            Defines the number of columns to use for progress output.
+            If <literal>max</literal> is defined as value, the number of columns will be maximum of the current terminal.
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.0/fr/textui.xml
+++ b/src/5.0/fr/textui.xml
@@ -134,10 +134,10 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --enforce-time-limit      Enforce time limit based on test size.
   --disallow-todo-tests     Disallow @todo-annotated tests.
-  --strict                  Run tests in strict mode (enables all of the above).
 
   --process-isolation       Run each test in a separate PHP process.
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
@@ -486,15 +486,6 @@ Miscellaneous Options:
         <listitem>
           <para>
             Arrête l'exécution au premier test incomplet.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Exécute les tests en mode strict.
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.0/ja/textui.xml
+++ b/src/5.0/ja/textui.xml
@@ -160,7 +160,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -587,18 +587,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           <para>
             テストのサイズに応じて、制限時間を設定します。
             詳細は <xref linkend="risky-tests" /> を参照ください。
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            テストを strict モードで実行します (<literal>--report-useless-tests</literal>、
-            <literal>--strict-coverage</literal>、<literal>--disallow-test-output</literal>、
-            そして <literal>--enforce-time-limit</literal> を指定するのと同じ動きです)。詳細は <xref
-            linkend="risky-tests" /> を参照ください。
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.0/pt_br/textui.xml
+++ b/src/5.0/pt_br/textui.xml
@@ -113,7 +113,7 @@ OK (2 tests, 2 assertions)</screen>
     </para>
 
     <screen><userinput>phpunit --help</userinput>
-<![CDATA[PHPUnit 4.7.0 by Sebastian Bergmann and contributors.
+<![CDATA[PHPUnit 5.0.0 by Sebastian Bergmann and contributors.
 
 Usage: phpunit [options] UnitTest [UnitTest.php]
        phpunit [options] <directory>
@@ -159,7 +159,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -585,18 +585,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Impõem limite de tempo baseado no tamanho do teste. Veja <xref
-            linkend="risky-tests" /> para detalhes.
-          </para>
-        </listitem>
-      </varlistentry>
-      
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Executa os testes em modo estrito (mesmo que usar <literal>--report-useless-tests</literal>,
-            <literal>--strict-coverage</literal>, <literal>--disallow-test-output</literal>,
-            e <literal>--enforce-time-limit</literal>). Veja <xref
             linkend="risky-tests" /> para detalhes.
           </para>
         </listitem>

--- a/src/5.0/zh_cn/textui.xml
+++ b/src/5.0/zh_cn/textui.xml
@@ -119,7 +119,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -430,13 +430,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
           <para>根据测试规模对其加上执行时长限制。详情参见<xref linkend="risky-tests"/>。</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>以严格模式运行测试（效果的功能等同于同时使用 <literal>--report-useless-tests</literal>、<literal>--strict-coverage</literal>、<literal>--disallow-test-output</literal> 和 <literal>--enforce-time-limit</literal>）。详情参见<xref linkend="risky-tests"/>。</para>
         </listitem>
       </varlistentry>
 

--- a/src/5.1/en/textui.xml
+++ b/src/5.1/en/textui.xml
@@ -159,7 +159,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -596,18 +596,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Run tests in strict mode (same as using <literal>--report-useless-tests</literal>,
-            <literal>--strict-coverage</literal>, <literal>--disallow-test-output</literal>,
-            and <literal>--enforce-time-limit</literal>). See <xref
-            linkend="risky-tests" /> for details.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <indexterm><primary>Process Isolation</primary></indexterm>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--process-isolation</literal></term>
@@ -646,6 +634,39 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           <para>
             Use colors in output.
             On Windows, use <ulink url="https://github.com/adoxa/ansicon">ANSICON</ulink> or <ulink url="https://github.com/Maximus5/ConEmu">ConEmu</ulink>.
+          </para>
+          <para>
+            There are three possible values for this option:
+            <itemizedlist>
+              <listitem>
+                <para>
+                  <literal>never</literal>: never displays colors in the output. This is the default value when <literal>--colors</literal> option is not used.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <literal>auto</literal>: displays colors in the output unless the current terminal doesn't supports colors,
+                  or if the output is piped to a command or redirected to a file.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  <literal>always</literal>: always displays colors in the output even when the current terminal doesn't supports colors,
+                  or when the output is piped to a command or redirected to a file.
+                </para>
+              </listitem>
+            </itemizedlist>
+            When <literal>--colors</literal> is used without any value, <literal>auto</literal> is the chosen value.
+          </para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><literal>--columns</literal></term>
+        <listitem>
+          <para>
+            Defines the number of columns to use for progress output.
+            If <literal>max</literal> is defined as value, the number of columns will be maximum of the current terminal.
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.1/fr/textui.xml
+++ b/src/5.1/fr/textui.xml
@@ -134,10 +134,10 @@ Test Execution Options:
 
   --report-useless-tests    Be strict about tests that do not test anything.
   --strict-coverage         Be strict about unintentionally covered code.
+  --strict-global-state     Be strict about changes to global state
   --disallow-test-output    Be strict about output during tests.
   --enforce-time-limit      Enforce time limit based on test size.
   --disallow-todo-tests     Disallow @todo-annotated tests.
-  --strict                  Run tests in strict mode (enables all of the above).
 
   --process-isolation       Run each test in a separate PHP process.
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
@@ -486,15 +486,6 @@ Miscellaneous Options:
         <listitem>
           <para>
             Arrête l'exécution au premier test incomplet.
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Exécute les tests en mode strict.
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.1/ja/textui.xml
+++ b/src/5.1/ja/textui.xml
@@ -160,7 +160,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -587,18 +587,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           <para>
             テストのサイズに応じて、制限時間を設定します。
             詳細は <xref linkend="risky-tests" /> を参照ください。
-          </para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            テストを strict モードで実行します (<literal>--report-useless-tests</literal>、
-            <literal>--strict-coverage</literal>、<literal>--disallow-test-output</literal>、
-            そして <literal>--enforce-time-limit</literal> を指定するのと同じ動きです)。詳細は <xref
-            linkend="risky-tests" /> を参照ください。
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.1/pt_br/textui.xml
+++ b/src/5.1/pt_br/textui.xml
@@ -113,7 +113,7 @@ OK (2 tests, 2 assertions)</screen>
     </para>
 
     <screen><userinput>phpunit --help</userinput>
-<![CDATA[PHPUnit 4.7.0 by Sebastian Bergmann and contributors.
+<![CDATA[PHPUnit 5.1.0 by Sebastian Bergmann and contributors.
 
 Usage: phpunit [options] UnitTest [UnitTest.php]
        phpunit [options] <directory>
@@ -159,7 +159,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -585,18 +585,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Impõem limite de tempo baseado no tamanho do teste. Veja <xref
-            linkend="risky-tests" /> para detalhes.
-          </para>
-        </listitem>
-      </varlistentry>
-      
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>
-            Executa os testes em modo estrito (mesmo que usar <literal>--report-useless-tests</literal>,
-            <literal>--strict-coverage</literal>, <literal>--disallow-test-output</literal>,
-            e <literal>--enforce-time-limit</literal>). Veja <xref
             linkend="risky-tests" /> para detalhes.
           </para>
         </listitem>

--- a/src/5.1/zh_cn/textui.xml
+++ b/src/5.1/zh_cn/textui.xml
@@ -119,7 +119,7 @@ Test Execution Options:
   --no-globals-backup       Do not backup and restore $GLOBALS for each test.
   --static-backup           Backup and restore static attributes for each test.
 
-  --colors                  Use colors in output.
+  --colors=<flag>           Use colors in output ("never", "auto" or "always").
   --columns <n>             Number of columns to use for progress output.
   --columns max             Use maximum number of columns for progress output.
   --stderr                  Write to STDERR instead of STDOUT.
@@ -430,13 +430,6 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
           <para>根据测试规模对其加上执行时长限制。详情参见<xref linkend="risky-tests"/>。</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term><literal>--strict</literal></term>
-        <listitem>
-          <para>以严格模式运行测试（效果的功能等同于同时使用 <literal>--report-useless-tests</literal>、<literal>--strict-coverage</literal>、<literal>--disallow-test-output</literal> 和 <literal>--enforce-time-limit</literal>）。详情参见<xref linkend="risky-tests"/>。</para>
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
As found during #319.

I've recovered all the missing pieces in the english file.

I've ported what I could to the translated versions, here is what I've found incomplete or recovered (as you can see from the diff):
 * fr:
  * `--colors` is correctly shown in CLI example, translated explanation still old version
  * `--strict-global-state` absent in CLI example, translated explanation still missing
  * `--strict` was still there (was deprecated and removed), removed from docs
 * ja, pt_br, zh_cn:
  * `--colors` old in CLI example, updated; translated explanation still old version
