### PR TITLE
[ja] Fix "Mock Builder" typo

### DIFF
--- a/src/4.0/ja/test-doubles.xml
+++ b/src/4.0/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.1/ja/test-doubles.xml
+++ b/src/4.1/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.2/ja/test-doubles.xml
+++ b/src/4.2/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.3/ja/test-doubles.xml
+++ b/src/4.3/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.4/ja/test-doubles.xml
+++ b/src/4.4/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.5/ja/test-doubles.xml
+++ b/src/4.5/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.6/ja/test-doubles.xml
+++ b/src/4.6/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.7/ja/test-doubles.xml
+++ b/src/4.7/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/4.8/ja/test-doubles.xml
+++ b/src/4.8/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/5.0/ja/test-doubles.xml
+++ b/src/5.0/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>

--- a/src/5.1/ja/test-doubles.xml
+++ b/src/5.1/ja/test-doubles.xml
@@ -215,7 +215,7 @@ class StubTest extends PHPUnit_Framework_TestCase
     </example>
 
     <para>
-      モックビルだーが提供するメソッドの一覧は、次のとおりです。
+      モックビルダーが提供するメソッドの一覧は、次のとおりです。
     </para>
 
     <itemizedlist>


### PR DESCRIPTION
@m-takagi

[ja] Fixes typo "モックビルだー" to "モックビルダー" in 4.0 - 5.1.

```
% ag --ignore build/output -l  モックビルだー
src/4.0/ja/test-doubles.xml
src/4.1/ja/test-doubles.xml
src/4.2/ja/test-doubles.xml
src/4.3/ja/test-doubles.xml
src/4.4/ja/test-doubles.xml
src/4.5/ja/test-doubles.xml
src/4.6/ja/test-doubles.xml
src/4.7/ja/test-doubles.xml
src/4.8/ja/test-doubles.xml
src/5.0/ja/test-doubles.xml
src/5.1/ja/test-doubles.xml
```
