### PR TITLE
Improvements in build.xml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ for example
     cd build
     ant build-en-4.3
 
+For more further info, you can see the project description:
+
+    cd build
+    ant -p
+
 # Output
 
 The generated files will be in `build/output/VERSION/LANG`.

--- a/build/build.xml
+++ b/build/build.xml
@@ -1,8 +1,21 @@
 <project name="phpunit-manual" default="build-current" basedir=".">
-  <target name="check-current" depends="check-en-5.2,check-ja-5.2,check-zh_cn-5.2,check-pt_br-5.2,check-en-5.1,check-ja-5.1,check-zh_cn-5.1,check-pt_br-5.1,check-en-5.0,check-ja-5.0,check-zh_cn-5.0,check-pt_br-5.0,check-en-4.8,check-ja-4.8,check-zh_cn-4.8,check-pt_br-4.8"/>
-  <target name="build-current" depends="build-en-5.2,build-ja-5.2,build-zh_cn-5.2,build-pt_br-5.2,build-en-5.1,build-ja-5.1,build-zh_cn-5.1,build-pt_br-5.1,build-en-5.0,build-ja-5.0,build-zh_cn-5.0,build-pt_br-5.0,build-en-4.8,build-ja-4.8,build-zh_cn-4.8,build-pt_br-4.8"/>
+  <target name="check-current" depends="check-current-en,check-current-ja,check-current-zh_cn,check-current-pt_br"/>
+  <target name="build-current" depends="build-current-en,build-current-ja,build-current-zh_cn,build-current-pt_br"/>
+
   <target name="build-old" depends="build-en-4.7,build-ja-4.7,build-zh_cn-4.7,build-pt_br-4.7,build-en-4.6,build-ja-4.6,build-zh_cn-4.6,build-pt_br-4.6,build-en-4.5,build-ja-4.5,build-zh_cn-4.5,build-pt_br-4.5,build-en-4.4,build-ja-4.4,build-zh_cn-4.4,build-en-4.3,build-ja-4.3,build-zh_cn-4.3,build-pt_br-4.3,build-en-4.2,build-ja-4.2,build-zh_cn-4.2,build-pt_br-4.2,build-en-4.1,build-ja-4.1,build-zh_cn-4.1,build-pt_br-4.1,build-en-4.0,build-ja-4.0,build-zh_cn-4.0,build-pt_br-4.0,build-en-3.7,build-ja-3.7,build-zh_cn-3.7,build-pt_br-3.7,build-en-3.6,build-ja-3.6,build-en-3.5,build-ja-3.5,build-en-3.4,build-ja-3.4,build-en-3.3,build-ja-3.3,build-en-3.2,build-ja-3.2,build-en-3.1,build-ja-3.1,build-en-3.0,build-ja-3.0,build-en-2.3,build-ja-2.3,build-de-2.3"/>
   <target name="check-old" depends="check-en-4.7,check-ja-4.7,check-zh_cn-4.7,check-pt_br-4.7,check-en-4.6,check-ja-4.6,check-zh_cn-4.6,check-pt_br-4.6,check-en-4.5,check-ja-4.5,check-zh_cn-4.5,check-pt_br-4.5,check-en-4.4,check-ja-4.4,check-zh_cn-4.4,check-en-4.3,check-ja-4.3,check-zh_cn-4.3,check-pt_br-4.3,check-en-4.2,check-ja-4.2,check-zh_cn-4.2,check-pt_br-4.2,check-en-4.1,check-ja-4.1,check-zh_cn-4.1,check-pt_br-4.1,check-en-4.0,check-ja-4.0,check-zh_cn-4.0,check-pt_br-4.0,check-en-3.7,check-ja-3.7,check-zh_cn-3.7,check-pt_br-3.7,check-en-3.6,check-ja-3.6,check-en-3.5,check-ja-3.5,check-en-3.4,check-ja-3.4,check-en-3.3,check-ja-3.3,check-en-3.2,check-ja-3.2,check-en-3.1,check-ja-3.1,check-en-3.0,check-ja-3.0,check-en-2.3,check-ja-2.3,check-de-2.3"/>
+
+  <target name="check-current-en" depends="check-en-5.2,check-en-5.1,check-en-5.0,check-en-4.8"/>
+  <target name="build-current-en" depends="build-en-5.2,build-en-5.1,build-en-5.0,build-en-4.8"/>
+
+  <target name="check-current-ja" depends="check-ja-5.2,check-ja-5.1,check-ja-5.0,check-ja-4.8"/>
+  <target name="build-current-ja" depends="build-ja-5.2,build-ja-5.1,build-ja-5.0,build-ja-4.8"/>
+
+  <target name="check-current-zh_cn" depends="check-zh_cn-5.2,check-zh_cn-5.1,check-zh_cn-5.0,check-zh_cn-4.8"/>
+  <target name="build-current-zh_cn" depends="build-zh_cn-5.2,build-zh_cn-5.1,build-zh_cn-5.0,build-zh_cn-4.8"/>
+
+  <target name="check-current-pt_br" depends="check-pt_br-5.2,check-pt_br-5.1,check-pt_br-5.0,check-pt_br-4.8"/>
+  <target name="build-current-pt_br" depends="build-pt_br-5.2,build-pt_br-5.1,build-pt_br-5.0,build-pt_br-4.8"/>
 
   <target name="check">
     <!-- Ensure parameter 'version' is not empty or undefined -->
@@ -33,7 +46,7 @@
         <not><available file="${basedir}/${book.xml}"/></not>
       </condition>
     </fail>
-    
+
     <exec dir="${basedir}" executable="xmllint" failonerror="true">
       <arg line="--noout --noent ${book.xml}"/>
     </exec>
@@ -459,28 +472,28 @@
       <param name="version" value="4.3"/>
     </antcall>
   </target>
-  
+
   <target name="build-pt_br-4.5" depends="check-pt_br-4.5">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.5"/>
     </antcall>
   </target>
-  
+
   <target name="build-pt_br-4.6" depends="check-pt_br-4.6">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.6"/>
     </antcall>
   </target>
-  
+
   <target name="build-pt_br-4.7" depends="check-pt_br-4.7">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.7"/>
     </antcall>
   </target>
-  
+
   <target name="build-pt_br-4.8" depends="check-pt_br-4.8">
     <antcall target="build">
       <param name="language" value="pt_br"/>
@@ -977,28 +990,28 @@
       <param name="version" value="4.3"/>
     </antcall>
   </target>
-  
+
   <target name="check-pt_br-4.5">
     <antcall target="check">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.5"/>
     </antcall>
   </target>
-  
+
   <target name="check-pt_br-4.6">
     <antcall target="check">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.6"/>
     </antcall>
   </target>
-  
+
   <target name="check-pt_br-4.7">
     <antcall target="check">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.7"/>
     </antcall>
   </target>
-  
+
   <target name="check-pt_br-4.8">
     <antcall target="check">
       <param name="language" value="pt_br"/>
@@ -1125,4 +1138,3 @@
     </antcall>
   </target>
 </project>
-

--- a/build/build.xml
+++ b/build/build.xml
@@ -1,23 +1,63 @@
 <project name="phpunit-manual" default="build-current" basedir=".">
-  <target name="check-current" depends="check-current-en,check-current-ja,check-current-zh_cn,check-current-pt_br"/>
-  <target name="build-current" depends="build-current-en,build-current-ja,build-current-zh_cn,build-current-pt_br"/>
+  <description>
+Documentation building system for all versions of PHPUnit in many languages.
 
-  <target name="build-old" depends="build-en-4.7,build-ja-4.7,build-zh_cn-4.7,build-pt_br-4.7,build-en-4.6,build-ja-4.6,build-zh_cn-4.6,build-pt_br-4.6,build-en-4.5,build-ja-4.5,build-zh_cn-4.5,build-pt_br-4.5,build-en-4.4,build-ja-4.4,build-zh_cn-4.4,build-en-4.3,build-ja-4.3,build-zh_cn-4.3,build-pt_br-4.3,build-en-4.2,build-ja-4.2,build-zh_cn-4.2,build-pt_br-4.2,build-en-4.1,build-ja-4.1,build-zh_cn-4.1,build-pt_br-4.1,build-en-4.0,build-ja-4.0,build-zh_cn-4.0,build-pt_br-4.0,build-en-3.7,build-ja-3.7,build-zh_cn-3.7,build-pt_br-3.7,build-en-3.6,build-ja-3.6,build-en-3.5,build-ja-3.5,build-en-3.4,build-ja-3.4,build-en-3.3,build-ja-3.3,build-en-3.2,build-ja-3.2,build-en-3.1,build-ja-3.1,build-en-3.0,build-ja-3.0,build-en-2.3,build-ja-2.3,build-de-2.3"/>
-  <target name="check-old" depends="check-en-4.7,check-ja-4.7,check-zh_cn-4.7,check-pt_br-4.7,check-en-4.6,check-ja-4.6,check-zh_cn-4.6,check-pt_br-4.6,check-en-4.5,check-ja-4.5,check-zh_cn-4.5,check-pt_br-4.5,check-en-4.4,check-ja-4.4,check-zh_cn-4.4,check-en-4.3,check-ja-4.3,check-zh_cn-4.3,check-pt_br-4.3,check-en-4.2,check-ja-4.2,check-zh_cn-4.2,check-pt_br-4.2,check-en-4.1,check-ja-4.1,check-zh_cn-4.1,check-pt_br-4.1,check-en-4.0,check-ja-4.0,check-zh_cn-4.0,check-pt_br-4.0,check-en-3.7,check-ja-3.7,check-zh_cn-3.7,check-pt_br-3.7,check-en-3.6,check-ja-3.6,check-en-3.5,check-ja-3.5,check-en-3.4,check-ja-3.4,check-en-3.3,check-ja-3.3,check-en-3.2,check-ja-3.2,check-en-3.1,check-ja-3.1,check-en-3.0,check-ja-3.0,check-en-2.3,check-ja-2.3,check-de-2.3"/>
+Usage:
+  ant -p
+    Print this project info.
 
-  <target name="check-current-en" depends="check-en-5.2,check-en-5.1,check-en-5.0,check-en-4.8"/>
-  <target name="build-current-en" depends="build-en-5.2,build-en-5.1,build-en-5.0,build-en-4.8"/>
+  ant
+    Performs the default target: build-current.
 
-  <target name="check-current-ja" depends="check-ja-5.2,check-ja-5.1,check-ja-5.0,check-ja-4.8"/>
-  <target name="build-current-ja" depends="build-ja-5.2,build-ja-5.1,build-ja-5.0,build-ja-4.8"/>
+  ant TARGET
+    Performs the especified TARGET task.
 
-  <target name="check-current-zh_cn" depends="check-zh_cn-5.2,check-zh_cn-5.1,check-zh_cn-5.0,check-zh_cn-4.8"/>
-  <target name="build-current-zh_cn" depends="build-zh_cn-5.2,build-zh_cn-5.1,build-zh_cn-5.0,build-zh_cn-4.8"/>
+  ant check-LANGUAGE-VERSION
+    Use defined target in order to check specific VERSION and LANGUAGE source files.
 
-  <target name="check-current-pt_br" depends="check-pt_br-5.2,check-pt_br-5.1,check-pt_br-5.0,check-pt_br-4.8"/>
-  <target name="build-current-pt_br" depends="build-pt_br-5.2,build-pt_br-5.1,build-pt_br-5.0,build-pt_br-4.8"/>
+  ant check -Dlanguage="LANGUAGE" -Dversion="VERSION"
+    Alternative to previous, using generic target.
 
-  <target name="check">
+  ant build-LANGUAGE-VERSION
+    Use defined target in order to build specific VERSION and LANGUAGE.
+
+  ant build -Dlanguage="LANGUAGE" -Dversion="VERSION"
+    Alternative to previous, using generic target. Warning: No check will be performed.
+
+See the main targets description for more detailed info.
+  </description>
+
+  <target name="check-current" depends="check-current-en,check-current-ja,check-current-zh_cn,check-current-pt_br"
+    description="Performs checks in PHPUnit Documentation (all languages) source files for active current versions supported in PHPUnit: 5.2 (alpha), 5.1 (beta), 5.0 (stable) and 4.8 (old)."/>
+  <target name="build-current" depends="build-current-en,build-current-ja,build-current-zh_cn,build-current-pt_br"
+    description="Builds PHPUnit Documentation (all languages) for active current versions supported in PHPUnit: 5.2 (alpha), 5.1 (beta), 5.0 (stable) and 4.8 (old)."/>
+
+  <target name="build-old" depends="build-en-4.7,build-ja-4.7,build-zh_cn-4.7,build-pt_br-4.7,build-en-4.6,build-ja-4.6,build-zh_cn-4.6,build-pt_br-4.6,build-en-4.5,build-ja-4.5,build-zh_cn-4.5,build-pt_br-4.5,build-en-4.4,build-ja-4.4,build-zh_cn-4.4,build-en-4.3,build-ja-4.3,build-zh_cn-4.3,build-pt_br-4.3,build-en-4.2,build-ja-4.2,build-zh_cn-4.2,build-pt_br-4.2,build-en-4.1,build-ja-4.1,build-zh_cn-4.1,build-pt_br-4.1,build-en-4.0,build-ja-4.0,build-zh_cn-4.0,build-pt_br-4.0,build-en-3.7,build-ja-3.7,build-zh_cn-3.7,build-pt_br-3.7,build-en-3.6,build-ja-3.6,build-en-3.5,build-ja-3.5,build-en-3.4,build-ja-3.4,build-en-3.3,build-ja-3.3,build-en-3.2,build-ja-3.2,build-en-3.1,build-ja-3.1,build-en-3.0,build-ja-3.0,build-en-2.3,build-ja-2.3,build-de-2.3"
+    description="Builds PHPUnit Documentation (all languages) for all old/unsupported versions of PHPUnit available."/>
+  <target name="check-old" depends="check-en-4.7,check-ja-4.7,check-zh_cn-4.7,check-pt_br-4.7,check-en-4.6,check-ja-4.6,check-zh_cn-4.6,check-pt_br-4.6,check-en-4.5,check-ja-4.5,check-zh_cn-4.5,check-pt_br-4.5,check-en-4.4,check-ja-4.4,check-zh_cn-4.4,check-en-4.3,check-ja-4.3,check-zh_cn-4.3,check-pt_br-4.3,check-en-4.2,check-ja-4.2,check-zh_cn-4.2,check-pt_br-4.2,check-en-4.1,check-ja-4.1,check-zh_cn-4.1,check-pt_br-4.1,check-en-4.0,check-ja-4.0,check-zh_cn-4.0,check-pt_br-4.0,check-en-3.7,check-ja-3.7,check-zh_cn-3.7,check-pt_br-3.7,check-en-3.6,check-ja-3.6,check-en-3.5,check-ja-3.5,check-en-3.4,check-ja-3.4,check-en-3.3,check-ja-3.3,check-en-3.2,check-ja-3.2,check-en-3.1,check-ja-3.1,check-en-3.0,check-ja-3.0,check-en-2.3,check-ja-2.3,check-de-2.3"
+    description="Performs checks in PHPUnit Documentation (all languages) source files for all old/unsupported versions of PHPUnit available."/>
+
+  <target name="check-current-en" depends="check-en-5.2,check-en-5.1,check-en-5.0,check-en-4.8"
+    description="Performs checks in English (en) PHPUnit Documentation source files for all active current versions supported in PHPUnit."/>
+  <target name="build-current-en" depends="build-en-5.2,build-en-5.1,build-en-5.0,build-en-4.8"
+    description="Builds English (en) PHPUnit Documentation for all active current versions supported in PHPUnit."/>
+
+  <target name="check-current-ja" depends="check-ja-5.2,check-ja-5.1,check-ja-5.0,check-ja-4.8"
+    description="Performs checks in Japanese (ja) PHPUnit Documentation source files for all active current versions supported in PHPUnit."/>
+  <target name="build-current-ja" depends="build-ja-5.2,build-ja-5.1,build-ja-5.0,build-ja-4.8"
+    description="Builds Japanese (ja) PHPUnit Documentation for all active current versions supported in PHPUnit."/>
+
+  <target name="check-current-zh_cn" depends="check-zh_cn-5.2,check-zh_cn-5.1,check-zh_cn-5.0,check-zh_cn-4.8"
+    description="Performs checks in Simplified Chinese (zh_cn) PHPUnit Documentation source files for all active current versions supported in PHPUnit."/>
+  <target name="build-current-zh_cn" depends="build-zh_cn-5.2,build-zh_cn-5.1,build-zh_cn-5.0,build-zh_cn-4.8"
+    description="Builds Simplified Chinese (zh_cn) PHPUnit Documentation for all active current versions supported in PHPUnit."/>
+
+  <target name="check-current-pt_br" depends="check-pt_br-5.2,check-pt_br-5.1,check-pt_br-5.0,check-pt_br-4.8"
+    description="Performs checks in Brazilian Portuguese (pt_br) PHPUnit Documentation source files for all active current versions supported in PHPUnit."/>
+  <target name="build-current-pt_br" depends="build-pt_br-5.2,build-pt_br-5.1,build-pt_br-5.0,build-pt_br-4.8"
+    description="Builds Brazilian Portuguese (pt_br) PHPUnit Documentation for all active current versions supported in PHPUnit."/>
+
+  <target name="check" description="[Generic] Performs checks in PHPUnit Documentation source files for specified &quot;language&quot; and PHPUnit &quot;version&quot;.">
     <!-- Ensure parameter 'version' is not empty or undefined -->
     <fail message="&quot;version&quot; property is missing or empty.">
       <condition>
@@ -52,7 +92,7 @@
     </exec>
   </target>
 
-  <target name="build">
+  <target name="build" description="[Generic] Builds PHPUnit Documentation for specified &quot;language&quot; and PHPUnit &quot;version&quot;.">
     <delete dir="output/${version}/${language}"/>
     <mkdir dir="output/${version}/${language}"/>
     <mkdir dir="figures"/>
@@ -221,28 +261,28 @@
     </antcall>
   </target>
 
-  <target name="build-en-4.8" depends="check-en-4.8">
+  <target name="build-en-4.8" depends="check-en-4.8" description="Builds English (en) documentation of PHPUnit 4.8.">
     <antcall target="build">
       <param name="language" value="en"/>
       <param name="version" value="4.8"/>
     </antcall>
   </target>
 
-  <target name="build-en-5.0" depends="check-en-5.0">
+  <target name="build-en-5.0" depends="check-en-5.0" description="Builds English (en) documentation of PHPUnit 5.0.">
     <antcall target="build">
       <param name="language" value="en"/>
       <param name="version" value="5.0"/>
     </antcall>
   </target>
 
-  <target name="build-en-5.1" depends="check-en-5.1">
+  <target name="build-en-5.1" depends="check-en-5.1" description="Builds English (en) documentation of PHPUnit 5.1.">
     <antcall target="build">
       <param name="language" value="en"/>
       <param name="version" value="5.1"/>
     </antcall>
   </target>
 
-  <target name="build-en-5.2" depends="check-en-5.2">
+  <target name="build-en-5.2" depends="check-en-5.2" description="Builds English (en) documentation of PHPUnit 5.2.">
     <antcall target="build">
       <param name="language" value="en"/>
       <param name="version" value="5.2"/>
@@ -368,28 +408,28 @@
     </antcall>
   </target>
 
-  <target name="build-ja-4.8" depends="check-ja-4.8">
+  <target name="build-ja-4.8" depends="check-ja-4.8" description="Builds Japanese (ja) documentation of PHPUnit 4.8.">
     <antcall target="build">
       <param name="language" value="ja"/>
       <param name="version" value="4.8"/>
     </antcall>
   </target>
 
-  <target name="build-ja-5.0" depends="check-ja-5.0">
+  <target name="build-ja-5.0" depends="check-ja-5.0" description="Builds Japanese (ja) documentation of PHPUnit 5.0.">
     <antcall target="build">
       <param name="language" value="ja"/>
       <param name="version" value="5.0"/>
     </antcall>
   </target>
 
-  <target name="build-ja-5.1" depends="check-ja-5.1">
+  <target name="build-ja-5.1" depends="check-ja-5.1" description="Builds Japanese (ja) documentation of PHPUnit 5.1">
     <antcall target="build">
       <param name="language" value="ja"/>
       <param name="version" value="5.1"/>
     </antcall>
   </target>
 
-  <target name="build-ja-5.2" depends="check-ja-5.2">
+  <target name="build-ja-5.2" depends="check-ja-5.2" description="Builds Japanese (ja) documentation of PHPUnit 5.2.">
     <antcall target="build">
       <param name="language" value="ja"/>
       <param name="version" value="5.2"/>
@@ -494,28 +534,28 @@
     </antcall>
   </target>
 
-  <target name="build-pt_br-4.8" depends="check-pt_br-4.8">
+  <target name="build-pt_br-4.8" depends="check-pt_br-4.8" description="Builds Brazilian Portuguese (pt_br) documentation of PHPUnit 4.8.">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="4.8"/>
     </antcall>
   </target>
 
-  <target name="build-pt_br-5.0" depends="check-pt_br-5.0">
+  <target name="build-pt_br-5.0" depends="check-pt_br-5.0"  description="Builds Brazilian Portuguese (pt_br) documentation of PHPUnit 5.0.">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="5.0"/>
     </antcall>
   </target>
 
-  <target name="build-pt_br-5.1" depends="check-pt_br-5.1">
+  <target name="build-pt_br-5.1" depends="check-pt_br-5.1"  description="Builds Brazilian Portuguese (pt_br) documentation of PHPUnit 5.1.">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="5.1"/>
     </antcall>
   </target>
 
-  <target name="build-pt_br-5.2" depends="check-pt_br-5.2">
+  <target name="build-pt_br-5.2" depends="check-pt_br-5.2"  description="Builds Brazilian Portuguese (pt_br) documentation of PHPUnit 5.2.">
     <antcall target="build">
       <param name="language" value="pt_br"/>
       <param name="version" value="5.2"/>
@@ -585,28 +625,28 @@
     </antcall>
   </target>
 
-  <target name="build-zh_cn-4.8" depends="check-zh_cn-4.8">
+  <target name="build-zh_cn-4.8" depends="check-zh_cn-4.8" description="Builds Simplified Chinese (zh_cn) documentation of PHPUnit 4.8.">
     <antcall target="build">
       <param name="language" value="zh_cn"/>
       <param name="version" value="4.8"/>
     </antcall>
   </target>
 
-  <target name="build-zh_cn-5.0" depends="check-zh_cn-5.0">
+  <target name="build-zh_cn-5.0" depends="check-zh_cn-5.0"  description="Builds Simplified Chinese (zh_cn) documentation of PHPUnit 5.0.">
     <antcall target="build">
       <param name="language" value="zh_cn"/>
       <param name="version" value="5.0"/>
     </antcall>
   </target>
 
-  <target name="build-zh_cn-5.1" depends="check-zh_cn-5.1">
+  <target name="build-zh_cn-5.1" depends="check-zh_cn-5.1" description="Builds Simplified Chinese (zh_cn) documentation of PHPUnit 5.1.">
     <antcall target="build">
       <param name="language" value="zh_cn"/>
       <param name="version" value="5.1"/>
     </antcall>
   </target>
 
-  <target name="build-zh_cn-5.2" depends="check-zh_cn-5.2">
+  <target name="build-zh_cn-5.2" depends="check-zh_cn-5.2" description="Builds Simplified Chinese (zh_cn) documentation of PHPUnit 5.2.">
     <antcall target="build">
       <param name="language" value="zh_cn"/>
       <param name="version" value="5.2"/>

--- a/build/build.xml
+++ b/build/build.xml
@@ -5,8 +5,37 @@
   <target name="check-old" depends="check-en-4.7,check-ja-4.7,check-zh_cn-4.7,check-pt_br-4.7,check-en-4.6,check-ja-4.6,check-zh_cn-4.6,check-pt_br-4.6,check-en-4.5,check-ja-4.5,check-zh_cn-4.5,check-pt_br-4.5,check-en-4.4,check-ja-4.4,check-zh_cn-4.4,check-en-4.3,check-ja-4.3,check-zh_cn-4.3,check-pt_br-4.3,check-en-4.2,check-ja-4.2,check-zh_cn-4.2,check-pt_br-4.2,check-en-4.1,check-ja-4.1,check-zh_cn-4.1,check-pt_br-4.1,check-en-4.0,check-ja-4.0,check-zh_cn-4.0,check-pt_br-4.0,check-en-3.7,check-ja-3.7,check-zh_cn-3.7,check-pt_br-3.7,check-en-3.6,check-ja-3.6,check-en-3.5,check-ja-3.5,check-en-3.4,check-ja-3.4,check-en-3.3,check-ja-3.3,check-en-3.2,check-ja-3.2,check-en-3.1,check-ja-3.1,check-en-3.0,check-ja-3.0,check-en-2.3,check-ja-2.3,check-de-2.3"/>
 
   <target name="check">
+    <!-- Ensure parameter 'version' is not empty or undefined -->
+    <fail message="&quot;version&quot; property is missing or empty.">
+      <condition>
+        <or>
+          <not><isset property="version"/></not>
+          <length string="${version}" trim="true" length="0" />
+        </or>
+      </condition>
+    </fail>
+
+    <!-- Ensure parameter 'language' is not empty or undefined -->
+    <fail message="&quot;language&quot; property is missing or empty.">
+      <condition>
+        <or>
+          <not><isset property="language"/></not>
+          <length string="${language}" trim="true" length="0" />
+        </or>
+      </condition>
+    </fail>
+
+    <property name="book.xml" value="../src/${version}/${language}/book.xml"/>
+
+    <!-- Ensure 'book.xml' resource is available before trying lint with xmllint. -->
+    <fail message="PHPUnit Documentation source files, for language=&quot;${language}&quot; and version=&quot;${version}&quot;, are not available. Source file not found: &quot;${book.xml}&quot;. Check the &quot;language&quot; and &quot;version&quot; values.">
+      <condition>
+        <not><available file="${basedir}/${book.xml}"/></not>
+      </condition>
+    </fail>
+    
     <exec dir="${basedir}" executable="xmllint" failonerror="true">
-      <arg line="--noout --noent ../src/${version}/${language}/book.xml"/>
+      <arg line="--noout --noent ${book.xml}"/>
     </exec>
   </target>
 


### PR DESCRIPTION
### Features:
- [x] **Validation in `check` target params:** <br/> `version` and `language` params are validated and  checked for *undefined* and *not empty* values. Throws a descriptive message on  error, showing that `version` or `language` values are invalid.<br/>This avoid some problems related and ugly messages on errors, by providing an useful error description, when perform `check`.

- [x] **Validation in `check` target source files:** <br/> *Availability* of source files (`book.xml` reference) is checked before to perform lint on it.<br/> Throws a descriptive message on  error, showing that maybe the `version` or `language` are misspelled or sources are not available.<br/>This provides an useful description on errors when performing `check`.

- [x] **Adition of `check` and `build` current versions by language:** <br/> Added targets which builds/checks specific language., making easy the building for translators when making reviews (new targets: `build-current-en`, `build-current-ja`, `build-current-pt_br`,  `build-current-zh_cn` `check-current-en`, `check-current-ja`, `check-current-pt_br` and `check-current-zh_cn`). <br/> The `check-current` and `build-current` now uses this targets as depends. This makes easy the maintain on update or new PHPUnit version. Note: `build-current` is made/sorted by language now instead of by version.

- [x] :memo: **Ant documentation:** <br/> Description added to main targets and project (with basic usage instructions).<br/> This makes available the project info via `ant -p`.

- [ ] Always performs `check` in `build` target?
