### PR TITLE
Remove references to Selenium XML config

### DIFF
--- a/src/5.0/en/configuration.xml
+++ b/src/5.0/en/configuration.xml
@@ -401,21 +401,8 @@ $_REQUEST['foo'] = 'bar';]]></screen>
     <para>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
-      The <literal><![CDATA[<selenium>]]></literal> element and its
-      <literal><![CDATA[<browser>]]></literal> children can be used to
-      configure a list of Selenium RC servers.
-    </para>
-
-    <screen><![CDATA[<selenium>
-  <browser name="Firefox on Linux"
-           browser="*firefox /usr/lib/firefox/firefox-bin"
-           host="my.linux.box"
-           port="4444"
-           timeout="30000"/>
-</selenium>]]></screen>
-
-    <para>
-      The XML configuration above corresponds to the following PHP code:
+      The following PHP code can be used to configure a list of Selenium
+      RC servers:
     </para>
 
     <screen><![CDATA[class WebTest extends PHPUnit_Extensions_SeleniumTestCase

--- a/src/5.1/en/configuration.xml
+++ b/src/5.1/en/configuration.xml
@@ -401,21 +401,8 @@ $_REQUEST['foo'] = 'bar';]]></screen>
     <para>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
-      The <literal><![CDATA[<selenium>]]></literal> element and its
-      <literal><![CDATA[<browser>]]></literal> children can be used to
-      configure a list of Selenium RC servers.
-    </para>
-
-    <screen><![CDATA[<selenium>
-  <browser name="Firefox on Linux"
-           browser="*firefox /usr/lib/firefox/firefox-bin"
-           host="my.linux.box"
-           port="4444"
-           timeout="30000"/>
-</selenium>]]></screen>
-
-    <para>
-      The XML configuration above corresponds to the following PHP code:
+      The following PHP code can be used to configure a list of Selenium
+      RC servers:
     </para>
 
     <screen><![CDATA[class WebTest extends PHPUnit_Extensions_SeleniumTestCase

--- a/src/5.2/en/configuration.xml
+++ b/src/5.2/en/configuration.xml
@@ -401,21 +401,8 @@ $_REQUEST['foo'] = 'bar';]]></screen>
     <para>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
-      The <literal><![CDATA[<selenium>]]></literal> element and its
-      <literal><![CDATA[<browser>]]></literal> children can be used to
-      configure a list of Selenium RC servers.
-    </para>
-
-    <screen><![CDATA[<selenium>
-  <browser name="Firefox on Linux"
-           browser="*firefox /usr/lib/firefox/firefox-bin"
-           host="my.linux.box"
-           port="4444"
-           timeout="30000"/>
-</selenium>]]></screen>
-
-    <para>
-      The XML configuration above corresponds to the following PHP code:
+      The following PHP code can be used to configure a list of Selenium
+      RC servers:
     </para>
 
     <screen><![CDATA[class WebTest extends PHPUnit_Extensions_SeleniumTestCase


### PR DESCRIPTION
Since PHPUnit v5 the selenium XML config has been removed.

This PR only covers EN.