### PR TITLE
add optional version identifier to @requires extension in 5.3 docs

### DIFF
--- a/src/5.3/en/incomplete-and-skipped-tests.xml
+++ b/src/5.3/en/incomplete-and-skipped-tests.xml
@@ -253,9 +253,9 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
           </row>
           <row>
             <entry><literal>extension</literal></entry>
-            <entry>Any extension name</entry>
+            <entry>Any extension name along with an optional version identifier</entry>
             <entry>@requires extension mysqli</entry>
-            <entry>@requires extension curl</entry>
+            <entry>@requires extension redis 2.2.0</entry>
           </row>
         </tbody>
       </tgroup>


### PR DESCRIPTION
This adds the optional version identifier introduced in PHPUnit 5.2 to the 5.3 docs.