### PR TITLE
Update doc for @small

### DIFF
--- a/src/4.7/en/annotations.xml
+++ b/src/4.7/en/annotations.xml
@@ -774,11 +774,8 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
   </section>

--- a/src/4.8/en/annotations.xml
+++ b/src/4.8/en/annotations.xml
@@ -774,11 +774,8 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
   </section>

--- a/src/5.0/en/annotations.xml
+++ b/src/5.0/en/annotations.xml
@@ -774,11 +774,8 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
   </section>

--- a/src/5.1/en/annotations.xml
+++ b/src/5.1/en/annotations.xml
@@ -774,11 +774,8 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
   </section>

--- a/src/5.2/en/annotations.xml
+++ b/src/5.2/en/annotations.xml
@@ -778,7 +778,7 @@ class MyTest extends PHPUnit_Framework_TestCase
         <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
-    </section>
+  </section>
 
   <section id="appendixes.annotations.test">
     <title>@test</title>

--- a/src/5.2/en/annotations.xml
+++ b/src/5.2/en/annotations.xml
@@ -774,14 +774,11 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
-  </section>
+    </section>
 
   <section id="appendixes.annotations.test">
     <title>@test</title>

--- a/src/5.3/en/annotations.xml
+++ b/src/5.3/en/annotations.xml
@@ -774,11 +774,8 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
   </section>

--- a/src/5.4/en/annotations.xml
+++ b/src/5.4/en/annotations.xml
@@ -774,11 +774,8 @@ class MyTest extends PHPUnit_Framework_TestCase
 
     <note>
       <para>
-        By default, all tests are considered to be small if they are not marked
-        as <literal>@medium</literal> or <literal>@large</literal>. Please note,
-        however, that <literal>--group</literal> and the related options will
-        only consider a test to be in the <literal>small</literal> group if it
-        is explicitly marked with the appropriate annotation.
+        Tests need to be explicitly annotated by either <literal>@small</literal>, 
+        <literal>@medium</literal> or <literal>@large</literal> to enable run time limits.
       </para>
     </note>
   </section>


### PR DESCRIPTION
The default behavior changed and does not consider unannotated tests to have a size anymore since PHPUnit 4.7

Fixes #311 in english documents. I won't boldly edit the other languages without knowing them.