### PR TITLE
Trick for avoid the mock limitations

### DIFF
--- a/src/5.4/en/test-doubles.xml
+++ b/src/5.4/en/test-doubles.xml
@@ -460,7 +460,59 @@ class StubTest extends PHPUnit_Framework_TestCase
         automatically by PHPUnit. Mock objects generated in data providers, for
         instance, or injected into the test using the <literal>@depends</literal>
         annotation will not be verified automatically by PHPUnit.
+
+        One way for achieve a similar result is to wrap the construction of the
+        mock object inside of a <literal>Closure</literal> and bind the test scope
+        before invoke the Closure.
       </para>
+
+      <example id="test-doubles.mock-objects.examples.wrapMocks.php">
+        <title>Wrapping the mock inside of Closure</title>
+        <programlisting><![CDATA[<?php
+class SubjectTest extends PHPUnit_Framework_TestCase
+{
+    public function mockProvider()
+    {
+      $mockCallable = function() {
+        return $this->getMockBuilder(Observer::class)
+             ->setMethods(['update'])
+             ->getMock();
+      }
+    
+      return [
+        [$mockCallable];
+    }
+
+    /**
+     * @dataProvider mockProvider
+     */
+    public function testObserversAreUpdated(Callable $mockCallable)
+    {
+        // Create a mock for the Observer class,
+        // only mock the update() method.
+        $observer = $mockCallable->bindTo($this);
+
+        // Set up the expectation for the update() method
+        // to be called only once and with the string 'something'
+        // as its parameter.
+        $observer->expects($this->once())
+                 ->method('update')
+                 ->with($this->equalTo('something'));
+
+        // Create a Subject object and attach the mocked
+        // Observer object to it.
+        $subject = new Subject('My subject');
+        $subject->attach($observer);
+
+        // Call the doSomething() method on the $subject object
+        // which we expect to call the mocked Observer object's
+        // update() method with the string 'something'.
+        $subject->doSomething();
+    }
+}
+?>]]></programlisting>
+      </example>
+
     </note>
 
     <para>

--- a/src/5.4/en/test-doubles.xml
+++ b/src/5.4/en/test-doubles.xml
@@ -490,7 +490,8 @@ class SubjectTest extends PHPUnit_Framework_TestCase
     {
         // Create a mock for the Observer class,
         // only mock the update() method.
-        $observer = $mockCallable->bindTo($this);
+        $mockCallable = $mockCallable->bindTo($this);
+        $observer = $mockCallable();
 
         // Set up the expectation for the update() method
         // to be called only once and with the string 'something'


### PR DESCRIPTION
One way of fix the limitations about "Automatic verification expectations" when those are created in a different scope than the target test (data providers, dependencies, ...) is to wrap the construction of the mock object into a Closure and bind the correct scope before create the mock object.
