### PR TITLE
Protected methods are not mocked either

### DIFF
--- a/src/5.4/en/test-doubles.xml
+++ b/src/5.4/en/test-doubles.xml
@@ -66,9 +66,9 @@
 
     <para>
       Please note that <literal>final</literal>, <literal>private</literal>
-      and <literal>static</literal> methods cannot be stubbed or mocked. They
-      are ignored by PHPUnit's test double functionality and retain their
-      original behavior.
+      <literal>static</literal>, and <literal>protected</literal> methods
+      cannot be stubbed or mocked. They are ignored by PHPUnit's test double
+      functionality and retain their original behavior.
     </para>
   </note>
 

--- a/src/5.4/en/test-doubles.xml
+++ b/src/5.4/en/test-doubles.xml
@@ -62,7 +62,7 @@
   </para>
 
   <note>
-    <title>Limitation: final, private, and static methods</title>
+    <title>Limitation: final, private, static, and protected methods</title>
 
     <para>
       Please note that <literal>final</literal>, <literal>private</literal>


### PR DESCRIPTION
Given the following code to get methods to stub:

src/Framework/MockObject/Generator.php:

``` php
/**
 * @param string $className
 *
 * @return array
 *
 * @since  Method available since Release 2.3.2
 */
private function getClassMethods($className)
{
    $class   = new ReflectionClass($className);
    $methods = [];

    foreach ($class->getMethods() as $method) {
        if ($method->isPublic() || $method->isAbstract()) {
            $methods[] = $method->getName();
        }
    }

    return $methods;
}
```

Only public or abstract methods are actually returned for stubbing. If I'm missing something please feel free to reject!
