### PR TITLE
Add documentation for setNotMethods

### DIFF
--- a/src/5.4/en/test-doubles.xml
+++ b/src/5.4/en/test-doubles.xml
@@ -819,7 +819,7 @@ class FooTest extends PHPUnit_Framework_TestCase
 
     <itemizedlist>
       <listitem><para><literal>setMethods(array $methods)</literal> can be called on the Mock Builder object to specify the methods that are to be replaced with a configurable test double. The behavior of the other methods is not changed. If you call <literal>setMethods(null)</literal>, then no methods will be replaced.</para></listitem>
-      <listitem><para><literal>setNotMethods(array $methods)</literal> can be called on the Mock Builder object to specify the methods that will not be replaced with a configurable test double while replacing all other public methods. If you call <literal>setNotMethods(null)</literal>, then no methods will be replaced. This works inverse to setMethods and both should not be used together.</para></listitem>
+      <listitem><para><literal>setMethodsExcept(array $methods)</literal> can be called on the Mock Builder object to specify the methods that will not be replaced with a configurable test double while replacing all other public methods. This works inverse to setMethods().</para></listitem>
       <listitem><para><literal>setConstructorArgs(array $args)</literal> can be called to provide a parameter array that is passed to the original class' constructor (which is not replaced with a dummy implementation by default).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> can be used to specify a class name for the generated test double class.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> can be used to disable the call to the original class' constructor.</para></listitem>

--- a/src/5.4/en/test-doubles.xml
+++ b/src/5.4/en/test-doubles.xml
@@ -819,6 +819,7 @@ class FooTest extends PHPUnit_Framework_TestCase
 
     <itemizedlist>
       <listitem><para><literal>setMethods(array $methods)</literal> can be called on the Mock Builder object to specify the methods that are to be replaced with a configurable test double. The behavior of the other methods is not changed. If you call <literal>setMethods(null)</literal>, then no methods will be replaced.</para></listitem>
+      <listitem><para><literal>setNotMethods(array $methods)</literal> can be called on the Mock Builder object to specify the methods that will not be replaced with a configurable test double while replacing all other public methods. If you call <literal>setNotMethods(null)</literal>, then no methods will be replaced. This works inverse to setMethods and both should not be used together.</para></listitem>
       <listitem><para><literal>setConstructorArgs(array $args)</literal> can be called to provide a parameter array that is passed to the original class' constructor (which is not replaced with a dummy implementation by default).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> can be used to specify a class name for the generated test double class.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> can be used to disable the call to the original class' constructor.</para></listitem>


### PR DESCRIPTION
Pending https://github.com/sebastianbergmann/phpunit-mock-objects/pull/306

Adds documentation for setNotMethods() for mock builder.
