### PR TITLE
"can be used skip" vs "can be used to skip"

### DIFF
--- a/src/3.7/en/annotations.xml
+++ b/src/3.7/en/annotations.xml
@@ -543,7 +543,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.0/en/annotations.xml
+++ b/src/4.0/en/annotations.xml
@@ -657,7 +657,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.1/en/annotations.xml
+++ b/src/4.1/en/annotations.xml
@@ -657,7 +657,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.2/en/annotations.xml
+++ b/src/4.2/en/annotations.xml
@@ -676,7 +676,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.3/en/annotations.xml
+++ b/src/4.3/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.4/en/annotations.xml
+++ b/src/4.4/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.5/en/annotations.xml
+++ b/src/4.5/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.6/en/annotations.xml
+++ b/src/4.6/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.7/en/annotations.xml
+++ b/src/4.7/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/4.8/en/annotations.xml
+++ b/src/4.8/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/5.0/en/annotations.xml
+++ b/src/5.0/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/5.1/en/annotations.xml
+++ b/src/5.1/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/5.2/en/annotations.xml
+++ b/src/5.2/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/5.3/en/annotations.xml
+++ b/src/5.3/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 

--- a/src/5.4/en/annotations.xml
+++ b/src/5.4/en/annotations.xml
@@ -686,7 +686,7 @@ class MyClass
     <para>
       <indexterm><primary><literal>@requires</literal></primary></indexterm>
 
-      The <literal>@requires</literal> annotation can be used skip tests when common
+      The <literal>@requires</literal> annotation can be used to skip tests when common
       preconditions, like the PHP Version or installed extensions, are not met.
     </para>
 


### PR DESCRIPTION
Just noticed this while reading through. Thought I'd contribute this
tiny fix.