### PR TITLE
Updated docs to the new option beStrictAboutCoversAnnotation.

### DIFF
--- a/src/5.2/en/risky-tests.xml
+++ b/src/5.2/en/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit can be strict about unintentionally covered code. This check
       can be enabled by using the <literal>--strict-coverage</literal> option on
       the commandline or by setting
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> in PHPUnit's
+      <literal>beStrictAboutCoversAnnotation="true"</literal> in PHPUnit's
       XML configuration file.
     </para>
 

--- a/src/5.2/ja/risky-tests.xml
+++ b/src/5.2/ja/risky-tests.xml
@@ -34,7 +34,7 @@
       このチェックを有効にするには、コマンドラインオプション
       <literal>--strict-coverage</literal>
       を使うか、あるいは PHPUnit の XML 設定ファイルで
-      <literal>checkForUnintentionallyCoveredCode="true"</literal>
+      <literal>beStrictAboutCoversAnnotation="true"</literal>
       を設定します。
     </para>
 

--- a/src/5.2/pt_br/risky-tests.xml
+++ b/src/5.2/pt_br/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit pode ser estrito sobre cobertura de código involuntária. Esta verificação
       pode ser habilitada usando a opção <literal>--strict-coverage</literal>
       na linha de comando ou pela definição 
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> no
+      <literal>beStrictAboutCoversAnnotation="true"</literal> no
       arquivo de configuração XML do PHPUnit.
     </para>
 

--- a/src/5.2/zh_cn/risky-tests.xml
+++ b/src/5.2/zh_cn/risky-tests.xml
@@ -16,7 +16,7 @@
   <section id="risky-tests.unintentionally-covered-code">
     <title>意外的代码覆盖</title>
 
-    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>checkForUnintentionallyCoveredCode=&quot;true&quot;</literal> 来启用。</para>
+    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>beStrictAboutCoversAnnotation=&quot;true&quot;</literal> 来启用。</para>
 
     <para>在启用本项检查后，如果某个带有 <code>@covers</code> 标注的测试执行了未在 <code>@covers</code> 或 <code>@uses</code> 标注中列出的代码，它将被标记为有风险。</para>
   </section>

--- a/src/5.3/en/risky-tests.xml
+++ b/src/5.3/en/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit can be strict about unintentionally covered code. This check
       can be enabled by using the <literal>--strict-coverage</literal> option on
       the commandline or by setting
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> in PHPUnit's
+      <literal>beStrictAboutCoversAnnotation="true"</literal> in PHPUnit's
       XML configuration file.
     </para>
 

--- a/src/5.3/ja/risky-tests.xml
+++ b/src/5.3/ja/risky-tests.xml
@@ -34,7 +34,7 @@
       このチェックを有効にするには、コマンドラインオプション
       <literal>--strict-coverage</literal>
       を使うか、あるいは PHPUnit の XML 設定ファイルで
-      <literal>checkForUnintentionallyCoveredCode="true"</literal>
+      <literal>beStrictAboutCoversAnnotation="true"</literal>
       を設定します。
     </para>
 

--- a/src/5.3/pt_br/risky-tests.xml
+++ b/src/5.3/pt_br/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit pode ser estrito sobre cobertura de código involuntária. Esta verificação
       pode ser habilitada usando a opção <literal>--strict-coverage</literal>
       na linha de comando ou pela definição 
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> no
+      <literal>beStrictAboutCoversAnnotation="true"</literal> no
       arquivo de configuração XML do PHPUnit.
     </para>
 

--- a/src/5.3/zh_cn/risky-tests.xml
+++ b/src/5.3/zh_cn/risky-tests.xml
@@ -16,7 +16,7 @@
   <section id="risky-tests.unintentionally-covered-code">
     <title>意外的代码覆盖</title>
 
-    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>checkForUnintentionallyCoveredCode=&quot;true&quot;</literal> 来启用。</para>
+    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>beStrictAboutCoversAnnotation=&quot;true&quot;</literal> 来启用。</para>
 
     <para>在启用本项检查后，如果某个带有 <code>@covers</code> 标注的测试执行了未在 <code>@covers</code> 或 <code>@uses</code> 标注中列出的代码，它将被标记为有风险。</para>
   </section>

--- a/src/5.4/en/risky-tests.xml
+++ b/src/5.4/en/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit can be strict about unintentionally covered code. This check
       can be enabled by using the <literal>--strict-coverage</literal> option on
       the commandline or by setting
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> in PHPUnit's
+      <literal>beStrictAboutCoversAnnotation="true"</literal> in PHPUnit's
       XML configuration file.
     </para>
 

--- a/src/5.4/ja/risky-tests.xml
+++ b/src/5.4/ja/risky-tests.xml
@@ -34,7 +34,7 @@
       このチェックを有効にするには、コマンドラインオプション
       <literal>--strict-coverage</literal>
       を使うか、あるいは PHPUnit の XML 設定ファイルで
-      <literal>checkForUnintentionallyCoveredCode="true"</literal>
+      <literal>beStrictAboutCoversAnnotation="true"</literal>
       を設定します。
     </para>
 

--- a/src/5.4/pt_br/risky-tests.xml
+++ b/src/5.4/pt_br/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit pode ser estrito sobre cobertura de código involuntária. Esta verificação
       pode ser habilitada usando a opção <literal>--strict-coverage</literal>
       na linha de comando ou pela definição 
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> no
+      <literal>beStrictAboutCoversAnnotation="true"</literal> no
       arquivo de configuração XML do PHPUnit.
     </para>
 

--- a/src/5.4/zh_cn/risky-tests.xml
+++ b/src/5.4/zh_cn/risky-tests.xml
@@ -16,7 +16,7 @@
   <section id="risky-tests.unintentionally-covered-code">
     <title>意外的代码覆盖</title>
 
-    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>checkForUnintentionallyCoveredCode=&quot;true&quot;</literal> 来启用。</para>
+    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>beStrictAboutCoversAnnotation=&quot;true&quot;</literal> 来启用。</para>
 
     <para>在启用本项检查后，如果某个带有 <code>@covers</code> 标注的测试执行了未在 <code>@covers</code> 或 <code>@uses</code> 标注中列出的代码，它将被标记为有风险。</para>
   </section>

--- a/src/5.5/en/risky-tests.xml
+++ b/src/5.5/en/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit can be strict about unintentionally covered code. This check
       can be enabled by using the <literal>--strict-coverage</literal> option on
       the commandline or by setting
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> in PHPUnit's
+      <literal>beStrictAboutCoversAnnotation="true"</literal> in PHPUnit's
       XML configuration file.
     </para>
 

--- a/src/5.5/ja/risky-tests.xml
+++ b/src/5.5/ja/risky-tests.xml
@@ -34,7 +34,7 @@
       このチェックを有効にするには、コマンドラインオプション
       <literal>--strict-coverage</literal>
       を使うか、あるいは PHPUnit の XML 設定ファイルで
-      <literal>checkForUnintentionallyCoveredCode="true"</literal>
+      <literal>beStrictAboutCoversAnnotation="true"</literal>
       を設定します。
     </para>
 

--- a/src/5.5/pt_br/risky-tests.xml
+++ b/src/5.5/pt_br/risky-tests.xml
@@ -33,7 +33,7 @@
       PHPUnit pode ser estrito sobre cobertura de código involuntária. Esta verificação
       pode ser habilitada usando a opção <literal>--strict-coverage</literal>
       na linha de comando ou pela definição 
-      <literal>checkForUnintentionallyCoveredCode="true"</literal> no
+      <literal>beStrictAboutCoversAnnotation="true"</literal> no
       arquivo de configuração XML do PHPUnit.
     </para>
 

--- a/src/5.5/zh_cn/risky-tests.xml
+++ b/src/5.5/zh_cn/risky-tests.xml
@@ -16,7 +16,7 @@
   <section id="risky-tests.unintentionally-covered-code">
     <title>意外的代码覆盖</title>
 
-    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>checkForUnintentionallyCoveredCode=&quot;true&quot;</literal> 来启用。</para>
+    <para>PHPUnit 可以更严格对待意外的代码覆盖。此项检查可以用命令行选项 <literal>--strict-coverage</literal> 或在 PHPUnit 的 XML 配置文件中设置 <literal>beStrictAboutCoversAnnotation=&quot;true&quot;</literal> 来启用。</para>
 
     <para>在启用本项检查后，如果某个带有 <code>@covers</code> 标注的测试执行了未在 <code>@covers</code> 或 <code>@uses</code> 标注中列出的代码，它将被标记为有风险。</para>
   </section>


### PR DESCRIPTION
The Chapter 6 about Risky Tests is still mentioning the option `checkForUnintentionallyCoveredCode` (which is deprecated and replaced by `beStrictAboutCoversAnnotation`).
The docs of both Version 5.4 [(https://phpunit.de/manual/5.4/en/risky-tests.html#risky-tests.unintentionally-covered-code)](https://phpunit.de/manual/5.4/en/risky-tests.html#risky-tests.unintentionally-covered-code) and 5.5 are outdated [(https://phpunit.de/manual/5.5/en/risky-tests.html#risky-tests.unintentionally-covered-code)](https://phpunit.de/manual/5.5/en/risky-tests.html#risky-tests.unintentionally-covered-code).
