### PR TITLE
added editor configuration file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,4 @@ trim_trailing_whitespace = true
 trim_trailing_whitespace = false
 
 [*.php]
-indent_size = 2
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.php]
+indent_size = 2


### PR DESCRIPTION
fixes #397 

proposing the following default rules:
- linux line endings
  -charset UTF-8
- 2 spaces for indentation
- trailing white line at end-of-file
- whitespace trimming on line end

overrides for PHP files (4 spaces indentation) and Markdown (no end-of-line whitespace trimming)
