### PR TITLE
Add documentation for @testWith annotation

### DIFF
--- a/src/4.8/en/annotations.xml
+++ b/src/4.8/en/annotations.xml
@@ -810,6 +810,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.0/en/annotations.xml
+++ b/src/5.0/en/annotations.xml
@@ -810,6 +810,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.1/en/annotations.xml
+++ b/src/5.1/en/annotations.xml
@@ -810,6 +810,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.2/en/annotations.xml
+++ b/src/5.2/en/annotations.xml
@@ -810,6 +810,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.3/en/annotations.xml
+++ b/src/5.3/en/annotations.xml
@@ -810,6 +810,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.4/en/annotations.xml
+++ b/src/5.4/en/annotations.xml
@@ -843,6 +843,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.5/en/annotations.xml
+++ b/src/5.5/en/annotations.xml
@@ -843,6 +843,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.6/en/annotations.xml
+++ b/src/5.6/en/annotations.xml
@@ -843,6 +843,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/5.7/en/annotations.xml
+++ b/src/5.7/en/annotations.xml
@@ -843,6 +843,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/6.0/en/annotations.xml
+++ b/src/6.0/en/annotations.xml
@@ -843,6 +843,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 

--- a/src/6.1/en/annotations.xml
+++ b/src/6.1/en/annotations.xml
@@ -843,6 +843,29 @@ public function initialBalanceShouldBe0()
     <programlisting></programlisting>
   </section>
 
+  <section id="appendixes.annotations.testWith">
+    <title>@testWith</title>
+
+    <para>
+        <indexterm><primary>@testWith</primary></indexterm>
+
+        Instead of writing a complete <literal>dataProvider</literal> method, you
+        can define a test data set within the annotation by the use of <literal>
+        @testWith</literal>.
+        <programlisting>/**
+ * @param string    $input
+ * @param int       $expectedLength
+ *
+ * @testWith        ["test", 4]
+ *                  ["longer-string", 13]
+ */
+public function testStringLength(string $input, int $expectedLength)
+{
+    $this->assertEquals($expectedLength, strlen($input));
+}</programlisting>
+    </para>
+  </section>
+
   <section id="appendixes.annotations.ticket">
     <title>@ticket</title>
 


### PR DESCRIPTION
Added a sample explaining the use of `@testWith`. I've added it for all versions since 4.8 (where I believe it was added).

<img width="928" alt="screenshot 2017-03-22 21 22 23" src="https://cloud.githubusercontent.com/assets/5747956/24219015/a9584c38-0f45-11e7-8c88-5057521c45e2.png">
