### PR TITLE
modify Exception to Throwable

### DIFF
--- a/src/4.0/en/fixtures.xml
+++ b/src/4.0/en/fixtures.xml
@@ -170,7 +170,7 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/4.0/fr/fixtures.xml
+++ b/src/4.0/fr/fixtures.xml
@@ -169,7 +169,7 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/4.0/ja/fixtures.xml
+++ b/src/4.0/ja/fixtures.xml
@@ -170,7 +170,7 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/4.0/pt_br/fixtures.xml
+++ b/src/4.0/pt_br/fixtures.xml
@@ -144,7 +144,7 @@ public static function tearDownAfterClass()
 fwrite(STDOUT, __METHOD__ . "\n");
 }
 
-protected function onNotSuccessfulTest(Exception $e)
+protected function onNotSuccessfulTest(Throwable $e)
 {
 fwrite(STDOUT, __METHOD__ . "\n");
 throw $e;

--- a/src/4.0/zh_cn/fixtures.xml
+++ b/src/4.0/zh_cn/fixtures.xml
@@ -116,7 +116,7 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;


### PR DESCRIPTION
PHP Warning in PHPUnit 6.0.11 : Declaration of TemplateMethodsTest::onNotSuccessfulTest(Exception $e) should be compatible with PHPUnit\Framework\TestCase::onNotSuccessfulTest(Throwable $t)