### PR TITLE
modify Exception to Throwable in PHPUnit 6.0.11

### DIFF
--- a/src/6.0/en/fixtures.xml
+++ b/src/6.0/en/fixtures.xml
@@ -174,7 +174,7 @@ class TemplateMethodsTest extends TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/6.0/fr/fixtures.xml
+++ b/src/6.0/fr/fixtures.xml
@@ -169,7 +169,7 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/6.0/ja/fixtures.xml
+++ b/src/6.0/ja/fixtures.xml
@@ -174,7 +174,7 @@ class TemplateMethodsTest extends TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/6.0/pt_br/fixtures.xml
+++ b/src/6.0/pt_br/fixtures.xml
@@ -169,7 +169,7 @@ class TemplateMethodsTest extends PHPUnit_Framework_TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;

--- a/src/6.0/zh_cn/fixtures.xml
+++ b/src/6.0/zh_cn/fixtures.xml
@@ -120,7 +120,7 @@ class TemplateMethodsTest extends TestCase
         fwrite(STDOUT, __METHOD__ . "\n");
     }
 
-    protected function onNotSuccessfulTest(Exception $e)
+    protected function onNotSuccessfulTest(Throwable $e)
     {
         fwrite(STDOUT, __METHOD__ . "\n");
         throw $e;


### PR DESCRIPTION
Declaration of TemplateMethodsTest::onNotSuccessfulTest(Exception $e) should be compatible with PHPUnit\Framework\TestCase::onNotSuccessfulTest(Throwable $t)