### PR TITLE
Add commas to "@depends clone" note

### DIFF
--- a/src/5.0/en/writing-tests-for-phpunit.xml
+++ b/src/5.0/en/writing-tests-for-phpunit.xml
@@ -141,7 +141,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.0/en/writing-tests-for-phpunit.xml
+++ b/src/5.0/en/writing-tests-for-phpunit.xml
@@ -143,7 +143,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.1/en/writing-tests-for-phpunit.xml
+++ b/src/5.1/en/writing-tests-for-phpunit.xml
@@ -141,7 +141,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.1/en/writing-tests-for-phpunit.xml
+++ b/src/5.1/en/writing-tests-for-phpunit.xml
@@ -143,7 +143,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.2/en/writing-tests-for-phpunit.xml
+++ b/src/5.2/en/writing-tests-for-phpunit.xml
@@ -141,7 +141,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.2/en/writing-tests-for-phpunit.xml
+++ b/src/5.2/en/writing-tests-for-phpunit.xml
@@ -143,7 +143,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.3/en/writing-tests-for-phpunit.xml
+++ b/src/5.3/en/writing-tests-for-phpunit.xml
@@ -141,7 +141,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.3/en/writing-tests-for-phpunit.xml
+++ b/src/5.3/en/writing-tests-for-phpunit.xml
@@ -143,7 +143,7 @@ class StackTest extends PHPUnit_Framework_TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.4/en/writing-tests-for-phpunit.xml
+++ b/src/5.4/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.4/en/writing-tests-for-phpunit.xml
+++ b/src/5.4/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.5/en/writing-tests-for-phpunit.xml
+++ b/src/5.5/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.5/en/writing-tests-for-phpunit.xml
+++ b/src/5.5/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.6/en/writing-tests-for-phpunit.xml
+++ b/src/5.6/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.6/en/writing-tests-for-phpunit.xml
+++ b/src/5.6/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/5.7/en/writing-tests-for-phpunit.xml
+++ b/src/5.7/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/5.7/en/writing-tests-for-phpunit.xml
+++ b/src/5.7/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/6.0/en/writing-tests-for-phpunit.xml
+++ b/src/6.0/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/6.0/en/writing-tests-for-phpunit.xml
+++ b/src/6.0/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/6.1/en/writing-tests-for-phpunit.xml
+++ b/src/6.1/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/6.1/en/writing-tests-for-phpunit.xml
+++ b/src/6.1/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>

--- a/src/6.2/en/writing-tests-for-phpunit.xml
+++ b/src/6.2/en/writing-tests-for-phpunit.xml
@@ -145,7 +145,7 @@ class StackTest extends TestCase
         <indexterm><primary>@depends</primary></indexterm>
 
         The return value yielded by a producer is passed "as-is" to its
-        consumers by default. This means that when a producer returns an object
+        consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
         should be used instead of a reference then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.

--- a/src/6.2/en/writing-tests-for-phpunit.xml
+++ b/src/6.2/en/writing-tests-for-phpunit.xml
@@ -147,7 +147,7 @@ class StackTest extends TestCase
         The return value yielded by a producer is passed "as-is" to its
         consumers by default. This means that when a producer returns an object,
         a reference to that object is passed to the consumers. When a copy
-        should be used instead of a reference then <code>@depends clone</code>
+        should be used instead of a reference, then <code>@depends clone</code>
         should be used instead of <code>@depends</code>.
       </para>
     </note>


### PR DESCRIPTION
These commas help to improve the clarity of the sentences involved.

The first comma separates two dependent clauses that have no obvious separation. The second comma clarifies the separation between two dependent clauses.