### PR TITLE
Remove file redirection for coverage-text option

### DIFF
--- a/src/6.2/en/configuration.xml
+++ b/src/6.2/en/configuration.xml
@@ -283,7 +283,6 @@
       <listitem><para><literal>--coverage-clover /tmp/coverage.xml</literal></para></listitem>
       <listitem><para><literal>--coverage-php /tmp/coverage.serialized</literal></para></listitem>
       <listitem><para><literal>--coverage-text</literal></para></listitem>
-      <listitem><para><literal><![CDATA[>]]> /tmp/logfile.txt</literal></para></listitem>
       <listitem><para><literal>--log-junit /tmp/logfile.xml</literal></para></listitem>
       <listitem><para><literal>--testdox-html /tmp/testdox.html</literal></para></listitem>
       <listitem><para><literal>--testdox-text /tmp/testdox.txt</literal></para></listitem>


### PR DESCRIPTION
The `coverage-text` XML `target` value is `php://stdout`, so the corresponding test runner should not redirect the output to a file.