### PR TITLE
Minor grammar "necessarily"

### DIFF
--- a/src/6.4/en/writing-tests-for-phpunit.xml
+++ b/src/6.4/en/writing-tests-for-phpunit.xml
@@ -62,7 +62,7 @@ class StackTest extends TestCase
         for a unit of software under test. To achieve these benefits, unit tests
         ideally should cover all the possible paths in a program. One unit test
         usually covers one specific path in one function or method. However a
-        test method is not necessary an encapsulated, independent entity. Often
+        test method is not necessarily an encapsulated, independent entity. Often
         there are implicit dependencies between test methods, hidden in the
         implementation scenario of a test.
       </para>


### PR DESCRIPTION
Fix it while I am reading.
What happens about this type of grammar fix for all the old doc version folders?