### PR TITLE
logIncompleteSkipped was removed from PHPUnit 6.0

### DIFF
--- a/src/6.0/en/configuration.xml
+++ b/src/6.0/en/configuration.xml
@@ -268,7 +268,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -290,8 +290,7 @@
     </itemizedlist>
 
     <para>
-      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> and
+      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> and
       <literal>showUncoveredFiles</literal> attributes have no equivalent TextUI
       test runner option.
     </para>

--- a/src/6.0/fr/configuration.xml
+++ b/src/6.0/fr/configuration.xml
@@ -205,7 +205,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -231,7 +231,7 @@
     <para>
       Les attributs <literal>charset</literal>, <literal>yui</literal>,
       <literal>highlight</literal>, <literal>lowUpperBound</literal>,
-      <literal>highLowerBound</literal>, <literal>logIncompleteSkipped</literal>
+      <literal>highLowerBound</literal>
       and <literal>showUncoveredFiles</literal>
       n'ont pas d'options équivalentes pour le lanceur de tests TextUI.
     </para>

--- a/src/6.0/ja/configuration.xml
+++ b/src/6.0/ja/configuration.xml
@@ -248,7 +248,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -269,8 +269,7 @@
     </itemizedlist>
 
     <para>
-      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、
-      <literal>logIncompleteSkipped</literal>
+      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal>
       および <literal>showUncoveredFiles</literal>
       属性には、TextUI テストランナーで対応するオプションがありません。
     </para>

--- a/src/6.0/pt_br/configuration.xml
+++ b/src/6.0/pt_br/configuration.xml
@@ -303,8 +303,7 @@
     </itemizedlist>
 
     <para>
-      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> e
+      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> e
       <literal>showUncoveredFiles</literal> não possuem opção de 
       execução de teste TextUI equivalente.
     </para>

--- a/src/6.0/zh_cn/configuration.xml
+++ b/src/6.0/zh_cn/configuration.xml
@@ -189,7 +189,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -207,7 +207,7 @@
       <listitem><para><literal>--testdox-text /tmp/testdox.txt</literal></para></listitem>
     </itemizedlist>
 
-    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、<literal>logIncompleteSkipped</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
+    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
 
     <itemizedlist>
       <listitem><para><literal>lowUpperBound</literal>：视为“低”覆盖率的最大覆盖率百分比。</para></listitem>

--- a/src/6.1/en/configuration.xml
+++ b/src/6.1/en/configuration.xml
@@ -268,7 +268,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -290,8 +290,7 @@
     </itemizedlist>
 
     <para>
-      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> and
+      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> and
       <literal>showUncoveredFiles</literal> attributes have no equivalent TextUI
       test runner option.
     </para>

--- a/src/6.1/fr/configuration.xml
+++ b/src/6.1/fr/configuration.xml
@@ -205,7 +205,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -231,8 +231,7 @@
     <para>
       Les attributs <literal>charset</literal>, <literal>yui</literal>,
       <literal>highlight</literal>, <literal>lowUpperBound</literal>,
-      <literal>highLowerBound</literal>, <literal>logIncompleteSkipped</literal>
-      and <literal>showUncoveredFiles</literal>
+      <literal>highLowerBound</literal> and <literal>showUncoveredFiles</literal>
       n'ont pas d'options équivalentes pour le lanceur de tests TextUI.
     </para>
 

--- a/src/6.1/ja/configuration.xml
+++ b/src/6.1/ja/configuration.xml
@@ -248,7 +248,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -269,9 +269,7 @@
     </itemizedlist>
 
     <para>
-      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、
-      <literal>logIncompleteSkipped</literal>
-      および <literal>showUncoveredFiles</literal>
+      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal> および <literal>showUncoveredFiles</literal>
       属性には、TextUI テストランナーで対応するオプションがありません。
     </para>
 

--- a/src/6.1/pt_br/configuration.xml
+++ b/src/6.1/pt_br/configuration.xml
@@ -279,7 +279,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -303,8 +303,7 @@
     </itemizedlist>
 
     <para>
-      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> e
+      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> e
       <literal>showUncoveredFiles</literal> não possuem opção de 
       execução de teste TextUI equivalente.
     </para>

--- a/src/6.1/zh_cn/configuration.xml
+++ b/src/6.1/zh_cn/configuration.xml
@@ -189,7 +189,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -207,7 +207,7 @@
       <listitem><para><literal>--testdox-text /tmp/testdox.txt</literal></para></listitem>
     </itemizedlist>
 
-    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、<literal>logIncompleteSkipped</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
+    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
 
     <itemizedlist>
       <listitem><para><literal>lowUpperBound</literal>：视为“低”覆盖率的最大覆盖率百分比。</para></listitem>

--- a/src/6.2/en/configuration.xml
+++ b/src/6.2/en/configuration.xml
@@ -268,7 +268,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -290,8 +290,7 @@
     </itemizedlist>
 
     <para>
-      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> and
+      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> and
       <literal>showUncoveredFiles</literal> attributes have no equivalent TextUI
       test runner option.
     </para>

--- a/src/6.2/fr/configuration.xml
+++ b/src/6.2/fr/configuration.xml
@@ -205,7 +205,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -231,8 +231,7 @@
     <para>
       Les attributs <literal>charset</literal>, <literal>yui</literal>,
       <literal>highlight</literal>, <literal>lowUpperBound</literal>,
-      <literal>highLowerBound</literal>, <literal>logIncompleteSkipped</literal>
-      and <literal>showUncoveredFiles</literal>
+      <literal>highLowerBound</literal> and <literal>showUncoveredFiles</literal>
       n'ont pas d'options équivalentes pour le lanceur de tests TextUI.
     </para>
 

--- a/src/6.2/ja/configuration.xml
+++ b/src/6.2/ja/configuration.xml
@@ -248,7 +248,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -269,9 +269,7 @@
     </itemizedlist>
 
     <para>
-      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、
-      <literal>logIncompleteSkipped</literal>
-      および <literal>showUncoveredFiles</literal>
+      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal> および <literal>showUncoveredFiles</literal>
       属性には、TextUI テストランナーで対応するオプションがありません。
     </para>
 

--- a/src/6.2/pt_br/configuration.xml
+++ b/src/6.2/pt_br/configuration.xml
@@ -279,7 +279,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -303,8 +303,7 @@
     </itemizedlist>
 
     <para>
-      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> e
+      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> e
       <literal>showUncoveredFiles</literal> não possuem opção de 
       execução de teste TextUI equivalente.
     </para>

--- a/src/6.2/zh_cn/configuration.xml
+++ b/src/6.2/zh_cn/configuration.xml
@@ -189,7 +189,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -207,7 +207,7 @@
       <listitem><para><literal>--testdox-text /tmp/testdox.txt</literal></para></listitem>
     </itemizedlist>
 
-    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、<literal>logIncompleteSkipped</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
+    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
 
     <itemizedlist>
       <listitem><para><literal>lowUpperBound</literal>：视为“低”覆盖率的最大覆盖率百分比。</para></listitem>

--- a/src/6.3/en/configuration.xml
+++ b/src/6.3/en/configuration.xml
@@ -268,7 +268,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -290,8 +290,7 @@
     </itemizedlist>
 
     <para>
-      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> and
+      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> and
       <literal>showUncoveredFiles</literal> attributes have no equivalent TextUI
       test runner option.
     </para>

--- a/src/6.3/fr/configuration.xml
+++ b/src/6.3/fr/configuration.xml
@@ -205,7 +205,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -231,8 +231,7 @@
     <para>
       Les attributs <literal>charset</literal>, <literal>yui</literal>,
       <literal>highlight</literal>, <literal>lowUpperBound</literal>,
-      <literal>highLowerBound</literal>, <literal>logIncompleteSkipped</literal>
-      and <literal>showUncoveredFiles</literal>
+      <literal>highLowerBound</literal> and <literal>showUncoveredFiles</literal>
       n'ont pas d'options équivalentes pour le lanceur de tests TextUI.
     </para>
 

--- a/src/6.3/ja/configuration.xml
+++ b/src/6.3/ja/configuration.xml
@@ -248,7 +248,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -269,9 +269,7 @@
     </itemizedlist>
 
     <para>
-      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、
-      <literal>logIncompleteSkipped</literal>
-      および <literal>showUncoveredFiles</literal>
+      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal> および <literal>showUncoveredFiles</literal>
       属性には、TextUI テストランナーで対応するオプションがありません。
     </para>
 

--- a/src/6.3/pt_br/configuration.xml
+++ b/src/6.3/pt_br/configuration.xml
@@ -279,7 +279,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -303,8 +303,7 @@
     </itemizedlist>
 
     <para>
-      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> e
+      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> e
       <literal>showUncoveredFiles</literal> não possuem opção de 
       execução de teste TextUI equivalente.
     </para>

--- a/src/6.3/zh_cn/configuration.xml
+++ b/src/6.3/zh_cn/configuration.xml
@@ -189,7 +189,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -207,7 +207,7 @@
       <listitem><para><literal>--testdox-text /tmp/testdox.txt</literal></para></listitem>
     </itemizedlist>
 
-    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、<literal>logIncompleteSkipped</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
+    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
 
     <itemizedlist>
       <listitem><para><literal>lowUpperBound</literal>：视为“低”覆盖率的最大覆盖率百分比。</para></listitem>

--- a/src/6.4/en/configuration.xml
+++ b/src/6.4/en/configuration.xml
@@ -268,7 +268,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -290,8 +290,7 @@
     </itemizedlist>
 
     <para>
-      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> and
+      The <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> and
       <literal>showUncoveredFiles</literal> attributes have no equivalent TextUI
       test runner option.
     </para>

--- a/src/6.4/fr/configuration.xml
+++ b/src/6.4/fr/configuration.xml
@@ -205,7 +205,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -231,8 +231,7 @@
     <para>
       Les attributs <literal>charset</literal>, <literal>yui</literal>,
       <literal>highlight</literal>, <literal>lowUpperBound</literal>,
-      <literal>highLowerBound</literal>, <literal>logIncompleteSkipped</literal>
-      and <literal>showUncoveredFiles</literal>
+      <literal>highLowerBound</literal> and <literal>showUncoveredFiles</literal>
       n'ont pas d'options équivalentes pour le lanceur de tests TextUI.
     </para>
 

--- a/src/6.4/ja/configuration.xml
+++ b/src/6.4/ja/configuration.xml
@@ -248,7 +248,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -269,9 +269,7 @@
     </itemizedlist>
 
     <para>
-      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、
-      <literal>logIncompleteSkipped</literal>
-      および <literal>showUncoveredFiles</literal>
+      <literal>lowUpperBound</literal>、<literal>highLowerBound</literal> および <literal>showUncoveredFiles</literal>
       属性には、TextUI テストランナーで対応するオプションがありません。
     </para>
 

--- a/src/6.4/pt_br/configuration.xml
+++ b/src/6.4/pt_br/configuration.xml
@@ -279,7 +279,7 @@
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
   <log type="json" target="/tmp/logfile.json"/>
   <log type="tap" target="/tmp/logfile.tap"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -303,8 +303,7 @@
     </itemizedlist>
 
     <para>
-      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
-      <literal>logIncompleteSkipped</literal> e
+      Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal> e
       <literal>showUncoveredFiles</literal> não possuem opção de 
       execução de teste TextUI equivalente.
     </para>

--- a/src/6.4/zh_cn/configuration.xml
+++ b/src/6.4/zh_cn/configuration.xml
@@ -189,7 +189,7 @@
   <log type="coverage-clover" target="/tmp/coverage.xml"/>
   <log type="coverage-php" target="/tmp/coverage.serialized"/>
   <log type="coverage-text" target="php://stdout" showUncoveredFiles="false"/>
-  <log type="junit" target="/tmp/logfile.xml" logIncompleteSkipped="false"/>
+  <log type="junit" target="/tmp/logfile.xml"/>
   <log type="testdox-html" target="/tmp/testdox.html"/>
   <log type="testdox-text" target="/tmp/testdox.txt"/>
 </logging>]]></screen>
@@ -207,7 +207,7 @@
       <listitem><para><literal>--testdox-text /tmp/testdox.txt</literal></para></listitem>
     </itemizedlist>
 
-    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal>、<literal>logIncompleteSkipped</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
+    <para><literal>lowUpperBound</literal>、<literal>highLowerBound</literal> 及 <literal>showUncoveredFiles</literal> 属性没有等价的 TextUI 测试执行器选项。</para>
 
     <itemizedlist>
       <listitem><para><literal>lowUpperBound</literal>：视为“低”覆盖率的最大覆盖率百分比。</para></listitem>


### PR DESCRIPTION
This fixes #463.