### PR TITLE
Fix PHPUnit_Framework_TestListener namespace

### DIFF
--- a/src/6.0/en/configuration.xml
+++ b/src/6.0/en/configuration.xml
@@ -308,7 +308,7 @@
     <title>Test Listeners</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       The <literal><![CDATA[<listeners>]]></literal> element and its

--- a/src/6.0/en/extending-phpunit.xml
+++ b/src/6.0/en/extending-phpunit.xml
@@ -123,13 +123,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implement PHPUnit_Framework_TestListener</title>
+    <title>Implement PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      shows a simple implementation of the <literal>PHPUnit_Framework_TestListener</literal>
+      shows a simple implementation of the <literal>PHPUnit\Framework\TestListener</literal>
       interface.
     </para>
 
@@ -137,8 +137,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>A simple test listener</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.0/en/textui.xml
+++ b/src/6.0/en/textui.xml
@@ -287,7 +287,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Specifies the result printer to use. The printer class must extend
             <literal>PHPUnit_Util_Printer</literal> and implement the
-            <literal>PHPUnit_Framework_TestListener</literal> interface.
+            <literal>PHPUnit\Framework\TestListener</literal> interface.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.0/fr/configuration.xml
+++ b/src/6.0/fr/configuration.xml
@@ -308,7 +308,7 @@
     <title>Écouteurs de tests</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Écouteurs de tests</primary></indexterm>
 
       L'élément <literal><![CDATA[<listeners>]]></literal> et ses enfants

--- a/src/6.0/fr/extending-phpunit.xml
+++ b/src/6.0/fr/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implémenter PHPUnit_Framework_TestListener</title>
+    <title>Implémenter PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       montre une implémentation simple de l'interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Un simple moniteur de test</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.0/fr/textui.xml
+++ b/src/6.0/fr/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Indique l'afficheur de résultats à utiliser. Cette classe d'afficheur doit
             hériter de <literal>PHPUnit_Util_Printer</literal> et implémenter l'interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.0/ja/configuration.xml
+++ b/src/6.0/ja/configuration.xml
@@ -287,7 +287,7 @@
     <title>テストリスナー</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       <literal><![CDATA[<listeners>]]></literal> 要素とその子要素である

--- a/src/6.0/ja/extending-phpunit.xml
+++ b/src/6.0/ja/extending-phpunit.xml
@@ -122,13 +122,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>PHPUnit_Framework_TestListener の実装</title>
+    <title>PHPUnit\Framework\TestListener の実装</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" /> は、
-      <literal>PHPUnit_Framework_TestListener</literal>
+      <literal>PHPUnit\Framework\TestListener</literal>
       インターフェイスのシンプルな実装例です。
     </para>
 
@@ -136,8 +136,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>シンプルなテストリスナー</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.0/ja/textui.xml
+++ b/src/6.0/ja/textui.xml
@@ -751,14 +751,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             結果を表示するために使うプリンタクラスを指定します。このプリンタクラスは
             <literal>PHPUnit_Util_Printer</literal> を継承し、かつ
-            <literal>PHPUnit_Framework_TestListener</literal>
+            <literal>PHPUnit\Framework\TestListener</literal>
             インターフェイスを実装したものでなければなりません。
           </para>
         </listitem>

--- a/src/6.0/pt_br/configuration.xml
+++ b/src/6.0/pt_br/configuration.xml
@@ -7,7 +7,7 @@
     <title>PHPUnit</title>
 
     <para>
-      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem 
+      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem
       ser usados para configurar a funcionalidade principal do PHPUnit.
     </para>
 
@@ -41,7 +41,7 @@
 </phpunit>]]></screen>
 
     <para>
-      A configuração XML acima corresponde ao comportamento padrão do 
+      A configuração XML acima corresponde ao comportamento padrão do
       executor de teste TextUI documentado na <xref linkend="textui.clioptions" />.
     </para>
 
@@ -55,10 +55,10 @@
         <term><literal>convertErrorsToExceptions</literal></term>
         <listitem>
           <para>
-            Por padrão, PHPUnit irá instalar um manipulador de erro que converte 
+            Por padrão, PHPUnit irá instalar um manipulador de erro que converte
             os seguintes erros para exceções:
           </para>
-         
+
           <itemizedlist>
             <listitem><literal>E_WARNING</literal></listitem>
             <listitem><literal>E_NOTICE</literal></listitem>
@@ -70,14 +70,14 @@
             <listitem><literal>E_DEPRECATED</literal></listitem>
             <listitem><literal>E_USER_DEPRECATED</literal></listitem>
           </itemizedlist>
-          
+
           <para>
             Definir <literal>convertErrorsToExceptions</literal> para
             <literal>false</literal> desabilita esta funcionalidade.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertNoticesToExceptions</literal></term>
         <listitem>
@@ -89,7 +89,7 @@
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertWarningsToExceptions</literal></term>
         <listitem>
@@ -107,31 +107,31 @@
         <listitem>
           <para>
             A Cobertura de Código só será gravada para testes que usem a anotação
-            <literal>@covers</literal> documentada na 
+            <literal>@covers</literal> documentada na
             <xref linkend="appendixes.annotations.covers" />.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForLargeTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@large</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForMediumTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@medium</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -142,8 +142,8 @@
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
-            define o tempo limite para todos os testes marcados como 
-            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste 
+            define o tempo limite para todos os testes marcados como
+            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste
             não completa dentro do tempo limite configurado, irá falhar.
           </para>
         </listitem>
@@ -157,8 +157,8 @@
     <para>
       <indexterm><primary>Suítes de Teste</primary></indexterm>
 
-      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s) 
-      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser 
+      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s)
+      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser
       usados para compor uma suíte de teste fora das suítes e casos de teste.
     </para>
 
@@ -172,10 +172,10 @@
 
     <para>
       Usando os atributos <literal>phpVersion</literal> e
-      <literal>phpVersionOperator</literal>, uma versão exigida do PHP 
-      pode ser especificada. O exemplo abaixo só vai adicionar os 
+      <literal>phpVersionOperator</literal>, uma versão exigida do PHP
+      pode ser especificada. O exemplo abaixo só vai adicionar os
       arquivos <filename>/caminho/para/*Test.php</filename> e
-      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP 
+      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP
       for no mínimo 5.3.0.
     </para>
 
@@ -187,7 +187,7 @@
   </testsuites>]]></screen>
 
     <para>
-      O atributo <literal>phpVersionOperator</literal> é opcional e 
+      O atributo <literal>phpVersionOperator</literal> é opcional e
       padronizado para <literal><![CDATA[>=]]></literal>.
     </para>
   </section>
@@ -201,7 +201,7 @@
       O elemento <literal><![CDATA[<groups>]]></literal> e seus filhos
       <literal><![CDATA[<include>]]></literal>,
       <literal><![CDATA[<exclude>]]></literal>, e
-      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar 
+      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar
       grupos de testes marcados com a anotação <literal>@group</literal>
       (documentada na <xref linkend="appendixes.annotations.group" />)
       que (não) deveriam ser executados.
@@ -217,7 +217,7 @@
 </groups>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de testes TextUI 
+      A configuração XML acima corresponde a invocar o executor de testes TextUI
       com as seguintes opções:
     </para>
 
@@ -235,8 +235,8 @@
       <indexterm><primary>Lista-negra</primary></indexterm>
       <indexterm><primary>Lista-branca</primary></indexterm>
 
-      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem 
-      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura 
+      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem
+      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura
       de código.
     </para>
 
@@ -267,7 +267,7 @@
       <indexterm><primary>Registrando</primary></indexterm>
 
       O elemento <literal><![CDATA[<logging>]]></literal> e seus filhos
-      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o 
+      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o
       registro da execução de teste.
     </para>
 
@@ -285,7 +285,7 @@
 </logging>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de teste TextUI 
+      A configuração XML acima corresponde a invocar o executor de teste TextUI
       com as seguintes opções:
     </para>
 
@@ -305,7 +305,7 @@
     <para>
       Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
       <literal>logIncompleteSkipped</literal> e
-      <literal>showUncoveredFiles</literal> não possuem opção de 
+      <literal>showUncoveredFiles</literal> não possuem opção de
       execução de teste TextUI equivalente.
     </para>
 
@@ -321,11 +321,11 @@
     <title>Ouvintes de Teste</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Ouvintes de Teste</primary></indexterm>
 
       O elemento <literal><![CDATA[<listeners>]]></literal> e seus filhos
-      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar 
+      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar
       ouvintes adicionais de teste para a execução dos testes.
     </para>
 
@@ -369,8 +369,8 @@
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary><literal>php.ini</literal></primary></indexterm>
 
-      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser 
-      usados para definir configurações do PHP, constantes e variáveis globais. Também pode 
+      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser
+      usados para definir configurações do PHP, constantes e variáveis globais. Também pode
       ser usado para preceder o <literal>include_path</literal>.
     </para>
 
@@ -411,7 +411,7 @@ $_REQUEST['foo'] = 'bar';]]></screen>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
       O elemento <literal><![CDATA[<selenium>]]></literal> e seus filhos
-      <literal><![CDATA[<browser>]]></literal> podem ser usados para 
+      <literal><![CDATA[<browser>]]></literal> podem ser usados para
       configurar uma lista de servidores Selenium RC.
     </para>
 

--- a/src/6.0/pt_br/extending-phpunit.xml
+++ b/src/6.0/pt_br/extending-phpunit.xml
@@ -4,8 +4,8 @@
   <title>Estendendo o PHPUnit</title>
 
   <para>
-    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes 
-    e personalizar as respostas que você recebe ao executar os testes. Aqui estão 
+    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes
+    e personalizar as respostas que você recebe ao executar os testes. Aqui estão
     pontos de partida comuns para estender o PHPUnit.
   </para>
 
@@ -16,8 +16,8 @@
       <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
       Escreva asserções personalizadas e métodos utilitários em uma subclasse abstrata do
-      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste 
-      dessa classe. Essa é uma das formas mais fáceis de estender 
+      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste
+      dessa classe. Essa é uma das formas mais fáceis de estender
       o PHPUnit.
     </para>
   </section>
@@ -26,7 +26,7 @@
     <title>Escreva asserções personalizadas</title>
 
     <para>
-      Ao escrever asserções personalizadas a melhor prática é seguir a mesma 
+      Ao escrever asserções personalizadas a melhor prática é seguir a mesma
       forma que as asserções do próprio PHPUnit são implementadas. Como você pode ver no
       <xref linkend="extending-phpunit.examples.Assert.php"/>, o método
       <literal>assertTrue()</literal> é apenas um empacotador em torno dos métodos
@@ -73,7 +73,7 @@ abstract class PHPUnit_Framework_Assert
 
     <para>
       O <xref linkend="extending-phpunit.examples.IsTrue.php"/> mostra como
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a
       classe base abstrata para objetos comparadores (ou restritores),
       <literal>PHPUnit_Framework_Constraint</literal>.
     </para>
@@ -110,29 +110,32 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
     <para>
       O esforço de implementar os métodos <literal>assertTrue()</literal> e
       <literal>isTrue()</literal> assim como a classe
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o 
-      benefício de que <literal>assertThat()</literal> automaticamente cuida de 
-      avaliar a asserção e escriturar tarefas como contá-las para 
-      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o
+      benefício de que <literal>assertThat()</literal> automaticamente cuida de
+      avaliar a asserção e escriturar tarefas como contá-las para
+      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser
       usado como um comparador ao configurar objetos falsificados.
     </para>
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implementando PHPUnit_Framework_TestListener</title>
+    <title>Implementando PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       O <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      mostra uma implementação simples da interface 
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      mostra uma implementação simples da interface
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Um simples ouvinte de teste</title>
       <programlisting><![CDATA[<?php
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
@@ -186,12 +189,12 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
       <indexterm><primary>PHPUnit_Framework_BaseTestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.BaseTestListener.php" />
-      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>, 
+      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>,
       que permite que você especifique apenas os métodos de interface que
       são interessantes para seu caso de uso, ao fornecer implementações vazias
       para todos os outros.
     </para>
-    
+
     <example id="extending-phpunit.examples.BaseTestListener.php">
       <title>Usando o ouvinte de teste base</title>
       <programlisting><![CDATA[<?php
@@ -206,8 +209,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
     </example>
 
     <para>
-      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver 
-      como configurar o PHPUnit para anexar seu ouvinte de teste para a 
+      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver
+      como configurar o PHPUnit para anexar seu ouvinte de teste para a
       execução do teste.
     </para>
   </section>
@@ -219,8 +222,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
       <indexterm><primary>PHPUnit_Extensions_TestDecorator</primary></indexterm>
 
       Você pode envolver casos de teste ou suítes de teste em uma subclasse de
-      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão 
-      de projeto Decorador para realizar algumas ações antes e depois da 
+      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão
+      de projeto Decorador para realizar algumas ações antes e depois da
       execução do teste.
     </para>
 
@@ -229,7 +232,7 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
 
       O PHPUnit navega com um decorador de teste concreto:
       <literal>PHPUnit_Extensions_RepeatedTest</literal>. Ele é usado para executar um
-      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem 
+      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem
       bem-sucedidas.
     </para>
 
@@ -287,7 +290,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
       <indexterm><primary>PHPUnit_Framework_Test</primary></indexterm>
       <indexterm><primary>Testes Guiados por Dados</primary></indexterm>
 
-      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e 
+      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e
       fácil de implementar. Você pode escrever uma implementação do
       <literal>PHPUnit_Framework_Test</literal> que é mais simples que
       <literal>PHPUnit_Framework_TestCase</literal> e que executa
@@ -296,9 +299,9 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
 
     <para>
       O <xref linkend="extending-phpunit.examples.DataDrivenTest.php" />
-      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo 
+      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo
       com Valores Separados por Vírgulas (CSV). Cada linha de tal arquivo parece com
-      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos 
+      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos
       e o segundo valor é o real.
     </para>
 

--- a/src/6.0/pt_br/textui.xml
+++ b/src/6.0/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -600,7 +600,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -611,18 +611,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -632,7 +632,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -660,7 +660,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -669,7 +669,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -692,17 +692,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -718,16 +718,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -759,14 +759,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Especifica o impressor de resultados a ser usado. A classe impressora deve estender
             <literal>PHPUnit_Util_Printer</literal> e implementar a interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>
@@ -786,14 +786,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -805,7 +805,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -830,7 +830,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/6.0/pt_br/upgrading.xml
+++ b/src/6.0/pt_br/upgrading.xml
@@ -11,20 +11,20 @@
           O suporte limitado para <ulink
           url="http://sebastian-bergmann.de/blog/883-Stubbing-and-Mocking-Static-Methods.html">esboçando
           e falsificando métodos estáticos</ulink> que foi introduzido no PHPUnit 3.5
-          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado 
-          era invocado de um outro método da mesma classe. Acreditamos 
+          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado
+          era invocado de um outro método da mesma classe. Acreditamos
           que o uso limitado desta funcionalidade não justificava o
           aumento da complexidade em geradores de dublês de testes em que incorreu.
           Pedimos desculpas por qualquer inconveniência que esta remoção possa causar e
-          incentivamos a refatoração do código sobre teste para não exigir esse recurso 
+          incentivamos a refatoração do código sobre teste para não exigir esse recurso
           para testes.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          O <code>addRiskyTest()</code> foi adicionado a interface 
-          <code>PHPUnit_Framework_TestListener</code>. Classes que 
+          O <code>addRiskyTest()</code> foi adicionado a interface
+          <code>PHPUnit\Framework\TestListener</code>. Classes que
           implementam esta interface tem que implementar esse novo método. Essa é
           a razão por quê o PHPStorm 7 não é compatível com o PHPUnit 4, por
           exemplo.
@@ -36,10 +36,10 @@
           As correções para <ulink url="https://github.com/sebastianbergmann/phpunit/issues/552">#552</ulink>,
           <ulink url="https://github.com/sebastianbergmann/phpunit/issues/573">#573</ulink>,
           e <ulink url="https://github.com/sebastianbergmann/phpunit/issues/582">#582</ulink>
-          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração 
-          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são 
+          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração
+          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são
           resolvidos em relação a esse arquivo de configuração. Quando atualizar, você pode
-          precisar atualizar os caminhos relativos para as configurações 
+          precisar atualizar os caminhos relativos para as configurações
           <code>testSuiteLoaderFile</code>, <code>printerFile</code>,
           <code>testsuites/file</code>, e <code>testsuites/exclude</code>.
         </para>
@@ -47,26 +47,26 @@
 
       <listitem>
         <para>
-          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O 
-          comparador numérico não é mais invocado quando fornecido com duas 
+          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O
+          comparador numérico não é mais invocado quando fornecido com duas
           strings</ulink>.
         </para>
       </listitem>
     </itemizedlist>
 
     <para>
-      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit 
-      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que 
-      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através 
-      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do 
+      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit
+      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que
+      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através
+      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do
       PEAR completamente.
     </para>
 
     <para>
-      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para 
-      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das 
+      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para
+      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das
       dependências do PHPUnit (PHP_CodeCoverage, PHPUnit_MockObject, ...) por trás
-      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os 
+      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os
       respectivos pacotes PEAR.
     </para>
   </section>

--- a/src/6.0/zh_cn/configuration.xml
+++ b/src/6.0/zh_cn/configuration.xml
@@ -221,7 +221,7 @@
     <title>测试监听器</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener （测试监听器）</primary></indexterm><literal>&lt;listeners&gt;</literal> 元素及其 <literal>&lt;listener&gt;</literal> 子元素用于在测试执行期间附加额外的测试监听器。</para>
 
     <screen><![CDATA[<listeners>

--- a/src/6.0/zh_cn/extending-phpunit.xml
+++ b/src/6.0/zh_cn/extending-phpunit.xml
@@ -93,19 +93,20 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>实现 PHPUnit_Framework_TestListener</title>
+    <title>实现 PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
-      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit_Framework_TestListener</literal> 接口的一个简单实现。</para>
+      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit\Framework\TestListener</literal> 接口的一个简单实现。</para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>简单的测试监听器</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.0/zh_cn/textui.xml
+++ b/src/6.0/zh_cn/textui.xml
@@ -568,11 +568,11 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
-          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit_Framework_TestListener</literal> 接口。</para>
+          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit\Framework\TestListener</literal> 接口。</para>
         </listitem>
       </varlistentry>
 

--- a/src/6.1/en/configuration.xml
+++ b/src/6.1/en/configuration.xml
@@ -308,7 +308,7 @@
     <title>Test Listeners</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       The <literal><![CDATA[<listeners>]]></literal> element and its

--- a/src/6.1/en/extending-phpunit.xml
+++ b/src/6.1/en/extending-phpunit.xml
@@ -123,13 +123,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implement PHPUnit_Framework_TestListener</title>
+    <title>Implement PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      shows a simple implementation of the <literal>PHPUnit_Framework_TestListener</literal>
+      shows a simple implementation of the <literal>PHPUnit\Framework\TestListener</literal>
       interface.
     </para>
 
@@ -137,8 +137,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>A simple test listener</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.1/en/textui.xml
+++ b/src/6.1/en/textui.xml
@@ -287,7 +287,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Specifies the result printer to use. The printer class must extend
             <literal>PHPUnit_Util_Printer</literal> and implement the
-            <literal>PHPUnit_Framework_TestListener</literal> interface.
+            <literal>PHPUnit\Framework\TestListener</literal> interface.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.1/fr/configuration.xml
+++ b/src/6.1/fr/configuration.xml
@@ -308,7 +308,7 @@
     <title>Écouteurs de tests</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Écouteurs de tests</primary></indexterm>
 
       L'élément <literal><![CDATA[<listeners>]]></literal> et ses enfants

--- a/src/6.1/fr/extending-phpunit.xml
+++ b/src/6.1/fr/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implémenter PHPUnit_Framework_TestListener</title>
+    <title>Implémenter PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       montre une implémentation simple de l'interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Un simple moniteur de test</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.1/fr/textui.xml
+++ b/src/6.1/fr/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Indique l'afficheur de résultats à utiliser. Cette classe d'afficheur doit
             hériter de <literal>PHPUnit_Util_Printer</literal> et implémenter l'interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.1/ja/configuration.xml
+++ b/src/6.1/ja/configuration.xml
@@ -287,7 +287,7 @@
     <title>テストリスナー</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       <literal><![CDATA[<listeners>]]></literal> 要素とその子要素である

--- a/src/6.1/ja/extending-phpunit.xml
+++ b/src/6.1/ja/extending-phpunit.xml
@@ -122,13 +122,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>PHPUnit_Framework_TestListener の実装</title>
+    <title>PHPUnit\Framework\TestListener の実装</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" /> は、
-      <literal>PHPUnit_Framework_TestListener</literal>
+      <literal>PHPUnit\Framework\TestListener</literal>
       インターフェイスのシンプルな実装例です。
     </para>
 
@@ -136,8 +136,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>シンプルなテストリスナー</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.1/ja/textui.xml
+++ b/src/6.1/ja/textui.xml
@@ -751,14 +751,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             結果を表示するために使うプリンタクラスを指定します。このプリンタクラスは
             <literal>PHPUnit_Util_Printer</literal> を継承し、かつ
-            <literal>PHPUnit_Framework_TestListener</literal>
+            <literal>PHPUnit\Framework\TestListener</literal>
             インターフェイスを実装したものでなければなりません。
           </para>
         </listitem>

--- a/src/6.1/pt_br/configuration.xml
+++ b/src/6.1/pt_br/configuration.xml
@@ -7,7 +7,7 @@
     <title>PHPUnit</title>
 
     <para>
-      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem 
+      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem
       ser usados para configurar a funcionalidade principal do PHPUnit.
     </para>
 
@@ -41,7 +41,7 @@
 </phpunit>]]></screen>
 
     <para>
-      A configuração XML acima corresponde ao comportamento padrão do 
+      A configuração XML acima corresponde ao comportamento padrão do
       executor de teste TextUI documentado na <xref linkend="textui.clioptions" />.
     </para>
 
@@ -55,10 +55,10 @@
         <term><literal>convertErrorsToExceptions</literal></term>
         <listitem>
           <para>
-            Por padrão, PHPUnit irá instalar um manipulador de erro que converte 
+            Por padrão, PHPUnit irá instalar um manipulador de erro que converte
             os seguintes erros para exceções:
           </para>
-         
+
           <itemizedlist>
             <listitem><literal>E_WARNING</literal></listitem>
             <listitem><literal>E_NOTICE</literal></listitem>
@@ -70,14 +70,14 @@
             <listitem><literal>E_DEPRECATED</literal></listitem>
             <listitem><literal>E_USER_DEPRECATED</literal></listitem>
           </itemizedlist>
-          
+
           <para>
             Definir <literal>convertErrorsToExceptions</literal> para
             <literal>false</literal> desabilita esta funcionalidade.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertNoticesToExceptions</literal></term>
         <listitem>
@@ -89,7 +89,7 @@
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertWarningsToExceptions</literal></term>
         <listitem>
@@ -107,31 +107,31 @@
         <listitem>
           <para>
             A Cobertura de Código só será gravada para testes que usem a anotação
-            <literal>@covers</literal> documentada na 
+            <literal>@covers</literal> documentada na
             <xref linkend="appendixes.annotations.covers" />.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForLargeTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@large</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForMediumTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@medium</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -142,8 +142,8 @@
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
-            define o tempo limite para todos os testes marcados como 
-            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste 
+            define o tempo limite para todos os testes marcados como
+            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste
             não completa dentro do tempo limite configurado, irá falhar.
           </para>
         </listitem>
@@ -157,8 +157,8 @@
     <para>
       <indexterm><primary>Suítes de Teste</primary></indexterm>
 
-      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s) 
-      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser 
+      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s)
+      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser
       usados para compor uma suíte de teste fora das suítes e casos de teste.
     </para>
 
@@ -172,10 +172,10 @@
 
     <para>
       Usando os atributos <literal>phpVersion</literal> e
-      <literal>phpVersionOperator</literal>, uma versão exigida do PHP 
-      pode ser especificada. O exemplo abaixo só vai adicionar os 
+      <literal>phpVersionOperator</literal>, uma versão exigida do PHP
+      pode ser especificada. O exemplo abaixo só vai adicionar os
       arquivos <filename>/caminho/para/*Test.php</filename> e
-      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP 
+      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP
       for no mínimo 5.3.0.
     </para>
 
@@ -187,7 +187,7 @@
   </testsuites>]]></screen>
 
     <para>
-      O atributo <literal>phpVersionOperator</literal> é opcional e 
+      O atributo <literal>phpVersionOperator</literal> é opcional e
       padronizado para <literal><![CDATA[>=]]></literal>.
     </para>
   </section>
@@ -201,7 +201,7 @@
       O elemento <literal><![CDATA[<groups>]]></literal> e seus filhos
       <literal><![CDATA[<include>]]></literal>,
       <literal><![CDATA[<exclude>]]></literal>, e
-      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar 
+      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar
       grupos de testes marcados com a anotação <literal>@group</literal>
       (documentada na <xref linkend="appendixes.annotations.group" />)
       que (não) deveriam ser executados.
@@ -217,7 +217,7 @@
 </groups>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de testes TextUI 
+      A configuração XML acima corresponde a invocar o executor de testes TextUI
       com as seguintes opções:
     </para>
 
@@ -235,8 +235,8 @@
       <indexterm><primary>Lista-negra</primary></indexterm>
       <indexterm><primary>Lista-branca</primary></indexterm>
 
-      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem 
-      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura 
+      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem
+      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura
       de código.
     </para>
 
@@ -267,7 +267,7 @@
       <indexterm><primary>Registrando</primary></indexterm>
 
       O elemento <literal><![CDATA[<logging>]]></literal> e seus filhos
-      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o 
+      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o
       registro da execução de teste.
     </para>
 
@@ -285,7 +285,7 @@
 </logging>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de teste TextUI 
+      A configuração XML acima corresponde a invocar o executor de teste TextUI
       com as seguintes opções:
     </para>
 
@@ -305,7 +305,7 @@
     <para>
       Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
       <literal>logIncompleteSkipped</literal> e
-      <literal>showUncoveredFiles</literal> não possuem opção de 
+      <literal>showUncoveredFiles</literal> não possuem opção de
       execução de teste TextUI equivalente.
     </para>
 
@@ -321,11 +321,11 @@
     <title>Ouvintes de Teste</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Ouvintes de Teste</primary></indexterm>
 
       O elemento <literal><![CDATA[<listeners>]]></literal> e seus filhos
-      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar 
+      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar
       ouvintes adicionais de teste para a execução dos testes.
     </para>
 
@@ -369,8 +369,8 @@
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary><literal>php.ini</literal></primary></indexterm>
 
-      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser 
-      usados para definir configurações do PHP, constantes e variáveis globais. Também pode 
+      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser
+      usados para definir configurações do PHP, constantes e variáveis globais. Também pode
       ser usado para preceder o <literal>include_path</literal>.
     </para>
 
@@ -411,7 +411,7 @@ $_REQUEST['foo'] = 'bar';]]></screen>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
       O elemento <literal><![CDATA[<selenium>]]></literal> e seus filhos
-      <literal><![CDATA[<browser>]]></literal> podem ser usados para 
+      <literal><![CDATA[<browser>]]></literal> podem ser usados para
       configurar uma lista de servidores Selenium RC.
     </para>
 

--- a/src/6.1/pt_br/extending-phpunit.xml
+++ b/src/6.1/pt_br/extending-phpunit.xml
@@ -4,8 +4,8 @@
   <title>Estendendo o PHPUnit</title>
 
   <para>
-    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes 
-    e personalizar as respostas que você recebe ao executar os testes. Aqui estão 
+    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes
+    e personalizar as respostas que você recebe ao executar os testes. Aqui estão
     pontos de partida comuns para estender o PHPUnit.
   </para>
 
@@ -16,8 +16,8 @@
       <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
       Escreva asserções personalizadas e métodos utilitários em uma subclasse abstrata do
-      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste 
-      dessa classe. Essa é uma das formas mais fáceis de estender 
+      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste
+      dessa classe. Essa é uma das formas mais fáceis de estender
       o PHPUnit.
     </para>
   </section>
@@ -26,7 +26,7 @@
     <title>Escreva asserções personalizadas</title>
 
     <para>
-      Ao escrever asserções personalizadas a melhor prática é seguir a mesma 
+      Ao escrever asserções personalizadas a melhor prática é seguir a mesma
       forma que as asserções do próprio PHPUnit são implementadas. Como você pode ver no
       <xref linkend="extending-phpunit.examples.Assert.php"/>, o método
       <literal>assertTrue()</literal> é apenas um empacotador em torno dos métodos
@@ -73,7 +73,7 @@ abstract class PHPUnit_Framework_Assert
 
     <para>
       O <xref linkend="extending-phpunit.examples.IsTrue.php"/> mostra como
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a
       classe base abstrata para objetos comparadores (ou restritores),
       <literal>PHPUnit_Framework_Constraint</literal>.
     </para>
@@ -110,29 +110,32 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
     <para>
       O esforço de implementar os métodos <literal>assertTrue()</literal> e
       <literal>isTrue()</literal> assim como a classe
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o 
-      benefício de que <literal>assertThat()</literal> automaticamente cuida de 
-      avaliar a asserção e escriturar tarefas como contá-las para 
-      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o
+      benefício de que <literal>assertThat()</literal> automaticamente cuida de
+      avaliar a asserção e escriturar tarefas como contá-las para
+      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser
       usado como um comparador ao configurar objetos falsificados.
     </para>
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implementando PHPUnit_Framework_TestListener</title>
+    <title>Implementando PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       O <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      mostra uma implementação simples da interface 
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      mostra uma implementação simples da interface
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Um simples ouvinte de teste</title>
       <programlisting><![CDATA[<?php
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
@@ -186,12 +189,12 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
       <indexterm><primary>PHPUnit_Framework_BaseTestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.BaseTestListener.php" />
-      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>, 
+      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>,
       que permite que você especifique apenas os métodos de interface que
       são interessantes para seu caso de uso, ao fornecer implementações vazias
       para todos os outros.
     </para>
-    
+
     <example id="extending-phpunit.examples.BaseTestListener.php">
       <title>Usando o ouvinte de teste base</title>
       <programlisting><![CDATA[<?php
@@ -206,8 +209,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
     </example>
 
     <para>
-      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver 
-      como configurar o PHPUnit para anexar seu ouvinte de teste para a 
+      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver
+      como configurar o PHPUnit para anexar seu ouvinte de teste para a
       execução do teste.
     </para>
   </section>
@@ -219,8 +222,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
       <indexterm><primary>PHPUnit_Extensions_TestDecorator</primary></indexterm>
 
       Você pode envolver casos de teste ou suítes de teste em uma subclasse de
-      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão 
-      de projeto Decorador para realizar algumas ações antes e depois da 
+      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão
+      de projeto Decorador para realizar algumas ações antes e depois da
       execução do teste.
     </para>
 
@@ -229,7 +232,7 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
 
       O PHPUnit navega com um decorador de teste concreto:
       <literal>PHPUnit_Extensions_RepeatedTest</literal>. Ele é usado para executar um
-      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem 
+      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem
       bem-sucedidas.
     </para>
 
@@ -287,7 +290,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
       <indexterm><primary>PHPUnit_Framework_Test</primary></indexterm>
       <indexterm><primary>Testes Guiados por Dados</primary></indexterm>
 
-      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e 
+      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e
       fácil de implementar. Você pode escrever uma implementação do
       <literal>PHPUnit_Framework_Test</literal> que é mais simples que
       <literal>PHPUnit_Framework_TestCase</literal> e que executa
@@ -296,9 +299,9 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
 
     <para>
       O <xref linkend="extending-phpunit.examples.DataDrivenTest.php" />
-      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo 
+      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo
       com Valores Separados por Vírgulas (CSV). Cada linha de tal arquivo parece com
-      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos 
+      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos
       e o segundo valor é o real.
     </para>
 

--- a/src/6.1/pt_br/textui.xml
+++ b/src/6.1/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -600,7 +600,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -611,18 +611,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -632,7 +632,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -660,7 +660,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -669,7 +669,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -692,17 +692,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -718,16 +718,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -759,14 +759,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Especifica o impressor de resultados a ser usado. A classe impressora deve estender
             <literal>PHPUnit_Util_Printer</literal> e implementar a interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>
@@ -786,14 +786,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -805,7 +805,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -830,7 +830,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/6.1/pt_br/upgrading.xml
+++ b/src/6.1/pt_br/upgrading.xml
@@ -11,20 +11,20 @@
           O suporte limitado para <ulink
           url="http://sebastian-bergmann.de/blog/883-Stubbing-and-Mocking-Static-Methods.html">esboçando
           e falsificando métodos estáticos</ulink> que foi introduzido no PHPUnit 3.5
-          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado 
-          era invocado de um outro método da mesma classe. Acreditamos 
+          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado
+          era invocado de um outro método da mesma classe. Acreditamos
           que o uso limitado desta funcionalidade não justificava o
           aumento da complexidade em geradores de dublês de testes em que incorreu.
           Pedimos desculpas por qualquer inconveniência que esta remoção possa causar e
-          incentivamos a refatoração do código sobre teste para não exigir esse recurso 
+          incentivamos a refatoração do código sobre teste para não exigir esse recurso
           para testes.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          O <code>addRiskyTest()</code> foi adicionado a interface 
-          <code>PHPUnit_Framework_TestListener</code>. Classes que 
+          O <code>addRiskyTest()</code> foi adicionado a interface
+          <code>PHPUnit\Framework\TestListener</code>. Classes que
           implementam esta interface tem que implementar esse novo método. Essa é
           a razão por quê o PHPStorm 7 não é compatível com o PHPUnit 4, por
           exemplo.
@@ -36,10 +36,10 @@
           As correções para <ulink url="https://github.com/sebastianbergmann/phpunit/issues/552">#552</ulink>,
           <ulink url="https://github.com/sebastianbergmann/phpunit/issues/573">#573</ulink>,
           e <ulink url="https://github.com/sebastianbergmann/phpunit/issues/582">#582</ulink>
-          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração 
-          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são 
+          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração
+          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são
           resolvidos em relação a esse arquivo de configuração. Quando atualizar, você pode
-          precisar atualizar os caminhos relativos para as configurações 
+          precisar atualizar os caminhos relativos para as configurações
           <code>testSuiteLoaderFile</code>, <code>printerFile</code>,
           <code>testsuites/file</code>, e <code>testsuites/exclude</code>.
         </para>
@@ -47,26 +47,26 @@
 
       <listitem>
         <para>
-          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O 
-          comparador numérico não é mais invocado quando fornecido com duas 
+          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O
+          comparador numérico não é mais invocado quando fornecido com duas
           strings</ulink>.
         </para>
       </listitem>
     </itemizedlist>
 
     <para>
-      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit 
-      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que 
-      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através 
-      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do 
+      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit
+      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que
+      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através
+      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do
       PEAR completamente.
     </para>
 
     <para>
-      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para 
-      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das 
+      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para
+      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das
       dependências do PHPUnit (PHP_CodeCoverage, PHPUnit_MockObject, ...) por trás
-      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os 
+      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os
       respectivos pacotes PEAR.
     </para>
   </section>

--- a/src/6.1/zh_cn/configuration.xml
+++ b/src/6.1/zh_cn/configuration.xml
@@ -221,7 +221,7 @@
     <title>测试监听器</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener （测试监听器）</primary></indexterm><literal>&lt;listeners&gt;</literal> 元素及其 <literal>&lt;listener&gt;</literal> 子元素用于在测试执行期间附加额外的测试监听器。</para>
 
     <screen><![CDATA[<listeners>

--- a/src/6.1/zh_cn/extending-phpunit.xml
+++ b/src/6.1/zh_cn/extending-phpunit.xml
@@ -93,19 +93,20 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>实现 PHPUnit_Framework_TestListener</title>
+    <title>实现 PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
-      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit_Framework_TestListener</literal> 接口的一个简单实现。</para>
+      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit\Framework\TestListener</literal> 接口的一个简单实现。</para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>简单的测试监听器</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.1/zh_cn/textui.xml
+++ b/src/6.1/zh_cn/textui.xml
@@ -568,11 +568,11 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
-          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit_Framework_TestListener</literal> 接口。</para>
+          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit\Framework\TestListener</literal> 接口。</para>
         </listitem>
       </varlistentry>
 

--- a/src/6.2/en/configuration.xml
+++ b/src/6.2/en/configuration.xml
@@ -308,7 +308,7 @@
     <title>Test Listeners</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       The <literal><![CDATA[<listeners>]]></literal> element and its

--- a/src/6.2/en/extending-phpunit.xml
+++ b/src/6.2/en/extending-phpunit.xml
@@ -123,13 +123,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implement PHPUnit_Framework_TestListener</title>
+    <title>Implement PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      shows a simple implementation of the <literal>PHPUnit_Framework_TestListener</literal>
+      shows a simple implementation of the <literal>PHPUnit\Framework\TestListener</literal>
       interface.
     </para>
 
@@ -137,8 +137,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>A simple test listener</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.2/en/textui.xml
+++ b/src/6.2/en/textui.xml
@@ -287,7 +287,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Specifies the result printer to use. The printer class must extend
             <literal>PHPUnit_Util_Printer</literal> and implement the
-            <literal>PHPUnit_Framework_TestListener</literal> interface.
+            <literal>PHPUnit\Framework\TestListener</literal> interface.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.2/fr/configuration.xml
+++ b/src/6.2/fr/configuration.xml
@@ -308,7 +308,7 @@
     <title>Écouteurs de tests</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Écouteurs de tests</primary></indexterm>
 
       L'élément <literal><![CDATA[<listeners>]]></literal> et ses enfants

--- a/src/6.2/fr/extending-phpunit.xml
+++ b/src/6.2/fr/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implémenter PHPUnit_Framework_TestListener</title>
+    <title>Implémenter PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       montre une implémentation simple de l'interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Un simple moniteur de test</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.2/fr/textui.xml
+++ b/src/6.2/fr/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Indique l'afficheur de résultats à utiliser. Cette classe d'afficheur doit
             hériter de <literal>PHPUnit_Util_Printer</literal> et implémenter l'interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.2/ja/configuration.xml
+++ b/src/6.2/ja/configuration.xml
@@ -287,7 +287,7 @@
     <title>テストリスナー</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       <literal><![CDATA[<listeners>]]></literal> 要素とその子要素である

--- a/src/6.2/ja/extending-phpunit.xml
+++ b/src/6.2/ja/extending-phpunit.xml
@@ -122,13 +122,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>PHPUnit_Framework_TestListener の実装</title>
+    <title>PHPUnit\Framework\TestListener の実装</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" /> は、
-      <literal>PHPUnit_Framework_TestListener</literal>
+      <literal>PHPUnit\Framework\TestListener</literal>
       インターフェイスのシンプルな実装例です。
     </para>
 
@@ -136,8 +136,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>シンプルなテストリスナー</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.2/ja/textui.xml
+++ b/src/6.2/ja/textui.xml
@@ -751,14 +751,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             結果を表示するために使うプリンタクラスを指定します。このプリンタクラスは
             <literal>PHPUnit_Util_Printer</literal> を継承し、かつ
-            <literal>PHPUnit_Framework_TestListener</literal>
+            <literal>PHPUnit\Framework\TestListener</literal>
             インターフェイスを実装したものでなければなりません。
           </para>
         </listitem>

--- a/src/6.2/pt_br/configuration.xml
+++ b/src/6.2/pt_br/configuration.xml
@@ -7,7 +7,7 @@
     <title>PHPUnit</title>
 
     <para>
-      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem 
+      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem
       ser usados para configurar a funcionalidade principal do PHPUnit.
     </para>
 
@@ -41,7 +41,7 @@
 </phpunit>]]></screen>
 
     <para>
-      A configuração XML acima corresponde ao comportamento padrão do 
+      A configuração XML acima corresponde ao comportamento padrão do
       executor de teste TextUI documentado na <xref linkend="textui.clioptions" />.
     </para>
 
@@ -55,10 +55,10 @@
         <term><literal>convertErrorsToExceptions</literal></term>
         <listitem>
           <para>
-            Por padrão, PHPUnit irá instalar um manipulador de erro que converte 
+            Por padrão, PHPUnit irá instalar um manipulador de erro que converte
             os seguintes erros para exceções:
           </para>
-         
+
           <itemizedlist>
             <listitem><literal>E_WARNING</literal></listitem>
             <listitem><literal>E_NOTICE</literal></listitem>
@@ -70,14 +70,14 @@
             <listitem><literal>E_DEPRECATED</literal></listitem>
             <listitem><literal>E_USER_DEPRECATED</literal></listitem>
           </itemizedlist>
-          
+
           <para>
             Definir <literal>convertErrorsToExceptions</literal> para
             <literal>false</literal> desabilita esta funcionalidade.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertNoticesToExceptions</literal></term>
         <listitem>
@@ -89,7 +89,7 @@
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertWarningsToExceptions</literal></term>
         <listitem>
@@ -107,31 +107,31 @@
         <listitem>
           <para>
             A Cobertura de Código só será gravada para testes que usem a anotação
-            <literal>@covers</literal> documentada na 
+            <literal>@covers</literal> documentada na
             <xref linkend="appendixes.annotations.covers" />.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForLargeTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@large</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForMediumTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@medium</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -142,8 +142,8 @@
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
-            define o tempo limite para todos os testes marcados como 
-            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste 
+            define o tempo limite para todos os testes marcados como
+            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste
             não completa dentro do tempo limite configurado, irá falhar.
           </para>
         </listitem>
@@ -157,8 +157,8 @@
     <para>
       <indexterm><primary>Suítes de Teste</primary></indexterm>
 
-      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s) 
-      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser 
+      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s)
+      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser
       usados para compor uma suíte de teste fora das suítes e casos de teste.
     </para>
 
@@ -172,10 +172,10 @@
 
     <para>
       Usando os atributos <literal>phpVersion</literal> e
-      <literal>phpVersionOperator</literal>, uma versão exigida do PHP 
-      pode ser especificada. O exemplo abaixo só vai adicionar os 
+      <literal>phpVersionOperator</literal>, uma versão exigida do PHP
+      pode ser especificada. O exemplo abaixo só vai adicionar os
       arquivos <filename>/caminho/para/*Test.php</filename> e
-      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP 
+      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP
       for no mínimo 5.3.0.
     </para>
 
@@ -187,7 +187,7 @@
   </testsuites>]]></screen>
 
     <para>
-      O atributo <literal>phpVersionOperator</literal> é opcional e 
+      O atributo <literal>phpVersionOperator</literal> é opcional e
       padronizado para <literal><![CDATA[>=]]></literal>.
     </para>
   </section>
@@ -201,7 +201,7 @@
       O elemento <literal><![CDATA[<groups>]]></literal> e seus filhos
       <literal><![CDATA[<include>]]></literal>,
       <literal><![CDATA[<exclude>]]></literal>, e
-      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar 
+      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar
       grupos de testes marcados com a anotação <literal>@group</literal>
       (documentada na <xref linkend="appendixes.annotations.group" />)
       que (não) deveriam ser executados.
@@ -217,7 +217,7 @@
 </groups>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de testes TextUI 
+      A configuração XML acima corresponde a invocar o executor de testes TextUI
       com as seguintes opções:
     </para>
 
@@ -235,8 +235,8 @@
       <indexterm><primary>Lista-negra</primary></indexterm>
       <indexterm><primary>Lista-branca</primary></indexterm>
 
-      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem 
-      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura 
+      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem
+      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura
       de código.
     </para>
 
@@ -267,7 +267,7 @@
       <indexterm><primary>Registrando</primary></indexterm>
 
       O elemento <literal><![CDATA[<logging>]]></literal> e seus filhos
-      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o 
+      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o
       registro da execução de teste.
     </para>
 
@@ -285,7 +285,7 @@
 </logging>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de teste TextUI 
+      A configuração XML acima corresponde a invocar o executor de teste TextUI
       com as seguintes opções:
     </para>
 
@@ -305,7 +305,7 @@
     <para>
       Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
       <literal>logIncompleteSkipped</literal> e
-      <literal>showUncoveredFiles</literal> não possuem opção de 
+      <literal>showUncoveredFiles</literal> não possuem opção de
       execução de teste TextUI equivalente.
     </para>
 
@@ -321,11 +321,11 @@
     <title>Ouvintes de Teste</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Ouvintes de Teste</primary></indexterm>
 
       O elemento <literal><![CDATA[<listeners>]]></literal> e seus filhos
-      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar 
+      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar
       ouvintes adicionais de teste para a execução dos testes.
     </para>
 
@@ -369,8 +369,8 @@
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary><literal>php.ini</literal></primary></indexterm>
 
-      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser 
-      usados para definir configurações do PHP, constantes e variáveis globais. Também pode 
+      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser
+      usados para definir configurações do PHP, constantes e variáveis globais. Também pode
       ser usado para preceder o <literal>include_path</literal>.
     </para>
 
@@ -411,7 +411,7 @@ $_REQUEST['foo'] = 'bar';]]></screen>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
       O elemento <literal><![CDATA[<selenium>]]></literal> e seus filhos
-      <literal><![CDATA[<browser>]]></literal> podem ser usados para 
+      <literal><![CDATA[<browser>]]></literal> podem ser usados para
       configurar uma lista de servidores Selenium RC.
     </para>
 

--- a/src/6.2/pt_br/extending-phpunit.xml
+++ b/src/6.2/pt_br/extending-phpunit.xml
@@ -4,8 +4,8 @@
   <title>Estendendo o PHPUnit</title>
 
   <para>
-    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes 
-    e personalizar as respostas que você recebe ao executar os testes. Aqui estão 
+    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes
+    e personalizar as respostas que você recebe ao executar os testes. Aqui estão
     pontos de partida comuns para estender o PHPUnit.
   </para>
 
@@ -16,8 +16,8 @@
       <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
       Escreva asserções personalizadas e métodos utilitários em uma subclasse abstrata do
-      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste 
-      dessa classe. Essa é uma das formas mais fáceis de estender 
+      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste
+      dessa classe. Essa é uma das formas mais fáceis de estender
       o PHPUnit.
     </para>
   </section>
@@ -26,7 +26,7 @@
     <title>Escreva asserções personalizadas</title>
 
     <para>
-      Ao escrever asserções personalizadas a melhor prática é seguir a mesma 
+      Ao escrever asserções personalizadas a melhor prática é seguir a mesma
       forma que as asserções do próprio PHPUnit são implementadas. Como você pode ver no
       <xref linkend="extending-phpunit.examples.Assert.php"/>, o método
       <literal>assertTrue()</literal> é apenas um empacotador em torno dos métodos
@@ -73,7 +73,7 @@ abstract class PHPUnit_Framework_Assert
 
     <para>
       O <xref linkend="extending-phpunit.examples.IsTrue.php"/> mostra como
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a
       classe base abstrata para objetos comparadores (ou restritores),
       <literal>PHPUnit_Framework_Constraint</literal>.
     </para>
@@ -110,29 +110,32 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
     <para>
       O esforço de implementar os métodos <literal>assertTrue()</literal> e
       <literal>isTrue()</literal> assim como a classe
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o 
-      benefício de que <literal>assertThat()</literal> automaticamente cuida de 
-      avaliar a asserção e escriturar tarefas como contá-las para 
-      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o
+      benefício de que <literal>assertThat()</literal> automaticamente cuida de
+      avaliar a asserção e escriturar tarefas como contá-las para
+      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser
       usado como um comparador ao configurar objetos falsificados.
     </para>
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implementando PHPUnit_Framework_TestListener</title>
+    <title>Implementando PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       O <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      mostra uma implementação simples da interface 
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      mostra uma implementação simples da interface
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Um simples ouvinte de teste</title>
       <programlisting><![CDATA[<?php
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
@@ -186,12 +189,12 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
       <indexterm><primary>PHPUnit_Framework_BaseTestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.BaseTestListener.php" />
-      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>, 
+      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>,
       que permite que você especifique apenas os métodos de interface que
       são interessantes para seu caso de uso, ao fornecer implementações vazias
       para todos os outros.
     </para>
-    
+
     <example id="extending-phpunit.examples.BaseTestListener.php">
       <title>Usando o ouvinte de teste base</title>
       <programlisting><![CDATA[<?php
@@ -206,8 +209,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
     </example>
 
     <para>
-      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver 
-      como configurar o PHPUnit para anexar seu ouvinte de teste para a 
+      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver
+      como configurar o PHPUnit para anexar seu ouvinte de teste para a
       execução do teste.
     </para>
   </section>
@@ -219,8 +222,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
       <indexterm><primary>PHPUnit_Extensions_TestDecorator</primary></indexterm>
 
       Você pode envolver casos de teste ou suítes de teste em uma subclasse de
-      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão 
-      de projeto Decorador para realizar algumas ações antes e depois da 
+      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão
+      de projeto Decorador para realizar algumas ações antes e depois da
       execução do teste.
     </para>
 
@@ -229,7 +232,7 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
 
       O PHPUnit navega com um decorador de teste concreto:
       <literal>PHPUnit_Extensions_RepeatedTest</literal>. Ele é usado para executar um
-      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem 
+      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem
       bem-sucedidas.
     </para>
 
@@ -287,7 +290,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
       <indexterm><primary>PHPUnit_Framework_Test</primary></indexterm>
       <indexterm><primary>Testes Guiados por Dados</primary></indexterm>
 
-      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e 
+      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e
       fácil de implementar. Você pode escrever uma implementação do
       <literal>PHPUnit_Framework_Test</literal> que é mais simples que
       <literal>PHPUnit_Framework_TestCase</literal> e que executa
@@ -296,9 +299,9 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
 
     <para>
       O <xref linkend="extending-phpunit.examples.DataDrivenTest.php" />
-      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo 
+      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo
       com Valores Separados por Vírgulas (CSV). Cada linha de tal arquivo parece com
-      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos 
+      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos
       e o segundo valor é o real.
     </para>
 

--- a/src/6.2/pt_br/textui.xml
+++ b/src/6.2/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -600,7 +600,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -611,18 +611,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -632,7 +632,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -660,7 +660,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -669,7 +669,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -692,17 +692,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -718,16 +718,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -759,14 +759,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Especifica o impressor de resultados a ser usado. A classe impressora deve estender
             <literal>PHPUnit_Util_Printer</literal> e implementar a interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>
@@ -786,14 +786,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -805,7 +805,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -830,7 +830,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/6.2/pt_br/upgrading.xml
+++ b/src/6.2/pt_br/upgrading.xml
@@ -11,20 +11,20 @@
           O suporte limitado para <ulink
           url="http://sebastian-bergmann.de/blog/883-Stubbing-and-Mocking-Static-Methods.html">esboçando
           e falsificando métodos estáticos</ulink> que foi introduzido no PHPUnit 3.5
-          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado 
-          era invocado de um outro método da mesma classe. Acreditamos 
+          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado
+          era invocado de um outro método da mesma classe. Acreditamos
           que o uso limitado desta funcionalidade não justificava o
           aumento da complexidade em geradores de dublês de testes em que incorreu.
           Pedimos desculpas por qualquer inconveniência que esta remoção possa causar e
-          incentivamos a refatoração do código sobre teste para não exigir esse recurso 
+          incentivamos a refatoração do código sobre teste para não exigir esse recurso
           para testes.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          O <code>addRiskyTest()</code> foi adicionado a interface 
-          <code>PHPUnit_Framework_TestListener</code>. Classes que 
+          O <code>addRiskyTest()</code> foi adicionado a interface
+          <code>PHPUnit\Framework\TestListener</code>. Classes que
           implementam esta interface tem que implementar esse novo método. Essa é
           a razão por quê o PHPStorm 7 não é compatível com o PHPUnit 4, por
           exemplo.
@@ -36,10 +36,10 @@
           As correções para <ulink url="https://github.com/sebastianbergmann/phpunit/issues/552">#552</ulink>,
           <ulink url="https://github.com/sebastianbergmann/phpunit/issues/573">#573</ulink>,
           e <ulink url="https://github.com/sebastianbergmann/phpunit/issues/582">#582</ulink>
-          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração 
-          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são 
+          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração
+          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são
           resolvidos em relação a esse arquivo de configuração. Quando atualizar, você pode
-          precisar atualizar os caminhos relativos para as configurações 
+          precisar atualizar os caminhos relativos para as configurações
           <code>testSuiteLoaderFile</code>, <code>printerFile</code>,
           <code>testsuites/file</code>, e <code>testsuites/exclude</code>.
         </para>
@@ -47,26 +47,26 @@
 
       <listitem>
         <para>
-          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O 
-          comparador numérico não é mais invocado quando fornecido com duas 
+          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O
+          comparador numérico não é mais invocado quando fornecido com duas
           strings</ulink>.
         </para>
       </listitem>
     </itemizedlist>
 
     <para>
-      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit 
-      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que 
-      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através 
-      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do 
+      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit
+      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que
+      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através
+      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do
       PEAR completamente.
     </para>
 
     <para>
-      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para 
-      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das 
+      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para
+      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das
       dependências do PHPUnit (PHP_CodeCoverage, PHPUnit_MockObject, ...) por trás
-      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os 
+      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os
       respectivos pacotes PEAR.
     </para>
   </section>

--- a/src/6.2/zh_cn/configuration.xml
+++ b/src/6.2/zh_cn/configuration.xml
@@ -221,7 +221,7 @@
     <title>测试监听器</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener （测试监听器）</primary></indexterm><literal>&lt;listeners&gt;</literal> 元素及其 <literal>&lt;listener&gt;</literal> 子元素用于在测试执行期间附加额外的测试监听器。</para>
 
     <screen><![CDATA[<listeners>

--- a/src/6.2/zh_cn/extending-phpunit.xml
+++ b/src/6.2/zh_cn/extending-phpunit.xml
@@ -93,19 +93,20 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>实现 PHPUnit_Framework_TestListener</title>
+    <title>实现 PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
-      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit_Framework_TestListener</literal> 接口的一个简单实现。</para>
+      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit\Framework\TestListener</literal> 接口的一个简单实现。</para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>简单的测试监听器</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.2/zh_cn/textui.xml
+++ b/src/6.2/zh_cn/textui.xml
@@ -568,11 +568,11 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
-          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit_Framework_TestListener</literal> 接口。</para>
+          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit\Framework\TestListener</literal> 接口。</para>
         </listitem>
       </varlistentry>
 

--- a/src/6.3/en/configuration.xml
+++ b/src/6.3/en/configuration.xml
@@ -308,7 +308,7 @@
     <title>Test Listeners</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       The <literal><![CDATA[<listeners>]]></literal> element and its

--- a/src/6.3/en/extending-phpunit.xml
+++ b/src/6.3/en/extending-phpunit.xml
@@ -123,13 +123,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implement PHPUnit_Framework_TestListener</title>
+    <title>Implement PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      shows a simple implementation of the <literal>PHPUnit_Framework_TestListener</literal>
+      shows a simple implementation of the <literal>PHPUnit\Framework\TestListener</literal>
       interface.
     </para>
 
@@ -137,8 +137,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>A simple test listener</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.3/en/textui.xml
+++ b/src/6.3/en/textui.xml
@@ -287,7 +287,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Specifies the result printer to use. The printer class must extend
             <literal>PHPUnit_Util_Printer</literal> and implement the
-            <literal>PHPUnit_Framework_TestListener</literal> interface.
+            <literal>PHPUnit\Framework\TestListener</literal> interface.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.3/fr/configuration.xml
+++ b/src/6.3/fr/configuration.xml
@@ -308,7 +308,7 @@
     <title>Écouteurs de tests</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Écouteurs de tests</primary></indexterm>
 
       L'élément <literal><![CDATA[<listeners>]]></literal> et ses enfants

--- a/src/6.3/fr/extending-phpunit.xml
+++ b/src/6.3/fr/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implémenter PHPUnit_Framework_TestListener</title>
+    <title>Implémenter PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       montre une implémentation simple de l'interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Un simple moniteur de test</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.3/fr/textui.xml
+++ b/src/6.3/fr/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Indique l'afficheur de résultats à utiliser. Cette classe d'afficheur doit
             hériter de <literal>PHPUnit_Util_Printer</literal> et implémenter l'interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.3/ja/configuration.xml
+++ b/src/6.3/ja/configuration.xml
@@ -287,7 +287,7 @@
     <title>テストリスナー</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       <literal><![CDATA[<listeners>]]></literal> 要素とその子要素である

--- a/src/6.3/ja/extending-phpunit.xml
+++ b/src/6.3/ja/extending-phpunit.xml
@@ -122,13 +122,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>PHPUnit_Framework_TestListener の実装</title>
+    <title>PHPUnit\Framework\TestListener の実装</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" /> は、
-      <literal>PHPUnit_Framework_TestListener</literal>
+      <literal>PHPUnit\Framework\TestListener</literal>
       インターフェイスのシンプルな実装例です。
     </para>
 
@@ -136,8 +136,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>シンプルなテストリスナー</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.3/ja/textui.xml
+++ b/src/6.3/ja/textui.xml
@@ -751,14 +751,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             結果を表示するために使うプリンタクラスを指定します。このプリンタクラスは
             <literal>PHPUnit_Util_Printer</literal> を継承し、かつ
-            <literal>PHPUnit_Framework_TestListener</literal>
+            <literal>PHPUnit\Framework\TestListener</literal>
             インターフェイスを実装したものでなければなりません。
           </para>
         </listitem>

--- a/src/6.3/pt_br/configuration.xml
+++ b/src/6.3/pt_br/configuration.xml
@@ -7,7 +7,7 @@
     <title>PHPUnit</title>
 
     <para>
-      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem 
+      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem
       ser usados para configurar a funcionalidade principal do PHPUnit.
     </para>
 
@@ -41,7 +41,7 @@
 </phpunit>]]></screen>
 
     <para>
-      A configuração XML acima corresponde ao comportamento padrão do 
+      A configuração XML acima corresponde ao comportamento padrão do
       executor de teste TextUI documentado na <xref linkend="textui.clioptions" />.
     </para>
 
@@ -55,10 +55,10 @@
         <term><literal>convertErrorsToExceptions</literal></term>
         <listitem>
           <para>
-            Por padrão, PHPUnit irá instalar um manipulador de erro que converte 
+            Por padrão, PHPUnit irá instalar um manipulador de erro que converte
             os seguintes erros para exceções:
           </para>
-         
+
           <itemizedlist>
             <listitem><literal>E_WARNING</literal></listitem>
             <listitem><literal>E_NOTICE</literal></listitem>
@@ -70,14 +70,14 @@
             <listitem><literal>E_DEPRECATED</literal></listitem>
             <listitem><literal>E_USER_DEPRECATED</literal></listitem>
           </itemizedlist>
-          
+
           <para>
             Definir <literal>convertErrorsToExceptions</literal> para
             <literal>false</literal> desabilita esta funcionalidade.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertNoticesToExceptions</literal></term>
         <listitem>
@@ -89,7 +89,7 @@
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>convertWarningsToExceptions</literal></term>
         <listitem>
@@ -107,31 +107,31 @@
         <listitem>
           <para>
             A Cobertura de Código só será gravada para testes que usem a anotação
-            <literal>@covers</literal> documentada na 
+            <literal>@covers</literal> documentada na
             <xref linkend="appendixes.annotations.covers" />.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForLargeTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@large</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>timeoutForMediumTests</literal></term>
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@medium</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -142,8 +142,8 @@
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
-            define o tempo limite para todos os testes marcados como 
-            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste 
+            define o tempo limite para todos os testes marcados como
+            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste
             não completa dentro do tempo limite configurado, irá falhar.
           </para>
         </listitem>
@@ -157,8 +157,8 @@
     <para>
       <indexterm><primary>Suítes de Teste</primary></indexterm>
 
-      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s) 
-      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser 
+      O elemento <literal><![CDATA[<testsuites>]]></literal> e seu(s)
+      um ou mais filhos <literal><![CDATA[<testsuite>]]></literal> podem ser
       usados para compor uma suíte de teste fora das suítes e casos de teste.
     </para>
 
@@ -172,10 +172,10 @@
 
     <para>
       Usando os atributos <literal>phpVersion</literal> e
-      <literal>phpVersionOperator</literal>, uma versão exigida do PHP 
-      pode ser especificada. O exemplo abaixo só vai adicionar os 
+      <literal>phpVersionOperator</literal>, uma versão exigida do PHP
+      pode ser especificada. O exemplo abaixo só vai adicionar os
       arquivos <filename>/caminho/para/*Test.php</filename> e
-      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP 
+      <filename>/caminho/para/MeuTest.php</filename> se a versão do PHP
       for no mínimo 5.3.0.
     </para>
 
@@ -187,7 +187,7 @@
   </testsuites>]]></screen>
 
     <para>
-      O atributo <literal>phpVersionOperator</literal> é opcional e 
+      O atributo <literal>phpVersionOperator</literal> é opcional e
       padronizado para <literal><![CDATA[>=]]></literal>.
     </para>
   </section>
@@ -201,7 +201,7 @@
       O elemento <literal><![CDATA[<groups>]]></literal> e seus filhos
       <literal><![CDATA[<include>]]></literal>,
       <literal><![CDATA[<exclude>]]></literal>, e
-      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar 
+      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar
       grupos de testes marcados com a anotação <literal>@group</literal>
       (documentada na <xref linkend="appendixes.annotations.group" />)
       que (não) deveriam ser executados.
@@ -217,7 +217,7 @@
 </groups>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de testes TextUI 
+      A configuração XML acima corresponde a invocar o executor de testes TextUI
       com as seguintes opções:
     </para>
 
@@ -235,8 +235,8 @@
       <indexterm><primary>Lista-negra</primary></indexterm>
       <indexterm><primary>Lista-branca</primary></indexterm>
 
-      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem 
-      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura 
+      O elemento <literal><![CDATA[<filter>]]></literal> e seus filhos podem
+      ser usados para configurar a lista-negra e lista-branca para o relatório de cobertura
       de código.
     </para>
 
@@ -267,7 +267,7 @@
       <indexterm><primary>Registrando</primary></indexterm>
 
       O elemento <literal><![CDATA[<logging>]]></literal> e seus filhos
-      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o 
+      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o
       registro da execução de teste.
     </para>
 
@@ -285,7 +285,7 @@
 </logging>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de teste TextUI 
+      A configuração XML acima corresponde a invocar o executor de teste TextUI
       com as seguintes opções:
     </para>
 
@@ -305,7 +305,7 @@
     <para>
       Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
       <literal>logIncompleteSkipped</literal> e
-      <literal>showUncoveredFiles</literal> não possuem opção de 
+      <literal>showUncoveredFiles</literal> não possuem opção de
       execução de teste TextUI equivalente.
     </para>
 
@@ -321,11 +321,11 @@
     <title>Ouvintes de Teste</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Ouvintes de Teste</primary></indexterm>
 
       O elemento <literal><![CDATA[<listeners>]]></literal> e seus filhos
-      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar 
+      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar
       ouvintes adicionais de teste para a execução dos testes.
     </para>
 
@@ -369,8 +369,8 @@
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary><literal>php.ini</literal></primary></indexterm>
 
-      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser 
-      usados para definir configurações do PHP, constantes e variáveis globais. Também pode 
+      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser
+      usados para definir configurações do PHP, constantes e variáveis globais. Também pode
       ser usado para preceder o <literal>include_path</literal>.
     </para>
 
@@ -411,7 +411,7 @@ $_REQUEST['foo'] = 'bar';]]></screen>
       <indexterm><primary>Selenium RC</primary></indexterm>
 
       O elemento <literal><![CDATA[<selenium>]]></literal> e seus filhos
-      <literal><![CDATA[<browser>]]></literal> podem ser usados para 
+      <literal><![CDATA[<browser>]]></literal> podem ser usados para
       configurar uma lista de servidores Selenium RC.
     </para>
 

--- a/src/6.3/pt_br/extending-phpunit.xml
+++ b/src/6.3/pt_br/extending-phpunit.xml
@@ -4,8 +4,8 @@
   <title>Estendendo o PHPUnit</title>
 
   <para>
-    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes 
-    e personalizar as respostas que você recebe ao executar os testes. Aqui estão 
+    O PHPUnit pode ser estendido de várias formas para facilitar a escrita de testes
+    e personalizar as respostas que você recebe ao executar os testes. Aqui estão
     pontos de partida comuns para estender o PHPUnit.
   </para>
 
@@ -16,8 +16,8 @@
       <indexterm><primary>PHPUnit_Framework_TestCase</primary></indexterm>
 
       Escreva asserções personalizadas e métodos utilitários em uma subclasse abstrata do
-      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste 
-      dessa classe. Essa é uma das formas mais fáceis de estender 
+      <literal>PHPUnit_Framework_TestCase</literal> e derive suas classes de caso de teste
+      dessa classe. Essa é uma das formas mais fáceis de estender
       o PHPUnit.
     </para>
   </section>
@@ -26,7 +26,7 @@
     <title>Escreva asserções personalizadas</title>
 
     <para>
-      Ao escrever asserções personalizadas a melhor prática é seguir a mesma 
+      Ao escrever asserções personalizadas a melhor prática é seguir a mesma
       forma que as asserções do próprio PHPUnit são implementadas. Como você pode ver no
       <xref linkend="extending-phpunit.examples.Assert.php"/>, o método
       <literal>assertTrue()</literal> é apenas um empacotador em torno dos métodos
@@ -73,7 +73,7 @@ abstract class PHPUnit_Framework_Assert
 
     <para>
       O <xref linkend="extending-phpunit.examples.IsTrue.php"/> mostra como
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> estende a
       classe base abstrata para objetos comparadores (ou restritores),
       <literal>PHPUnit_Framework_Constraint</literal>.
     </para>
@@ -110,29 +110,32 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
     <para>
       O esforço de implementar os métodos <literal>assertTrue()</literal> e
       <literal>isTrue()</literal> assim como a classe
-      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o 
-      benefício de que <literal>assertThat()</literal> automaticamente cuida de 
-      avaliar a asserção e escriturar tarefas como contá-las para 
-      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser 
+      <literal>PHPUnit_Framework_Constraint_IsTrue</literal> rende o
+      benefício de que <literal>assertThat()</literal> automaticamente cuida de
+      avaliar a asserção e escriturar tarefas como contá-las para
+      estatísticas. Além disso, o método <literal>isTrue()</literal> pode ser
       usado como um comparador ao configurar objetos falsificados.
     </para>
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implementando PHPUnit_Framework_TestListener</title>
+    <title>Implementando PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       O <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      mostra uma implementação simples da interface 
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      mostra uma implementação simples da interface
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Um simples ouvinte de teste</title>
       <programlisting><![CDATA[<?php
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {
@@ -186,12 +189,12 @@ class SimpleTestListener implements PHPUnit_Framework_TestListener
       <indexterm><primary>PHPUnit_Framework_BaseTestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.BaseTestListener.php" />
-      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>, 
+      mostra como a subclasse da classe abstrata <literal>PHPUnit_Framework_BaseTestListener</literal>,
       que permite que você especifique apenas os métodos de interface que
       são interessantes para seu caso de uso, ao fornecer implementações vazias
       para todos os outros.
     </para>
-    
+
     <example id="extending-phpunit.examples.BaseTestListener.php">
       <title>Usando o ouvinte de teste base</title>
       <programlisting><![CDATA[<?php
@@ -206,8 +209,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
     </example>
 
     <para>
-      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver 
-      como configurar o PHPUnit para anexar seu ouvinte de teste para a 
+      Em <xref linkend="appendixes.configuration.test-listeners"/> você pode ver
+      como configurar o PHPUnit para anexar seu ouvinte de teste para a
       execução do teste.
     </para>
   </section>
@@ -219,8 +222,8 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
       <indexterm><primary>PHPUnit_Extensions_TestDecorator</primary></indexterm>
 
       Você pode envolver casos de teste ou suítes de teste em uma subclasse de
-      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão 
-      de projeto Decorador para realizar algumas ações antes e depois da 
+      <literal>PHPUnit_Extensions_TestDecorator</literal> e usar o padrão
+      de projeto Decorador para realizar algumas ações antes e depois da
       execução do teste.
     </para>
 
@@ -229,7 +232,7 @@ class ShortTestListener extends PHPUnit_Framework_BaseTestListener
 
       O PHPUnit navega com um decorador de teste concreto:
       <literal>PHPUnit_Extensions_RepeatedTest</literal>. Ele é usado para executar um
-      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem 
+      um teste repetidamente e apenas o conta como bem-sucedido se todas as iterações forem
       bem-sucedidas.
     </para>
 
@@ -287,7 +290,7 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
       <indexterm><primary>PHPUnit_Framework_Test</primary></indexterm>
       <indexterm><primary>Testes Guiados por Dados</primary></indexterm>
 
-      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e 
+      A interface <literal>PHPUnit_Framework_Test</literal> é limitada e
       fácil de implementar. Você pode escrever uma implementação do
       <literal>PHPUnit_Framework_Test</literal> que é mais simples que
       <literal>PHPUnit_Framework_TestCase</literal> e que executa
@@ -296,9 +299,9 @@ class PHPUnit_Extensions_RepeatedTest extends PHPUnit_Extensions_TestDecorator
 
     <para>
       O <xref linkend="extending-phpunit.examples.DataDrivenTest.php" />
-      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo 
+      mostra uma classe de caso de teste guiado por dados que compara valores de um arquivo
       com Valores Separados por Vírgulas (CSV). Cada linha de tal arquivo parece com
-      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos 
+      <literal>foo;bar</literal>, onde o primeiro valor é o qual esperamos
       e o segundo valor é o real.
     </para>
 

--- a/src/6.3/pt_br/textui.xml
+++ b/src/6.3/pt_br/textui.xml
@@ -5,7 +5,7 @@
 
   <para>
     O executor de testes em linha-de-comando do PHPUnit pode ser invocado através do comando
-    <filename>phpunit</filename>. O código seguinte mostra como executar 
+    <filename>phpunit</filename>. O código seguinte mostra como executar
     testes com o executor de testes em linha-de-comando do PHPUnit:
   </para>
 
@@ -27,7 +27,7 @@ OK (2 tests, 2 assertions)</screen>
   </para>
 
   <para>
-    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para 
+    Para cada teste executado, a ferramenta de linha-de-comando do PHPUnit imprime um caractere para
       indicar o progresso:
   </para>
 
@@ -58,7 +58,7 @@ OK (2 tests, 2 assertions)</screen>
         </para>
       </listitem>
     </varlistentry>
-    
+
     <varlistentry>
       <term><literal>R</literal></term>
       <listitem>
@@ -83,7 +83,7 @@ OK (2 tests, 2 assertions)</screen>
       <term><literal>I</literal></term>
       <listitem>
         <para>
-          Impresso quando o teste é marcado como incompleto ou ainda não 
+          Impresso quando o teste é marcado como incompleto ou ainda não
           implementado (veja <xref linkend="incomplete-and-skipped-tests" />).
         </para>
       </listitem>
@@ -97,10 +97,10 @@ OK (2 tests, 2 assertions)</screen>
     O PHPUnit distingue entre <emphasis>falhas</emphasis> e
     <emphasis>erros</emphasis>. Uma falha é uma asserção do PHPUnit violada
     assim como uma chamada falha ao <literal>assertEquals()</literal>.
-    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes 
-    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar 
-    do que falhas. Se você tiver uma grande lista de problemas, é melhor 
-    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de 
+    Um erro é uma exceção inesperada ou um erro do PHP. Às vezes
+    essa distinção se mostra útil já que erros tendem a ser mais fáceis de consertar
+    do que falhas. Se você tiver uma grande lista de problemas, é melhor
+    enfrentar os erros primeiro e ver se quaisquer falhas continuam depois de
     todos consertados.
   </para>
 
@@ -196,15 +196,15 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que essa classe seja declarada
             no arquivo-fonte <filename>UnitTest.php</filename>.
           </para>
 
           <para>
-            <literal>UnitTest</literal> deve ser ou uma classe que herda 
-            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que 
-            fornece um método <literal>public static suite()</literal> que 
-            retorna um objeto <literal>PHPUnit_Framework_Test</literal>, 
+            <literal>UnitTest</literal> deve ser ou uma classe que herda
+            de <literal>PHPUnit_Framework_TestCase</literal> ou uma classe que
+            fornece um método <literal>public static suite()</literal> que
+            retorna um objeto <literal>PHPUnit_Framework_Test</literal>,
             por exemplo uma instância da classe
             <literal>PHPUnit_Framework_TestSuite</literal>.
           </para>
@@ -216,18 +216,18 @@ Miscellaneous Options:
         <listitem>
           <para>
             Executa os testes que são fornecidos pela classe
-            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada 
+            <literal>UnitTest</literal>. Espera-se que esta classe seja declarada
             no arquivo-fonte especificado.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Cobertura de código</primary></indexterm>
         <term><literal>--coverage-clover</literal></term>
         <listitem>
           <para>
-            Gera uma arquivo de registro no formato XML com as informações da cobertura de código 
+            Gera uma arquivo de registro no formato XML com as informações da cobertura de código
             para a execução dos testes. Veja <xref linkend="logging" /> para mais detlahes.
           </para>
           <para>
@@ -269,7 +269,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Gera um objeto PHP_CodeCoverage serializado com as 
+            Gera um objeto PHP_CodeCoverage serializado com as
             informações de cobertura de código.
           </para>
           <para>
@@ -300,7 +300,7 @@ Miscellaneous Options:
         <term><literal>--log-junit</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro no formato XML Junit para a execução dos testes. 
+            Gera um arquivo de registro no formato XML Junit para a execução dos testes.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -311,8 +311,8 @@ Miscellaneous Options:
         <term><literal>--log-tap</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink> 
-            para a execução dos testes. Veja <xref linkend="logging" /> para mais 
+            Gera um arquivo de registro usando o formato <ulink url="http://testanything.org/">Test Anything Protocol (TAP)</ulink>
+            para a execução dos testes. Veja <xref linkend="logging" /> para mais
             detalhes.
           </para>
         </listitem>
@@ -323,8 +323,8 @@ Miscellaneous Options:
         <term><literal>--log-json</literal></term>
         <listitem>
           <para>
-            Gera um arquivo de registro usando o 
-            formato <ulink url="http://www.json.org/">JSON</ulink>. 
+            Gera um arquivo de registro usando o
+            formato <ulink url="http://www.json.org/">JSON</ulink>.
             Veja <xref linkend="logging" /> para mais detalhes.
           </para>
         </listitem>
@@ -335,8 +335,8 @@ Miscellaneous Options:
         <term><literal>--testdox-html</literal> e <literal>--testdox-text</literal></term>
         <listitem>
           <para>
-            Gera documentação ágil no formato HTML ou texto plano para os 
-            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para 
+            Gera documentação ágil no formato HTML ou texto plano para os
+            testes que são executados. Veja <xref linkend="other-uses-for-tests" /> para
             mais detalhes.
           </para>
         </listitem>
@@ -346,11 +346,11 @@ Miscellaneous Options:
         <term><literal>--filter</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes cujos nomes combinam com o padrão 
+            Apenas executa os testes cujos nomes combinam com o padrão
             fornecido. Se o padrão não for colocado entre delimitadores, o PHPUnit
             irá colocar o padrão no delimitador <literal>/</literal>.
           </para>
-          
+
           <para>
             Os nomes de teste para combinar estará em um dos seguintes formatos:
           </para>
@@ -360,8 +360,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod</literal></term>
               <listitem>
                 <para>
-                  O formato do nome de teste padrão é o equivalente ao usar 
-                  a constante mágica <literal>__METHOD__</literal> dentro 
+                  O formato do nome de teste padrão é o equivalente ao usar
+                  a constante mágica <literal>__METHOD__</literal> dentro
                   do método de teste.
                 </para>
               </listitem>
@@ -371,8 +371,8 @@ Miscellaneous Options:
               <term><literal>TestNamespace\TestCaseClass::testMethod with data set #0</literal></term>
               <listitem>
                 <para>
-                  Quando um teste tem um provedor de dados, cada iteração dos 
-                  dados obtém o índice atual acrescido ao final do 
+                  Quando um teste tem um provedor de dados, cada iteração dos
+                  dados obtém o índice atual acrescido ao final do
                   nome do teste padrão.
                 </para>
               </listitem>
@@ -383,9 +383,9 @@ Miscellaneous Options:
               <listitem>
                 <para>
                   Quando um teste tem um provedor de dados que usa conjuntos nomeados, cada
-                  iteração dos dados obtém o nome atual acrescido ao 
-                  final do nome do teste padrão. Veja 
-                  <xref linkend="textui.examples.TestCaseClass.php" /> para um 
+                  iteração dos dados obtém o nome atual acrescido ao
+                  final do nome do teste padrão. Veja
+                  <xref linkend="textui.examples.TestCaseClass.php" /> para um
                   exemplo de conjunto de dados nomeados.
                 </para>
 
@@ -428,7 +428,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </variablelist>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos 
+            Veja <xref linkend="textui.examples.filter-patterns" /> para exemplos
             de padrões de filtros válidos.
           </para>
 
@@ -448,7 +448,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
 
           <para>
-            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns 
+            Veja <xref linkend="textui.examples.filter-shortcuts" /> para alguns
             atalhos adicionais que estão disponíveis para combinar provedores de dados
           </para>
 
@@ -468,7 +468,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </example>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--testsuite</literal></term>
         <listitem>
@@ -486,12 +486,12 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--group</literal></term>
         <listitem>
           <para>
-            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Apenas executa os testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
           <para>
             A anotação <literal>@author</literal> é um apelido para
-            <literal>@group</literal>, permitindo filtrar os testes com base em seus 
+            <literal>@group</literal>, permitindo filtrar os testes com base em seus
             autores.
           </para>
         </listitem>
@@ -504,7 +504,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--exclude-group</literal></term>
         <listitem>
           <para>
-            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como 
+            Exclui testes do(s) grupo(s) especificado(s). Um teste pode ser marcado como
             pertencente a um grupo usando a anotação <literal>@group</literal>.
           </para>
         </listitem>
@@ -521,7 +521,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--test-suffix</literal></term>
         <listitem>
@@ -530,7 +530,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--report-useless-tests</literal></term>
         <listitem>
@@ -540,7 +540,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-coverage</literal></term>
         <listitem>
@@ -550,7 +550,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--strict-global-state</literal></term>
         <listitem>
@@ -560,7 +560,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-test-output</literal></term>
         <listitem>
@@ -570,7 +570,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
@@ -579,7 +579,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--enforce-time-limit</literal></term>
         <listitem>
@@ -589,7 +589,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Processo</primary></indexterm>
         <indexterm><primary>Isoalmento de Teste</primary></indexterm>
@@ -600,7 +600,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Test Isolation</primary></indexterm>
         <term><literal>--no-globals-backup</literal></term>
@@ -611,18 +611,18 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <indexterm><primary>Isolamento de Teste</primary></indexterm>
         <term><literal>--static-backup</literal></term>
         <listitem>
           <para>
-            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário. 
+            Faz cópia de segurança e restaura atributos estáticos das classes definidas pelo usuário.
             Veja <xref linkend="fixtures.global-state" /> para mais detalhes.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--colors</literal></term>
         <listitem>
@@ -632,7 +632,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stderr</literal></term>
         <listitem>
@@ -660,7 +660,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
@@ -669,7 +669,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
@@ -692,17 +692,17 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>--verbose</literal></term>
         <listitem>
           <para>
-            Saída mais verbosa de informações, por exemplo os nomes dos testes 
+            Saída mais verbosa de informações, por exemplo os nomes dos testes
             que ficaram incompletos ou foram pulados.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--debug</literal></term>
         <listitem>
           <para>
-            Informação de saída da depuração como o nome de um teste quando a 
+            Informação de saída da depuração como o nome de um teste quando a
             execução começa.
           </para>
         </listitem>
@@ -718,16 +718,16 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
           </para>
 
           <para>
-            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no 
-            diretório de trabalho atual e em cada diretório que está especificado na 
+            O carregador de suíte de teste padrão irá procurar pelo arquivo-fonte no
+            diretório de trabalho atual e em cada diretório que está especificado na
             configuração de diretiva <literal>include_path</literal> do PHP.
-            Um nome de classe como <literal>Project_Package_Class</literal> é 
-            mapeado para o nome de arquivo-fonte 
+            Um nome de classe como <literal>Project_Package_Class</literal> é
+            mapeado para o nome de arquivo-fonte
             <filename>Project/Package/Class.php</filename>.
           </para>
         </listitem>
       </varlistentry>
-      
+
       <varlistentry>
         <term><literal>--repeat</literal></term>
         <listitem>
@@ -759,14 +759,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Especifica o impressor de resultados a ser usado. A classe impressora deve estender
             <literal>PHPUnit_Util_Printer</literal> e implementar a interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>
@@ -786,14 +786,14 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <term><literal>-c</literal></term>
         <listitem>
           <para>
-            Lê a configuração de um arquivo XML. 
+            Lê a configuração de um arquivo XML.
             Veja <xref linkend="appendixes.configuration" /> para mais detalhes.
           </para>
           <para>
             Se <filename>phpunit.xml</filename> ou
-            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no 
-            diretório de trabalho atual e <literal>--configuration</literal> 
-            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente 
+            <filename>phpunit.xml.dist</filename> (nessa ordem) existirem no
+            diretório de trabalho atual e <literal>--configuration</literal>
+            <emphasis>não</emphasis> for usado, a configuração será lida automaticamente
             desse arquivo.
           </para>
         </listitem>
@@ -805,7 +805,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         <listitem>
           <para>
             Ignora <filename>phpunit.xml</filename> e
-            <filename>phpunit.xml.dist</filename> do diretório de trabalho 
+            <filename>phpunit.xml.dist</filename> do diretório de trabalho
             atual.
           </para>
         </listitem>
@@ -830,7 +830,7 @@ class TestCaseClass extends \PHPUnit_Framework_TestCase
         </listitem>
       </varlistentry>
     </variablelist>
-    
+
     <note>
       <para>
         Por favor, note que as opções não devem ser colocadas depois do(s) argumento(s).

--- a/src/6.3/pt_br/upgrading.xml
+++ b/src/6.3/pt_br/upgrading.xml
@@ -11,20 +11,20 @@
           O suporte limitado para <ulink
           url="http://sebastian-bergmann.de/blog/883-Stubbing-and-Mocking-Static-Methods.html">esboçando
           e falsificando métodos estáticos</ulink> que foi introduzido no PHPUnit 3.5
-          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado 
-          era invocado de um outro método da mesma classe. Acreditamos 
+          foi removido. Essa funcionalidade apenas funciona quando o método estático esboçado ou falsificado
+          era invocado de um outro método da mesma classe. Acreditamos
           que o uso limitado desta funcionalidade não justificava o
           aumento da complexidade em geradores de dublês de testes em que incorreu.
           Pedimos desculpas por qualquer inconveniência que esta remoção possa causar e
-          incentivamos a refatoração do código sobre teste para não exigir esse recurso 
+          incentivamos a refatoração do código sobre teste para não exigir esse recurso
           para testes.
         </para>
       </listitem>
 
       <listitem>
         <para>
-          O <code>addRiskyTest()</code> foi adicionado a interface 
-          <code>PHPUnit_Framework_TestListener</code>. Classes que 
+          O <code>addRiskyTest()</code> foi adicionado a interface
+          <code>PHPUnit\Framework\TestListener</code>. Classes que
           implementam esta interface tem que implementar esse novo método. Essa é
           a razão por quê o PHPStorm 7 não é compatível com o PHPUnit 4, por
           exemplo.
@@ -36,10 +36,10 @@
           As correções para <ulink url="https://github.com/sebastianbergmann/phpunit/issues/552">#552</ulink>,
           <ulink url="https://github.com/sebastianbergmann/phpunit/issues/573">#573</ulink>,
           e <ulink url="https://github.com/sebastianbergmann/phpunit/issues/582">#582</ulink>
-          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração 
-          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são 
+          necessita de uma alteração de como caminhos relativos são resolvidos para o arquivo de configuração
+          XML do PHPUnit. Todos caminhos relativos no arquivo de configuração agora são
           resolvidos em relação a esse arquivo de configuração. Quando atualizar, você pode
-          precisar atualizar os caminhos relativos para as configurações 
+          precisar atualizar os caminhos relativos para as configurações
           <code>testSuiteLoaderFile</code>, <code>printerFile</code>,
           <code>testsuites/file</code>, e <code>testsuites/exclude</code>.
         </para>
@@ -47,26 +47,26 @@
 
       <listitem>
         <para>
-          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O 
-          comparador numérico não é mais invocado quando fornecido com duas 
+          <ulink url="https://github.com/sebastianbergmann/phpunit/commit/f5df97cda0b25f2b7368395344da095ac529de62">O
+          comparador numérico não é mais invocado quando fornecido com duas
           strings</ulink>.
         </para>
       </listitem>
     </itemizedlist>
 
     <para>
-      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit 
-      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que 
-      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através 
-      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do 
+      Por favor, note que iniciar com PHPUnit 4.0.0, o pacote PEAR do PHPUnit
+      é apenas um mecanismo de distribuição para o PHP Archive (PHAR) e que
+      muitas dependências do PHPUnit não irão mais ser lançadas individualmente através
+      do PEAR. Iremos eventualmente parar de fazer lançamentos do PHPUnit disponível através do
       PEAR completamente.
     </para>
 
     <para>
-      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para 
-      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das 
+      Por favor, note que usando o instalador PEAR para atualizar de PHPUnit 3.7 para
+      PHPUnit 4.0 vai deixar o arquivo-fonte obsoleto de versões anteriores das
       dependências do PHPUnit (PHP_CodeCoverage, PHPUnit_MockObject, ...) por trás
-      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os 
+      de seu diretório PEAR do ambiente do PHP. Aconselha-se desinstalar os
       respectivos pacotes PEAR.
     </para>
   </section>

--- a/src/6.3/zh_cn/configuration.xml
+++ b/src/6.3/zh_cn/configuration.xml
@@ -221,7 +221,7 @@
     <title>测试监听器</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener （测试监听器）</primary></indexterm><literal>&lt;listeners&gt;</literal> 元素及其 <literal>&lt;listener&gt;</literal> 子元素用于在测试执行期间附加额外的测试监听器。</para>
 
     <screen><![CDATA[<listeners>

--- a/src/6.3/zh_cn/extending-phpunit.xml
+++ b/src/6.3/zh_cn/extending-phpunit.xml
@@ -93,19 +93,20 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>实现 PHPUnit_Framework_TestListener</title>
+    <title>实现 PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
-      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit_Framework_TestListener</literal> 接口的一个简单实现。</para>
+      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit\Framework\TestListener</literal> 接口的一个简单实现。</para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>简单的测试监听器</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.3/zh_cn/textui.xml
+++ b/src/6.3/zh_cn/textui.xml
@@ -568,11 +568,11 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
-          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit_Framework_TestListener</literal> 接口。</para>
+          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit\Framework\TestListener</literal> 接口。</para>
         </listitem>
       </varlistentry>
 

--- a/src/6.4/en/configuration.xml
+++ b/src/6.4/en/configuration.xml
@@ -308,7 +308,7 @@
     <title>Test Listeners</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       The <literal><![CDATA[<listeners>]]></literal> element and its

--- a/src/6.4/en/extending-phpunit.xml
+++ b/src/6.4/en/extending-phpunit.xml
@@ -123,13 +123,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implement PHPUnit_Framework_TestListener</title>
+    <title>Implement PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      shows a simple implementation of the <literal>PHPUnit_Framework_TestListener</literal>
+      shows a simple implementation of the <literal>PHPUnit\Framework\TestListener</literal>
       interface.
     </para>
 
@@ -137,8 +137,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>A simple test listener</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.4/en/textui.xml
+++ b/src/6.4/en/textui.xml
@@ -287,7 +287,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Specifies the result printer to use. The printer class must extend
             <literal>PHPUnit_Util_Printer</literal> and implement the
-            <literal>PHPUnit_Framework_TestListener</literal> interface.
+            <literal>PHPUnit\Framework\TestListener</literal> interface.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.4/fr/configuration.xml
+++ b/src/6.4/fr/configuration.xml
@@ -308,7 +308,7 @@
     <title>Écouteurs de tests</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Écouteurs de tests</primary></indexterm>
 
       L'élément <literal><![CDATA[<listeners>]]></literal> et ses enfants

--- a/src/6.4/fr/extending-phpunit.xml
+++ b/src/6.4/fr/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implémenter PHPUnit_Framework_TestListener</title>
+    <title>Implémenter PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       montre une implémentation simple de l'interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Un simple moniteur de test</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.4/fr/textui.xml
+++ b/src/6.4/fr/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Indique l'afficheur de résultats à utiliser. Cette classe d'afficheur doit
             hériter de <literal>PHPUnit_Util_Printer</literal> et implémenter l'interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.4/ja/configuration.xml
+++ b/src/6.4/ja/configuration.xml
@@ -287,7 +287,7 @@
     <title>テストリスナー</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       <literal><![CDATA[<listeners>]]></literal> 要素とその子要素である

--- a/src/6.4/ja/extending-phpunit.xml
+++ b/src/6.4/ja/extending-phpunit.xml
@@ -122,13 +122,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>PHPUnit_Framework_TestListener の実装</title>
+    <title>PHPUnit\Framework\TestListener の実装</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" /> は、
-      <literal>PHPUnit_Framework_TestListener</literal>
+      <literal>PHPUnit\Framework\TestListener</literal>
       インターフェイスのシンプルな実装例です。
     </para>
 
@@ -136,8 +136,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>シンプルなテストリスナー</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.4/ja/textui.xml
+++ b/src/6.4/ja/textui.xml
@@ -751,14 +751,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             結果を表示するために使うプリンタクラスを指定します。このプリンタクラスは
             <literal>PHPUnit_Util_Printer</literal> を継承し、かつ
-            <literal>PHPUnit_Framework_TestListener</literal>
+            <literal>PHPUnit\Framework\TestListener</literal>
             インターフェイスを実装したものでなければなりません。
           </para>
         </listitem>

--- a/src/6.4/pt_br/configuration.xml
+++ b/src/6.4/pt_br/configuration.xml
@@ -7,7 +7,7 @@
     <title>PHPUnit</title>
 
     <para>
-      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem 
+      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem
       ser usados para configurar a funcionalidade principal do PHPUnit.
     </para>
 
@@ -42,7 +42,7 @@
 </phpunit>]]></screen>
 
     <para>
-      A configuração XML acima corresponde ao comportamento padrão do 
+      A configuração XML acima corresponde ao comportamento padrão do
       executor de teste TextUI documentado na <xref linkend="textui.clioptions" />.
     </para>
 
@@ -56,7 +56,7 @@
         <term><literal>convertErrorsToExceptions</literal></term>
         <listitem>
           <para>
-            Por padrão, PHPUnit irá instalar um manipulador de erro que converte 
+            Por padrão, PHPUnit irá instalar um manipulador de erro que converte
             os seguintes erros para exceções:
           </para>
 
@@ -108,7 +108,7 @@
         <listitem>
           <para>
             A Cobertura de Código só será registrada para testes que usem a anotação
-            <literal>@covers</literal> documentada na 
+            <literal>@covers</literal> documentada na
             <xref linkend="appendixes.annotations.covers" />.
           </para>
         </listitem>
@@ -120,7 +120,7 @@
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@large</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -132,7 +132,7 @@
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@medium</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -143,8 +143,8 @@
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
-            define o tempo limite para todos os testes marcados como 
-            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste 
+            define o tempo limite para todos os testes marcados como
+            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste
             não completa dentro do tempo limite configurado, irá falhar.
           </para>
         </listitem>
@@ -173,7 +173,7 @@
 
     <para>
       Usando os atributos <literal>phpVersion</literal> e
-      <literal>phpVersionOperator</literal>, uma versão exigida do PHP 
+      <literal>phpVersionOperator</literal>, uma versão exigida do PHP
       pode ser especificada. O exemplo abaixo só vai adicionar os
       arquivos <filename>/path/to/*Test.php</filename> e
       <filename>/path/to/MyTest.php</filename> se a versão do PHP
@@ -188,7 +188,7 @@
   </testsuites>]]></screen>
 
     <para>
-      O atributo <literal>phpVersionOperator</literal> é opcional e 
+      O atributo <literal>phpVersionOperator</literal> é opcional e
       padronizado para <literal><![CDATA[>=]]></literal>.
     </para>
   </section>
@@ -202,7 +202,7 @@
       O elemento <literal><![CDATA[<groups>]]></literal> e seus filhos
       <literal><![CDATA[<include>]]></literal>,
       <literal><![CDATA[<exclude>]]></literal>, e
-      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar 
+      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar
       grupos de testes marcados com a anotação <literal>@group</literal>
       (documentada na <xref linkend="appendixes.annotations.group" />)
       que (não) deveriam ser executados.
@@ -218,7 +218,7 @@
 </groups>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de testes TextUI 
+      A configuração XML acima corresponde a invocar o executor de testes TextUI
       com as seguintes opções:
     </para>
 
@@ -258,7 +258,7 @@
       <indexterm><primary>Registrando</primary></indexterm>
 
       O elemento <literal><![CDATA[<logging>]]></literal> e seus filhos
-      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o 
+      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o
       registro da execução de teste.
     </para>
 
@@ -274,7 +274,7 @@
 </logging>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de teste TextUI 
+      A configuração XML acima corresponde a invocar o executor de teste TextUI
       com as seguintes opções:
     </para>
 
@@ -292,7 +292,7 @@
     <para>
       Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
       <literal>logIncompleteSkipped</literal> e
-      <literal>showUncoveredFiles</literal> não possuem opção de 
+      <literal>showUncoveredFiles</literal> não possuem opção de
       execução de teste TextUI equivalente.
     </para>
 
@@ -308,11 +308,11 @@
     <title>Ouvintes de Teste</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Ouvintes de Teste</primary></indexterm>
 
       O elemento <literal><![CDATA[<listeners>]]></literal> e seus filhos
-      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar 
+      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar
       ouvintes adicionais de teste para a execução dos testes.
     </para>
 
@@ -356,8 +356,8 @@
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary><literal>php.ini</literal></primary></indexterm>
 
-      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser 
-      usados para definir configurações do PHP, constantes e variáveis globais. Também pode 
+      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser
+      usados para definir configurações do PHP, constantes e variáveis globais. Também pode
       ser usado para preceder o <literal>include_path</literal>.
     </para>
 

--- a/src/6.4/pt_br/extending-phpunit.xml
+++ b/src/6.4/pt_br/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implementando PHPUnit_Framework_TestListener</title>
+    <title>Implementando PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       O <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       mostra uma implementação simples da interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Um simples ouvinte de teste</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.4/pt_br/textui.xml
+++ b/src/6.4/pt_br/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Especifica a impressora de resultados a ser usada. A classe impressora deve estender
             <literal>PHPUnit_Util_Printer</literal> e implementar a interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.4/zh_cn/configuration.xml
+++ b/src/6.4/zh_cn/configuration.xml
@@ -221,7 +221,7 @@
     <title>测试监听器</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener （测试监听器）</primary></indexterm><literal>&lt;listeners&gt;</literal> 元素及其 <literal>&lt;listener&gt;</literal> 子元素用于在测试执行期间附加额外的测试监听器。</para>
 
     <screen><![CDATA[<listeners>

--- a/src/6.4/zh_cn/extending-phpunit.xml
+++ b/src/6.4/zh_cn/extending-phpunit.xml
@@ -93,19 +93,20 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>实现 PHPUnit_Framework_TestListener</title>
+    <title>实现 PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
-      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit_Framework_TestListener</literal> 接口的一个简单实现。</para>
+      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit\Framework\TestListener</literal> 接口的一个简单实现。</para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>简单的测试监听器</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.4/zh_cn/textui.xml
+++ b/src/6.4/zh_cn/textui.xml
@@ -568,11 +568,11 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
-          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit_Framework_TestListener</literal> 接口。</para>
+          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit\Framework\TestListener</literal> 接口。</para>
         </listitem>
       </varlistentry>
 

--- a/src/6.5/en/configuration.xml
+++ b/src/6.5/en/configuration.xml
@@ -308,7 +308,7 @@
     <title>Test Listeners</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       The <literal><![CDATA[<listeners>]]></literal> element and its

--- a/src/6.5/en/extending-phpunit.xml
+++ b/src/6.5/en/extending-phpunit.xml
@@ -123,13 +123,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implement PHPUnit_Framework_TestListener</title>
+    <title>Implement PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
-      shows a simple implementation of the <literal>PHPUnit_Framework_TestListener</literal>
+      shows a simple implementation of the <literal>PHPUnit\Framework\TestListener</literal>
       interface.
     </para>
 
@@ -137,8 +137,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>A simple test listener</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.5/en/textui.xml
+++ b/src/6.5/en/textui.xml
@@ -287,7 +287,7 @@ Miscellaneous Options:
         <term><literal>--coverage-php</literal></term>
         <listitem>
           <para>
-            Generates a serialized PHP_CodeCoverage object with the 
+            Generates a serialized PHP_CodeCoverage object with the
             code coverage information.
           </para>
           <para>
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Specifies the result printer to use. The printer class must extend
             <literal>PHPUnit_Util_Printer</literal> and implement the
-            <literal>PHPUnit_Framework_TestListener</literal> interface.
+            <literal>PHPUnit\Framework\TestListener</literal> interface.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.5/fr/configuration.xml
+++ b/src/6.5/fr/configuration.xml
@@ -308,7 +308,7 @@
     <title>Écouteurs de tests</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Écouteurs de tests</primary></indexterm>
 
       L'élément <literal><![CDATA[<listeners>]]></literal> et ses enfants

--- a/src/6.5/fr/extending-phpunit.xml
+++ b/src/6.5/fr/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implémenter PHPUnit_Framework_TestListener</title>
+    <title>Implémenter PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       montre une implémentation simple de l'interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Un simple moniteur de test</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.5/fr/textui.xml
+++ b/src/6.5/fr/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Indique l'afficheur de résultats à utiliser. Cette classe d'afficheur doit
             hériter de <literal>PHPUnit_Util_Printer</literal> et implémenter l'interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.5/ja/configuration.xml
+++ b/src/6.5/ja/configuration.xml
@@ -287,7 +287,7 @@
     <title>テストリスナー</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener</primary></indexterm>
 
       <literal><![CDATA[<listeners>]]></literal> 要素とその子要素である

--- a/src/6.5/ja/extending-phpunit.xml
+++ b/src/6.5/ja/extending-phpunit.xml
@@ -122,13 +122,13 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>PHPUnit_Framework_TestListener の実装</title>
+    <title>PHPUnit\Framework\TestListener の実装</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       <xref linkend="extending-phpunit.examples.SimpleTestListener.php" /> は、
-      <literal>PHPUnit_Framework_TestListener</literal>
+      <literal>PHPUnit\Framework\TestListener</literal>
       インターフェイスのシンプルな実装例です。
     </para>
 
@@ -136,8 +136,9 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
       <title>シンプルなテストリスナー</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.5/ja/textui.xml
+++ b/src/6.5/ja/textui.xml
@@ -751,14 +751,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             結果を表示するために使うプリンタクラスを指定します。このプリンタクラスは
             <literal>PHPUnit_Util_Printer</literal> を継承し、かつ
-            <literal>PHPUnit_Framework_TestListener</literal>
+            <literal>PHPUnit\Framework\TestListener</literal>
             インターフェイスを実装したものでなければなりません。
           </para>
         </listitem>

--- a/src/6.5/pt_br/configuration.xml
+++ b/src/6.5/pt_br/configuration.xml
@@ -7,7 +7,7 @@
     <title>PHPUnit</title>
 
     <para>
-      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem 
+      Os atributos do elemento <literal><![CDATA[<phpunit>]]></literal> podem
       ser usados para configurar a funcionalidade principal do PHPUnit.
     </para>
 
@@ -42,7 +42,7 @@
 </phpunit>]]></screen>
 
     <para>
-      A configuração XML acima corresponde ao comportamento padrão do 
+      A configuração XML acima corresponde ao comportamento padrão do
       executor de teste TextUI documentado na <xref linkend="textui.clioptions" />.
     </para>
 
@@ -56,7 +56,7 @@
         <term><literal>convertErrorsToExceptions</literal></term>
         <listitem>
           <para>
-            Por padrão, PHPUnit irá instalar um manipulador de erro que converte 
+            Por padrão, PHPUnit irá instalar um manipulador de erro que converte
             os seguintes erros para exceções:
           </para>
 
@@ -108,7 +108,7 @@
         <listitem>
           <para>
             A Cobertura de Código só será registrada para testes que usem a anotação
-            <literal>@covers</literal> documentada na 
+            <literal>@covers</literal> documentada na
             <xref linkend="appendixes.annotations.covers" />.
           </para>
         </listitem>
@@ -120,7 +120,7 @@
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@large</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -132,7 +132,7 @@
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
             define o tempo limite para todos os testes marcados como <literal>@medium</literal>.
-            Se um teste não completa dentro do tempo limite configurado, irá 
+            Se um teste não completa dentro do tempo limite configurado, irá
             falhar.
           </para>
         </listitem>
@@ -143,8 +143,8 @@
         <listitem>
           <para>
             Se o limite de tempo baseado no tamanho do teste são forçados então esse atributo
-            define o tempo limite para todos os testes marcados como 
-            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste 
+            define o tempo limite para todos os testes marcados como
+            <literal>@medium</literal> ou <literal>@large</literal>. Se um teste
             não completa dentro do tempo limite configurado, irá falhar.
           </para>
         </listitem>
@@ -173,7 +173,7 @@
 
     <para>
       Usando os atributos <literal>phpVersion</literal> e
-      <literal>phpVersionOperator</literal>, uma versão exigida do PHP 
+      <literal>phpVersionOperator</literal>, uma versão exigida do PHP
       pode ser especificada. O exemplo abaixo só vai adicionar os
       arquivos <filename>/path/to/*Test.php</filename> e
       <filename>/path/to/MyTest.php</filename> se a versão do PHP
@@ -188,7 +188,7 @@
   </testsuites>]]></screen>
 
     <para>
-      O atributo <literal>phpVersionOperator</literal> é opcional e 
+      O atributo <literal>phpVersionOperator</literal> é opcional e
       padronizado para <literal><![CDATA[>=]]></literal>.
     </para>
   </section>
@@ -202,7 +202,7 @@
       O elemento <literal><![CDATA[<groups>]]></literal> e seus filhos
       <literal><![CDATA[<include>]]></literal>,
       <literal><![CDATA[<exclude>]]></literal>, e
-      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar 
+      <literal><![CDATA[<group>]]></literal> podem ser usados para selecionar
       grupos de testes marcados com a anotação <literal>@group</literal>
       (documentada na <xref linkend="appendixes.annotations.group" />)
       que (não) deveriam ser executados.
@@ -218,7 +218,7 @@
 </groups>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de testes TextUI 
+      A configuração XML acima corresponde a invocar o executor de testes TextUI
       com as seguintes opções:
     </para>
 
@@ -258,7 +258,7 @@
       <indexterm><primary>Registrando</primary></indexterm>
 
       O elemento <literal><![CDATA[<logging>]]></literal> e seus filhos
-      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o 
+      <literal><![CDATA[<log>]]></literal> podem ser usados para configurar o
       registro da execução de teste.
     </para>
 
@@ -274,7 +274,7 @@
 </logging>]]></screen>
 
     <para>
-      A configuração XML acima corresponde a invocar o executor de teste TextUI 
+      A configuração XML acima corresponde a invocar o executor de teste TextUI
       com as seguintes opções:
     </para>
 
@@ -292,7 +292,7 @@
     <para>
       Os atributos <literal>lowUpperBound</literal>, <literal>highLowerBound</literal>,
       <literal>logIncompleteSkipped</literal> e
-      <literal>showUncoveredFiles</literal> não possuem opção de 
+      <literal>showUncoveredFiles</literal> não possuem opção de
       execução de teste TextUI equivalente.
     </para>
 
@@ -308,11 +308,11 @@
     <title>Ouvintes de Teste</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Ouvintes de Teste</primary></indexterm>
 
       O elemento <literal><![CDATA[<listeners>]]></literal> e seus filhos
-      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar 
+      <literal><![CDATA[<listener>]]></literal> podem ser usados para anexar
       ouvintes adicionais de teste para a execução dos testes.
     </para>
 
@@ -356,8 +356,8 @@
       <indexterm><primary>Variável Global</primary></indexterm>
       <indexterm><primary><literal>php.ini</literal></primary></indexterm>
 
-      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser 
-      usados para definir configurações do PHP, constantes e variáveis globais. Também pode 
+      O elemento <literal><![CDATA[<php>]]></literal> e seus filhos podem ser
+      usados para definir configurações do PHP, constantes e variáveis globais. Também pode
       ser usado para preceder o <literal>include_path</literal>.
     </para>
 

--- a/src/6.5/pt_br/extending-phpunit.xml
+++ b/src/6.5/pt_br/extending-phpunit.xml
@@ -123,22 +123,23 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>Implementando PHPUnit_Framework_TestListener</title>
+    <title>Implementando PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
       O <xref linkend="extending-phpunit.examples.SimpleTestListener.php" />
       mostra uma implementação simples da interface
-      <literal>PHPUnit_Framework_TestListener</literal>.
+      <literal>PHPUnit\Framework\TestListener</literal>.
     </para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>Um simples ouvinte de teste</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.5/pt_br/textui.xml
+++ b/src/6.5/pt_br/textui.xml
@@ -779,14 +779,14 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
           <para>
             Especifica a impressora de resultados a ser usada. A classe impressora deve estender
             <literal>PHPUnit_Util_Printer</literal> e implementar a interface
-            <literal>PHPUnit_Framework_TestListener</literal>.
+            <literal>PHPUnit\Framework\TestListener</literal>.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.5/zh_cn/configuration.xml
+++ b/src/6.5/zh_cn/configuration.xml
@@ -221,7 +221,7 @@
     <title>测试监听器</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
       <indexterm><primary>Test Listener （测试监听器）</primary></indexterm><literal>&lt;listeners&gt;</literal> 元素及其 <literal>&lt;listener&gt;</literal> 子元素用于在测试执行期间附加额外的测试监听器。</para>
 
     <screen><![CDATA[<listeners>

--- a/src/6.5/zh_cn/extending-phpunit.xml
+++ b/src/6.5/zh_cn/extending-phpunit.xml
@@ -93,19 +93,20 @@ class PHPUnit_Framework_Constraint_IsTrue extends PHPUnit_Framework_Constraint
   </section>
 
   <section id="extending-phpunit.PHPUnit_Framework_TestListener">
-    <title>实现 PHPUnit_Framework_TestListener</title>
+    <title>实现 PHPUnit\Framework\TestListener</title>
 
     <para>
-      <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+      <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
 
-      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit_Framework_TestListener</literal> 接口的一个简单实现。</para>
+      <xref linkend="extending-phpunit.examples.SimpleTestListener.php"/>展示了 <literal>PHPUnit\Framework\TestListener</literal> 接口的一个简单实现。</para>
 
     <example id="extending-phpunit.examples.SimpleTestListener.php">
       <title>简单的测试监听器</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
 
-class SimpleTestListener implements PHPUnit_Framework_TestListener
+class SimpleTestListener implements TestListener
 {
     public function addError(PHPUnit_Framework_Test $test, Exception $e, $time)
     {

--- a/src/6.5/zh_cn/textui.xml
+++ b/src/6.5/zh_cn/textui.xml
@@ -568,11 +568,11 @@ class TestCaseClass extends TestCase
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>PHPUnit_Framework_TestListener</primary></indexterm>
+        <indexterm><primary>PHPUnit\Framework\TestListener</primary></indexterm>
         <indexterm><primary>PHPUnit_Util_Printer</primary></indexterm>
         <term><literal>--printer</literal></term>
         <listitem>
-          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit_Framework_TestListener</literal> 接口。</para>
+          <para>指定要使用的结果输出器(printer)。输出器类必须扩展 <literal>PHPUnit_Util_Printer</literal> 并且实现 <literal>PHPUnit\Framework\TestListener</literal> 接口。</para>
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
Since 6.0, PHPUnit_Framework_TestListener has changed, it's PHPUnit\Framework\TestListener now.

Will fix https://github.com/sebastianbergmann/phpunit-documentation/issues/436