### PR TITLE
French translation - Review for 5.7 to 6.5 versions

### DIFF
--- a/src/5.7/fr/README.md
+++ b/src/5.7/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-5.7
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues

--- a/src/5.7/fr/annotations.xml
+++ b/src/5.7/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/5.7/fr/assertions.xml
+++ b/src/5.7/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/5.7/fr/code-coverage-analysis.xml
+++ b/src/5.7/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de 
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/5.7/fr/test-doubles.xml
+++ b/src/5.7/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/5.7/fr/textui.xml
+++ b/src/5.7/fr/textui.xml
@@ -701,7 +701,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -710,7 +710,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -719,7 +719,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -728,7 +728,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -737,7 +737,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.7/fr/writing-tests-for-phpunit.xml
+++ b/src/5.7/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 

--- a/src/6.0/fr/README.md
+++ b/src/6.0/fr/README.md
@@ -10,9 +10,9 @@ Pour compiler la documentation en français, les pré-requis sont les suivants :
 Pour compiler la documentation en français :
 
     cd build
-    ant build-fr-6.1
+    ant build-fr-6.0
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues

--- a/src/6.0/fr/annotations.xml
+++ b/src/6.0/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/6.0/fr/assertions.xml
+++ b/src/6.0/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/6.0/fr/code-coverage-analysis.xml
+++ b/src/6.0/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/6.0/fr/test-doubles.xml
+++ b/src/6.0/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/6.0/fr/textui.xml
+++ b/src/6.0/fr/textui.xml
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.0/fr/writing-tests-for-phpunit.xml
+++ b/src/6.0/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 

--- a/src/6.1/fr/README.md
+++ b/src/6.1/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-6.1
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues
@@ -45,7 +45,7 @@ Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
 | organizing-tests.xml              | OK        | @gbprod           | done                     |
 | other-uses-for-tests.xml          | OK        | @gbprod           | done                     |
 | risky-tests.xml                   | OK        | @gbprod           | done                     |
-| test-doubles.xml                  | OK        | @brice @gbprod    | done                     |
+| test-doubles.xml                  | OK        | @brice @gbprod    | done                     |
 | testing-practices.xml             | OK        | @gbprod           | done                     |
 | textui.xml                        | OK        | @gbprod           | done                     |
 | writing-tests-for-phpunit.xml     | OK        | @gbprod           | done                     |
@@ -55,26 +55,27 @@ Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
-
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres: testing => tester               |
 
 ## Historique du projet de traduction
 
 14/02/2017 : Je relance le projet de traduction de la doc de PHPUnit afin de permettre à des francophones de mieux appréhender ce produit. La dernière version française complète est lié à la version 4.3 de phpunit. C'est cette version qui est dupliquée dans les répertoires 4.4 à 6.0. La traduction commence à la version 6.1 avec un travail en cours de récupération des fichiers manquants et mise à jour des fichiers existant.
 
-03/03/2017 : J'ai ajouté un tableau d'avancement ppur mesurer le travail à fournir pour arriver au bout des traductions.
+03/03/2017 : J'ai ajouté un tableau d'avancement pour mesurer le travail à fournir pour arriver au bout des traductions.

--- a/src/6.1/fr/annotations.xml
+++ b/src/6.1/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/6.1/fr/assertions.xml
+++ b/src/6.1/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/6.1/fr/code-coverage-analysis.xml
+++ b/src/6.1/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/6.1/fr/test-doubles.xml
+++ b/src/6.1/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/6.1/fr/textui.xml
+++ b/src/6.1/fr/textui.xml
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.1/fr/writing-tests-for-phpunit.xml
+++ b/src/6.1/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 

--- a/src/6.2/fr/README.md
+++ b/src/6.2/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-6.2
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues

--- a/src/6.2/fr/annotations.xml
+++ b/src/6.2/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/6.2/fr/assertions.xml
+++ b/src/6.2/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/6.2/fr/code-coverage-analysis.xml
+++ b/src/6.2/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/6.2/fr/test-doubles.xml
+++ b/src/6.2/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/6.2/fr/textui.xml
+++ b/src/6.2/fr/textui.xml
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.2/fr/writing-tests-for-phpunit.xml
+++ b/src/6.2/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 

--- a/src/6.3/fr/README.md
+++ b/src/6.3/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-6.3
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues

--- a/src/6.3/fr/annotations.xml
+++ b/src/6.3/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/6.3/fr/assertions.xml
+++ b/src/6.3/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/6.3/fr/code-coverage-analysis.xml
+++ b/src/6.3/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/6.3/fr/test-doubles.xml
+++ b/src/6.3/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/6.3/fr/textui.xml
+++ b/src/6.3/fr/textui.xml
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.3/fr/writing-tests-for-phpunit.xml
+++ b/src/6.3/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 

--- a/src/6.4/fr/README.md
+++ b/src/6.4/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-6.4
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues

--- a/src/6.4/fr/annotations.xml
+++ b/src/6.4/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/6.4/fr/assertions.xml
+++ b/src/6.4/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/6.4/fr/code-coverage-analysis.xml
+++ b/src/6.4/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/6.4/fr/test-doubles.xml
+++ b/src/6.4/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/6.4/fr/textui.xml
+++ b/src/6.4/fr/textui.xml
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.4/fr/writing-tests-for-phpunit.xml
+++ b/src/6.4/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 

--- a/src/6.5/fr/README.md
+++ b/src/6.5/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-6.5
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues

--- a/src/6.5/fr/annotations.xml
+++ b/src/6.5/fr/annotations.xml
@@ -20,7 +20,7 @@
   <note>
     <para>
         Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,7 +799,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
+      est activé, un test "small" va échouer s'il prend plus d'1
       seconde pour s'executer. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/6.5/fr/assertions.xml
+++ b/src/6.5/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>

--- a/src/6.5/fr/code-coverage-analysis.xml
+++ b/src/6.5/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -72,11 +72,11 @@
 
       <varlistentry>
         <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
             seulement quand toutes ses lignes executables sont couvertes.
           </para>
@@ -102,7 +102,7 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
             dès que l'un de ses opcode est executé.
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -130,7 +130,7 @@
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
             si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        de <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -177,12 +177,12 @@
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/6.5/fr/test-doubles.xml
+++ b/src/6.5/fr/test-doubles.xml
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 

--- a/src/6.5/fr/textui.xml
+++ b/src/6.5/fr/textui.xml
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.5/fr/writing-tests-for-phpunit.xml
+++ b/src/6.5/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 


### PR DESCRIPTION
- fixed some spelling errors in French translation (5.7 to 6.5 versions) .
- used a markdown array for "Guide de traduction" in [src/6.1/fr/README.md ](https://github.com/dzc34/phpunit-documentation/blob/8ca2a2a35b3b6fe908736418e14924a303909ef6/src/6.1/fr/README.md#guide-de-traduction) ([diff](https://github.com/sebastianbergmann/phpunit-documentation/pull/491/files#diff-e47d05b923909526e77053883c6adb50R58)) instead of no formated text.

 

ping @gbprod

