### PR TITLE
French translation - Review for 5.7 to 7.0 versions

### DIFF
--- a/src/5.7/fr/README.md
+++ b/src/5.7/fr/README.md
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/5.7/fr/annotations.xml
+++ b/src/5.7/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/5.7/fr/assertions.xml
+++ b/src/5.7/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/5.7/fr/code-coverage-analysis.xml
+++ b/src/5.7/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/5.7/fr/database.xml
+++ b/src/5.7/fr/database.xml
@@ -792,7 +792,7 @@ class CsvGuestbookTest extends PHPUnit_Extensions_Database_TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1107,7 +1107,7 @@ class CompositeTest extends PHPUnit_Extensions_Database_TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1298,7 +1298,7 @@ class GuestbookTest extends PHPUnit_Extensions_Database_TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/5.7/fr/extending-phpunit.xml
+++ b/src/5.7/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/5.7/fr/fixtures.xml
+++ b/src/5.7/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -361,8 +361,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -409,7 +409,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -426,7 +426,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/5.7/fr/incomplete-and-skipped-tests.xml
+++ b/src/5.7/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/5.7/fr/installation.xml
+++ b/src/5.7/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,7 +53,7 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
@@ -65,7 +65,7 @@
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -158,7 +158,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -176,7 +176,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -343,7 +343,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -362,7 +362,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/5.7/fr/logging.xml
+++ b/src/5.7/fr/logging.xml
@@ -224,7 +224,7 @@ not ok 2 - Error: testError(FailureErrorTest)
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/5.7/fr/other-uses-for-tests.xml
+++ b/src/5.7/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/5.7/fr/risky-tests.xml
+++ b/src/5.7/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/5.7/fr/test-doubles.xml
+++ b/src/5.7/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/5.7/fr/textui.xml
+++ b/src/5.7/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -596,7 +596,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/5.7/fr/writing-tests-for-phpunit.xml
+++ b/src/5.7/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/6.0/fr/README.md
+++ b/src/6.0/fr/README.md
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/6.0/fr/annotations.xml
+++ b/src/6.0/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/6.0/fr/assertions.xml
+++ b/src/6.0/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/6.0/fr/code-coverage-analysis.xml
+++ b/src/6.0/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/6.0/fr/database.xml
+++ b/src/6.0/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/6.0/fr/extending-phpunit.xml
+++ b/src/6.0/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/6.0/fr/fixtures.xml
+++ b/src/6.0/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/6.0/fr/incomplete-and-skipped-tests.xml
+++ b/src/6.0/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/6.0/fr/installation.xml
+++ b/src/6.0/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/6.0/fr/logging.xml
+++ b/src/6.0/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/6.0/fr/other-uses-for-tests.xml
+++ b/src/6.0/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/6.0/fr/risky-tests.xml
+++ b/src/6.0/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/6.0/fr/test-doubles.xml
+++ b/src/6.0/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/6.0/fr/textui.xml
+++ b/src/6.0/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.0/fr/writing-tests-for-phpunit.xml
+++ b/src/6.0/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/6.1/fr/README.md
+++ b/src/6.1/fr/README.md
@@ -72,7 +72,7 @@ Sont notamment visés les termes techniques.
 | appendix      | annexe                                                                    |
 | fixture       | fixture (pas trouvé mieux en français)                                    |
 | stub          | bouchon                                                                   |
-| verbe ing     | traduits par l'infinitif dans les titres: testing => tester               |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
 
 ## Historique du projet de traduction
 

--- a/src/6.1/fr/annotations.xml
+++ b/src/6.1/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/6.1/fr/assertions.xml
+++ b/src/6.1/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/6.1/fr/code-coverage-analysis.xml
+++ b/src/6.1/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/6.1/fr/database.xml
+++ b/src/6.1/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/6.1/fr/extending-phpunit.xml
+++ b/src/6.1/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/6.1/fr/fixtures.xml
+++ b/src/6.1/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/6.1/fr/incomplete-and-skipped-tests.xml
+++ b/src/6.1/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/6.1/fr/installation.xml
+++ b/src/6.1/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/6.1/fr/logging.xml
+++ b/src/6.1/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/6.1/fr/other-uses-for-tests.xml
+++ b/src/6.1/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/6.1/fr/risky-tests.xml
+++ b/src/6.1/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/6.1/fr/test-doubles.xml
+++ b/src/6.1/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/6.1/fr/textui.xml
+++ b/src/6.1/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.1/fr/writing-tests-for-phpunit.xml
+++ b/src/6.1/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/6.2/fr/README.md
+++ b/src/6.2/fr/README.md
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/6.2/fr/annotations.xml
+++ b/src/6.2/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/6.2/fr/assertions.xml
+++ b/src/6.2/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/6.2/fr/code-coverage-analysis.xml
+++ b/src/6.2/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/6.2/fr/database.xml
+++ b/src/6.2/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/6.2/fr/extending-phpunit.xml
+++ b/src/6.2/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/6.2/fr/fixtures.xml
+++ b/src/6.2/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/6.2/fr/incomplete-and-skipped-tests.xml
+++ b/src/6.2/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/6.2/fr/installation.xml
+++ b/src/6.2/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/6.2/fr/logging.xml
+++ b/src/6.2/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/6.2/fr/other-uses-for-tests.xml
+++ b/src/6.2/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/6.2/fr/risky-tests.xml
+++ b/src/6.2/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/6.2/fr/test-doubles.xml
+++ b/src/6.2/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/6.2/fr/textui.xml
+++ b/src/6.2/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.2/fr/writing-tests-for-phpunit.xml
+++ b/src/6.2/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/6.3/fr/README.md
+++ b/src/6.3/fr/README.md
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/6.3/fr/annotations.xml
+++ b/src/6.3/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/6.3/fr/assertions.xml
+++ b/src/6.3/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/6.3/fr/code-coverage-analysis.xml
+++ b/src/6.3/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/6.3/fr/database.xml
+++ b/src/6.3/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/6.3/fr/extending-phpunit.xml
+++ b/src/6.3/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/6.3/fr/fixtures.xml
+++ b/src/6.3/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/6.3/fr/incomplete-and-skipped-tests.xml
+++ b/src/6.3/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/6.3/fr/installation.xml
+++ b/src/6.3/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/6.3/fr/logging.xml
+++ b/src/6.3/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/6.3/fr/other-uses-for-tests.xml
+++ b/src/6.3/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/6.3/fr/risky-tests.xml
+++ b/src/6.3/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/6.3/fr/test-doubles.xml
+++ b/src/6.3/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/6.3/fr/textui.xml
+++ b/src/6.3/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.3/fr/writing-tests-for-phpunit.xml
+++ b/src/6.3/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/6.4/fr/README.md
+++ b/src/6.4/fr/README.md
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/6.4/fr/annotations.xml
+++ b/src/6.4/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/6.4/fr/assertions.xml
+++ b/src/6.4/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/6.4/fr/code-coverage-analysis.xml
+++ b/src/6.4/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/6.4/fr/database.xml
+++ b/src/6.4/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/6.4/fr/extending-phpunit.xml
+++ b/src/6.4/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/6.4/fr/fixtures.xml
+++ b/src/6.4/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/6.4/fr/incomplete-and-skipped-tests.xml
+++ b/src/6.4/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/6.4/fr/installation.xml
+++ b/src/6.4/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/6.4/fr/logging.xml
+++ b/src/6.4/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/6.4/fr/other-uses-for-tests.xml
+++ b/src/6.4/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/6.4/fr/risky-tests.xml
+++ b/src/6.4/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/6.4/fr/test-doubles.xml
+++ b/src/6.4/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/6.4/fr/textui.xml
+++ b/src/6.4/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.4/fr/writing-tests-for-phpunit.xml
+++ b/src/6.4/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/6.5/fr/README.md
+++ b/src/6.5/fr/README.md
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/6.5/fr/annotations.xml
+++ b/src/6.5/fr/annotations.xml
@@ -19,7 +19,7 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
         <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -800,7 +800,7 @@ class MyTest extends TestCase
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
       est activé, un test "small" va échouer s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>

--- a/src/6.5/fr/assertions.xml
+++ b/src/6.5/fr/assertions.xml
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/6.5/fr/code-coverage-analysis.xml
+++ b/src/6.5/fr/code-coverage-analysis.xml
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
         <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
             mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -105,7 +105,7 @@
             si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivis lors de l'exécution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -170,7 +170,7 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).

--- a/src/6.5/fr/database.xml
+++ b/src/6.5/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/6.5/fr/extending-phpunit.xml
+++ b/src/6.5/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/6.5/fr/fixtures.xml
+++ b/src/6.5/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/6.5/fr/incomplete-and-skipped-tests.xml
+++ b/src/6.5/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/6.5/fr/installation.xml
+++ b/src/6.5/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/6.5/fr/logging.xml
+++ b/src/6.5/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/6.5/fr/other-uses-for-tests.xml
+++ b/src/6.5/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/6.5/fr/risky-tests.xml
+++ b/src/6.5/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/6.5/fr/test-doubles.xml
+++ b/src/6.5/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/6.5/fr/textui.xml
+++ b/src/6.5/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>

--- a/src/6.5/fr/writing-tests-for-phpunit.xml
+++ b/src/6.5/fr/writing-tests-for-phpunit.xml
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>

--- a/src/7.0/fr/README.md
+++ b/src/7.0/fr/README.md
@@ -12,7 +12,7 @@ Pour compiler la documentation en français :
     cd build
     ant build-fr-6.5
 
-Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
+Attention, la documentation est en cours de traduction (cf. tableau ci-dessous)
 
 
 ## Contributions attendues
@@ -55,20 +55,24 @@ Attention, la documentation est en cours de traduction (cf. tableau ci dessous)
 Dans ce fichier sont recensées les règles de traductions utilisées de manière à garantir la cohérence d'ensemble.
 Sont notamment visés les termes techniques.
 
-actual:			constatée (valeur)
-array:			traduit par tableau sauf quand on fait explicitement référence à PHP
-assertion:		traduit par asssertion, plus parlant que affirmation
-composable:		composable (rien trouvé de mieux)
-expected:		attendue (valeur)
-framework:		framework
-isolated:		indépendant (isolé est ambigu, étanche un peu moins...)
-notice:			remarque
-return:			retourne plutôt que renvoie
-requirements:	pré-requis
-extension:		extensions
-code coverage:	couverture de code
-appendix:       annexe
-fixture:        fixture (pas trouvé mieux en français)
-stub:           bouchon
 
-verbe ing: 	traduits par l'infinitif dans les titres: testing => tester
+| Anglais       | Français                                                                  |
+| :------------ | :------------------------------------------------------------------------ |
+| actual        | constatée (valeur)                                                        |
+| array         | traduit par tableau sauf quand on fait explicitement référence à PHP      |
+| assertion     | traduit par asssertion, plus parlant que affirmation                      |
+| composable    | composable (rien trouvé de mieux)                                         |
+| expected      | attendue (valeur)                                                         |
+| framework     | framework                                                                 |
+| isolated      | indépendant (isolé est ambigu, étanche un peu moins...)                   |
+| notice        | remarque                                                                  |
+| return        | retourne plutôt que renvoie                                               |
+| requirements  | pré-requis                                                                |
+| extension     | extensions                                                                |
+| code coverage | couverture de code                                                        |
+| appendix      | annexe                                                                    |
+| fixture       | fixture (pas trouvé mieux en français)                                    |
+| stub          | bouchon                                                                   |
+| verbe ing     | traduits par l'infinitif dans les titres : testing => tester              |
+
+

--- a/src/7.0/fr/annotations.xml
+++ b/src/7.0/fr/annotations.xml
@@ -19,8 +19,8 @@
 
   <note>
     <para>
-        Un "doc comment" en PHP doit commencé par <literal>/**</literal> et se terminer avec
-        <literal>*/</literal>. Les annotations se trouvant des des commentaires d'un autre style
+        Un "doc comment" en PHP doit commencer par <literal>/**</literal> et se terminer avec
+        <literal>*/</literal>. Les annotations se trouvant dans des commentaires d'un autre style
         seront ignorées.
     </para>
   </note>
@@ -47,7 +47,7 @@
 
     <para>
 
-      L'annotation <literal>@after</literal> peut être utilisé pour spécifier des méthodes
+      L'annotation <literal>@after</literal> peut être utilisée pour spécifier des méthodes
       devant être appelées après chaque méthode de test dans une classe de cas de tests.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -77,7 +77,7 @@ class MyTest extends TestCase
 
     <para>
 
-      L'annotation <literal>@afterClass</literal> peut-être utilisées pour spécifier
+      L'annotation <literal>@afterClass</literal> peut être utilisée pour spécifier
       des méthodes statiques devant être appelées après chaque méthode de test
       dans une classe de test pour être exécuté afin de nettoyer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -125,7 +125,7 @@ class MyTest extends TestCase
       <indexterm><primary><literal>@backupGlobals</literal></primary></indexterm>
 
       L'annotation <literal>@backupGlobals</literal> peut également être
-      utilisée au niveau d'une méthode. Cela permet une configuration fine des
+      utilisée au niveau d'une méthode. Cela permet une configuration fine
       des opérations de sauvegarde et de restauration : <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -152,7 +152,7 @@ class MyTest extends TestCase
 
       L'annotation <literal>@backupStaticAttributes</literal> peut être utilisée pour
       enregistrer tous les attributs statiques dans toutes les classes déclarées
-      avant chaque test et les restaurer après. Elle peut être utilisé au niveau de la classe ou
+      avant chaque test et les restaurer après. Elle peut être utilisée au niveau de la classe ou
       au niveau de la méthode :
 
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -222,7 +222,7 @@ class MyTest extends TestCase
     <para>
 
       L'annotation <literal>@beforeClass</literal> peut être utilisée pour spécifier
-      des méthodes statiques qui doivent être appellées avant chaque méthodes de test dans une classe
+      des méthodes statiques qui doivent être appelées avant chaque méthode de test dans une classe
       de test qui sont exécutés pour paramétrer des fixtures partagées.
       <programlisting>use PHPUnit\Framework\TestCase;
 
@@ -435,7 +435,7 @@ class CoversDefaultClassTest extends TestCase
 
       PHPUnit gère la déclaration des dépendances explicites entre les méthodes
       de test. De telles dépendances ne définissent pas l'ordre dans lequel les
-      méthodes de test doivent être exécutées mais elles permettent de retourner
+      méthodes de test doivent être exécutées, mais elles permettent de retourner
       l'instance d'une fixture de test par un producteur et de la passer aux consommateurs dépendants.
       <xref linkend="writing-tests-for-phpunit.examples.StackTest2.php"/> montre
       comment utiliser l'annotation <literal>@depends</literal> pour exprimer des
@@ -472,7 +472,7 @@ class CoversDefaultClassTest extends TestCase
       <indexterm><primary>@expectedExceptionCode</primary></indexterm>
 
       L'annotation <literal>@expectedExceptionCode</literal>, en conjonction avec
-      <literal>@expectedException</literal> permet de faire des assertions sur le
+      <literal>@expectedException</literal>, permet de faire des assertions sur le
       code d'erreur d'une exception levée ce qui permet de cibler une exception
       particulière.
 
@@ -690,7 +690,7 @@ class MyTest extends TestCase
       tenter de conserver l'état global du processus parent en
       sérialisant toutes les globales dans le processus parent et en les désérialisant
       dans le processus enfant. Cela peut poser des problèmes si le processus parent
-      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empécher
+      contient des globales qui ne sont pas sérialisable. Pour corriger cela, vous pouvez empêcher
       PHPUnit de conserver l'état global avec
       l'annotation <literal>@preserveGlobalState</literal>.
       <programlisting>use PHPUnit\Framework\TestCase;
@@ -732,7 +732,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runTestsInSeparateProcesses</primary></indexterm>
 
-      Indique que tous les tests d'une classe de tests doivent être executés dans
+      Indique que tous les tests d'une classe de tests doivent être exécutés dans
       un processus PHP séparé. <programlisting>use PHPUnit\Framework\TestCase;
 
 /**
@@ -759,7 +759,7 @@ class MyTest extends TestCase
     <para>
       <indexterm><primary>@runInSeparateProcess</primary></indexterm>
 
-      Indique qu'un test doit être executé dans un processus PHP séparé.
+      Indique qu'un test doit être exécuté dans un processus PHP séparé.
       <programlisting>use PHPUnit\Framework\TestCase;
 
 class MyTest extends TestCase
@@ -799,8 +799,8 @@ class MyTest extends TestCase
       <indexterm><primary><literal>timeoutForSmallTests</literal></primary></indexterm>
 
       Si le paquet <literal>PHP_Invoker</literal> est installé et que le mode strict
-      est activé, un test "small" va échoué s'il prend plus d'1
-      seconde pour s'executer. Ce délai est configurable via
+      est activé, un test "small" va échouer s'il prend plus d'1
+      seconde pour s'exécuter. Ce délai est configurable via
       l'attrubut <literal>timeoutForSmallTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -808,7 +808,7 @@ class MyTest extends TestCase
     <note>
       <para>
         Les tests doivent être explicitement annotés par soit <literal>@small</literal>,
-        <literal>@medium</literal>, ou <literal>@large</literal> pour activer les temps limites d'execution.
+        <literal>@medium</literal> ou <literal>@large</literal> pour activer les temps limites d'exécution.
       </para>
     </note>
   </section>
@@ -859,8 +859,8 @@ public function initialBalanceShouldBe0()
     <para>
       <indexterm><primary>@uses</primary></indexterm>
 
-      L'annotation <literal>@uses</literal> spécifies du code qui sera exécuté
-      par un test, mais qui n'et pas destiné à être couvert par le test. Un bon
+      L'annotation <literal>@uses</literal> spécifie du code qui sera exécuté
+      par un test, mais qui n'est pas destiné à être couvert par le test. Un bon
       exemple est un objet-valeur qui est nécessaire pour tester une partie du code.
       <programlisting>/**
  * @covers BankAccount::deposit
@@ -876,7 +876,7 @@ public function testMoneyCanBeDepositedInAccount()
       Cette annotation est spéciali
       This annotation is notamment utile en mode de couverture stricte où
       du code involontairement couvert va faire échouer un test. Voir
-      <xref linkend="risky-tests.unintentionally-covered-code"/> fpour plus
+      <xref linkend="risky-tests.unintentionally-covered-code"/> pour plus
       d'informations sur le mode de couverture stricte.
     </para>
   </section>

--- a/src/7.0/fr/assertions.xml
+++ b/src/7.0/fr/assertions.xml
@@ -31,7 +31,7 @@
     <para>
       Une question fréquente, surtout de la part des développeurs qui ne connaissent pas PHPUnit, est si
       utiliser <code>$this->assertTrue()</code> ou <code>self::assertTrue()</code>,
-      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est: il
+      par exemple, est "la bonne façon" d'appeler une assertion. La réponse courte est : il
       n'y a pas de bonne façon. Et il n'y a pas de mauvaise façon non plus. C'est une
       question de préférence personnelle.
     </para>
@@ -824,7 +824,7 @@ Tests: 2, Assertions: 2, Failures: 1.</screen>
     </example>
 
     <para><literal>assertEquals(DOMDocument $expected, DOMDocument $actual[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme cannonique sans commentaires des documents XML représentéspar les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si la forme canonique sans commentaires des documents XML représentés par les deux objets DOMDocument <literal>$expected</literal> et <literal>$actual</literal> ne sont pas égaux.</para>
     <example id="appendixes.assertions.assertEquals.example3">
       <title>Utilisation de assertEquals() avec des objets DOMDocument</title>
       <programlisting><![CDATA[<?php
@@ -1133,7 +1133,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <indexterm><primary>assertFileIsWritable()</primary></indexterm>
     <indexterm><primary>assertFileNotIsWritable()</primary></indexterm>
     <para><literal>assertFileIsWritable(string $filename[, string $message = ''])</literal></para>
-    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en éciture.</para>
+    <para>Signale une erreur identifiée par <literal>$message</literal> si le fichier spécifié par <literal>$filename</literal> n'est pas un fichier ou n'est pas accessible en écriture.</para>
     <para><literal>assertFileNotIsWritable()</literal> est l'inverse de cette assertion et prend les mêmes arguments.</para>
     <example id="appendixes.assertions.assertFileIsWritable.example">
       <title>Utilisation de assertFileIsWritable()</title>
@@ -1855,13 +1855,13 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <itemizedlist>
       <listitem><para><literal>%e</literal>: Représente un séparateur de répertoire, par exemple <literal>/</literal> sur Linux. </para></listitem>
       <listitem><para><literal>%s</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%S</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%A</literal>: Zéro ou pusieurs de n'importe quoi (caractère ou espace) incluant le caratère de fin de ligne.</para></listitem>
-      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caratères espace.</para></listitem>
-      <listitem><para><literal>%i</literal>: Une valeure entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
-      <listitem><para><literal>%d</literal>: Une valeure entière non signée, par exemple <literal>123456</literal>.</para></listitem>
-      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadecimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
+      <listitem><para><literal>%S</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) sauf le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%a</literal>: Un ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%A</literal>: Zéro ou plusieurs de n'importe quoi (caractère ou espace) incluant le caractère de fin de ligne.</para></listitem>
+      <listitem><para><literal>%w</literal>: Zéro ou plusieurs caractères espace.</para></listitem>
+      <listitem><para><literal>%i</literal>: Une valeur entière signée, par exemple <literal>+3142</literal>, <literal>-3142</literal>.</para></listitem>
+      <listitem><para><literal>%d</literal>: Une valeur entière non signée, par exemple <literal>123456</literal>.</para></listitem>
+      <listitem><para><literal>%x</literal>: Un ou plusieurs caractères hexadécimaux. Ce sont les caractères compris entre <literal>0-9</literal>, <literal>a-f</literal>, <literal>A-F</literal>.</para></listitem>
       <listitem><para><literal>%f</literal>: Un nombre à virgule flottante, par exemple: <literal>3.142</literal>, <literal>-3.142</literal>, <literal>3.142E-10</literal>, <literal>3.142e+10</literal>.</para></listitem>
       <listitem><para><literal>%c</literal>: Un caractère unique quel qu'il soit.</para></listitem>
     </itemizedlist>
@@ -2113,7 +2113,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
     <para>
       Des assertions plus complexes peuvent être formulées en utilisant les
       classes <literal>PHPUnit_Framework_Constraint</literal>. Elles peuvent être
-      evaluées avec la méthode <literal>assertThat()</literal>.
+      évaluées avec la méthode <literal>assertThat()</literal>.
       <xref linkend="appendixes.assertions.assertThat.example" /> montre comment les contraintes
       <literal>logicalNot()</literal> et <literal>equalTo()</literal>
       peuvent être utilisées pour exprimer la même assertion que
@@ -2174,7 +2174,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>arrayHasKey()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_ArrayHasKey arrayHasKey(mixed $key)</literal></entry>
-            <entry>Ccontrainte qui valide que le tableau évalué a une clé donnée.</entry>
+            <entry>Contrainte qui valide que le tableau évalué a une clé donnée.</entry>
           </row>
           <row>
             <indexterm><primary>contains()</primary></indexterm>
@@ -2189,7 +2189,7 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>containsOnlyInstancesOf()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_TraversableContainsOnly containsOnlyInstancesOf(string $classname)</literal></entry>
-            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instance d'une classe donnée.</entry>
+            <entry>Contrainte qui valide que le <literal>tableau</literal> ou l'objet qui implémente l'interface <literal>Iterator</literal> évalué ne contient que des instances d'une classe donnée.</entry>
           </row>
           <row>
             <indexterm><primary>equalTo()</primary></indexterm>
@@ -2209,17 +2209,17 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>fileExists()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_FileExists fileExists()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué existe.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué existe.</entry>
           </row>
           <row>
             <indexterm><primary>isReadable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsReadable isReadable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>isWritable()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_IsWritable isWritable()</literal></entry>
-            <entry>Contrainte qui vérifie si le fichier(name) évalué est accessible en écriture.</entry>
+            <entry>Contrainte qui vérifie si le fichier (name) évalué est accessible en écriture.</entry>
           </row>
           <row>
             <indexterm><primary>greaterThan()</primary></indexterm>
@@ -2319,12 +2319,12 @@ class BiscuitTest extends TestCase
           <row>
             <indexterm><primary>stringEndsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringEndsWith stringEndsWith(string $suffix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée termine par un suffix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée termine par un suffixe donné.</entry>
           </row>
           <row>
             <indexterm><primary>stringStartsWith()</primary></indexterm>
             <entry><literal>PHPUnit_Framework_Constraint_StringStartsWith stringStartsWith(string $prefix)</literal></entry>
-            <entry>Contrainte qui valide que la chaine évaluée commence par un préfix donné.</entry>
+            <entry>Contrainte qui valide que la chaine évaluée commence par un préfixe donné.</entry>
           </row>
         </tbody>
       </tgroup>

--- a/src/7.0/fr/code-coverage-analysis.xml
+++ b/src/7.0/fr/code-coverage-analysis.xml
@@ -39,8 +39,8 @@
   <para>
     PHPUnit peut générer un rapport de couverture de code HTML aussi bien que
     des fichiers de log en XML avec les informations de couverture de code dans différents formats
-    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapporté
-    en text (et affiché vers STDOUT) et exporté en PHP pour un traitement
+    (Clover, Crap4J, PHPUnit). Les informations de couverture de code peuvent aussi être rapportées
+    en text (et affichées vers STDOUT) et exportées en PHP pour un traitement
     ultérieur.
   </para>
 
@@ -55,7 +55,7 @@
     <title>Indicateurs logiciels pour la couverture de code</title>
 
     <para>
-      Différents indicateurs logiciels existent pour mesurer la couverture de code:
+      Différents indicateurs logiciels existent pour mesurer la couverture de code :
     </para>
 
     <variablelist>
@@ -71,14 +71,14 @@
       </varlistentry>
 
       <varlistentry>
-        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction de méthode</secondary></indexterm>
-        <term><emphasis>Couverture de fonction de méthode</emphasis></term>
+        <indexterm><primary>Couverture de code</primary><secondary>Couverture de fonction et de méthode</secondary></indexterm>
+        <term><emphasis>Couverture de fonction et de méthode</emphasis></term>
         <listitem>
           <para>
-            L'indicateur logiciel de <emphasis>couverture de fonction de méthode</emphasis>
-            mesure si chaque fonction ou méthode à été invoquée.
+            L'indicateur logiciel de <emphasis>couverture de fonction et de méthode</emphasis>
+            mesure si chaque fonction ou méthode a été invoquée.
             PHP_CodeCoverage considère qu'une fonction ou une méthode a été couverte
-            seulement quand toutes ses lignes executables sont couvertes.
+            seulement quand toutes ses lignes exécutables sont couvertes.
           </para>
         </listitem>
       </varlistentry>
@@ -102,10 +102,10 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture d'opcode</emphasis> mesure
-            si chaque opcode d'une fonction ou d'une méthode a été executé lors de l'execution
+            si chaque opcode d'une fonction ou d'une méthode a été exécuté lors de l'exécution
             de la suite de test. Une ligne de code se compile habituellement en plus
             d'un opcode. La couverture de ligne considère une ligne de code comme couverte
-            dès que l'un de ses opcode est executé.
+            dès que l'un de ses opcode est exécuté.
           </para>
         </listitem>
       </varlistentry>
@@ -116,8 +116,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de branche</emphasis> mesure
-            si l'expression booléenne de chaque structure de contrôle a été évalué
-            à <literal>true</literal> et à <literal>false</literal> pendant l'execution
+            si l'expression booléenne de chaque structure de contrôle a été évaluée
+            à <literal>true</literal> et à <literal>false</literal> pendant l'exécution
             de la suite de test.
           </para>
         </listitem>
@@ -129,8 +129,8 @@
         <listitem>
           <para>
             L'indicateur logiciel de <emphasis>couverture de chemin</emphasis> mesure
-            si chacun des chemins d'execution possible dans une fonction ou une méthode
-            ont été suivit lors de l'execution de la suite de test. Un chemin d'execution est
+            si chacun des chemins d'exécution possible dans une fonction ou une méthode
+            ont été suivis lors de l'exécution de la suite de test. Un chemin d'exécution est
             une séquence unique de branches depuis l'entrée de la fonction ou
             de la méthode jusqu'à sa sortie.
           </para>
@@ -145,7 +145,7 @@
             L'index <emphasis>Change Risk Anti-Patterns (CRAP)</emphasis> est
             calculé en se basant sur la complexité cyclomatique et la couverture de code
             d'une portion de code. Du code qui n'est pas trop complexe et qui a une couverture
-            de code adéquate aurat un index CRAP faible. L'index CRAP peut être baissé
+            de code adéquate aura un index CRAP faible. L'index CRAP peut être baissé
             en écrivant des tests et en refactorisant le code pour diminuer sa
             complexité.
           </para>
@@ -155,8 +155,8 @@
 
     <note>
       <para>
-        L'indicateur logiciel de <emphasis>Couverture d'Opcode</emphasis>,
-        <emphasis>Couverture de branche</emphasis>, et de
+        Les indicateurs logiciel de <emphasis>Couverture d'Opcode</emphasis>,
+        <emphasis>Couverture de branche</emphasis> et de
         <emphasis>Couverture de chemin</emphasis> ne sont pas encore
         supportés par PHP_CodeCoverage.
       </para>
@@ -170,19 +170,19 @@
       <indexterm><primary>Couverture de code</primary><secondary>Liste blanche</secondary></indexterm>
 
       Il est requis de configurer une <emphasis>liste blanche</emphasis> pour dire à
-      PHPUnit quels fichiers de code source inclure dans le raport de couverture de code.
+      PHPUnit quels fichiers de code source inclure dans le rapport de couverture de code.
       Cela peut être fait en utilisant l'option de ligne de commande <literal>--whitelist</literal>
       ou via le fichier de configuration (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>).
     </para>
 
     <para>
-      Optionnellement, tous les fichiers en liste blanche peut être ajouté au rapport
+      Optionnellement, tous les fichiers en liste blanche peuvent être ajoutés au rapport
       de couverture de code en paramétrant <literal>addUncoveredFilesFromWhitelist="true"</literal>
       dans votre fichier de configuration PHPUnit (voir <xref
       linkend="appendixes.configuration.whitelisting-files"/>). Cela autorise
-      l'inclusion de fichiers quine sont pas encore testé du tout. Si vous voulez avoir des
-      information sur quelles lignes d'un fichier non couvert sont exécutable,
+      l'inclusion de fichiers qui ne sont pas encore testés du tout. Si vous voulez avoir des
+      information sur quelles lignes d'un fichier non couvert sont exécutables,
       par exemple, vous devez également définir
       <literal>processUncoveredFilesFromWhitelist="true"</literal> dans votre
       fichier de configuration PHPUnit (voir <xref

--- a/src/7.0/fr/database.xml
+++ b/src/7.0/fr/database.xml
@@ -835,7 +835,7 @@ class CsvGuestbookTest extends TestCase
       <section id="database.array-dataset">
         <title>DataSet tableau</title>
         <para>
-          Il n'existe pas (encore) de DataSet basé sur les tableau dans
+          Il n'existe pas (encore) de DataSet basé sur les tableaux dans
           l'extension base de données de PHPUnit, mais vous pouvez implémenter
           facilement la vôtre. Notre exemple du Livre d'or devrait ressembler à :
         </para>
@@ -1175,7 +1175,7 @@ class CompositeTest extends TestCase
       </para>
     </section>
     <section id="database.implementing-your-own-datasetsdatatables">
-      <title>Implementer vos propres DataSets/DataTables</title>
+      <title>Implémenter vos propres DataSets/DataTables</title>
       <para>
         Pour comprendre le fonctionnement interne des DataSets et des DataTables
         jetons un oeil sur l'interface d'un DataSet. Vous pouvez sauter cette partie
@@ -1386,7 +1386,7 @@ class GuestbookTest extends TestCase
     <section id="database.asserting-the-state-of-a-table">
       <title>Faire une assertion sur l'état d'une table</title>
       <para>
-        L'assertion précédent est utile, mais nous voudrons certainement tester
+        L'assertion précédente est utile, mais nous voudrons certainement tester
         le contenu présent de la table pour vérifier que toutes les valeurs ont
         été écrites dans les bonnes colonnes. Ceci peut être réalisé avec une assertion
         de table.

--- a/src/7.0/fr/extending-phpunit.xml
+++ b/src/7.0/fr/extending-phpunit.xml
@@ -17,7 +17,7 @@
 
       Ecrivez des assertions personnalisées et des méthodes utilitaires dans une sous classe abstraite de
       <literal>PHPUnit\Framework\TestCase</literal> et faites hériter vos classes
-      de cas de test de cette classe. C'est une des façon les plus faciles pour
+      de cas de test de cette classe. C'est une des façons les plus faciles pour
       étendre PHPUnit.
     </para>
   </section>

--- a/src/7.0/fr/fixtures.xml
+++ b/src/7.0/fr/fixtures.xml
@@ -19,7 +19,7 @@
     qu'un simple tableau, et le volume de code nécessaire pour la mettre en place
     croîtra dans les mêmes proportions. Le contenu effectif du test sera perdu
     dans le bruit de configuration de la fixture. Ce problème s'aggrave quand
-    vous écrivez plusieurs tests doté de fixtures similaires. Sans l'aide du
+    vous écrivez plusieurs tests dotés de fixtures similaires. Sans l'aide du
     framework de test, nous aurions à dupliquer le code qui configure la fixture
     pour chaque test que nous écrivons.
   </para>
@@ -231,7 +231,7 @@ Tests: 2, Assertions: 2, Failures: 1.]]></screen>
     <title>Variantes</title>
 
     <para>
-      Que se passe-t'il si vous avez deux tests avec deux setups légèrement
+      Que se passe-t-il si vous avez deux tests avec deux setups légèrement
       différents ? Il y a deux possibilités :
     </para>
 
@@ -364,7 +364,7 @@ class DatabaseTest extends TestCase
     <para>
       En utilisant l'option <literal>--static-backup</literal> ou le paramètre
       <literal>backupStaticAttributes="true"</literal> dans le
-      fichier XML de configuration, cet isolation peut être étendue aux attributs statiques
+      fichier XML de configuration, cette isolation peut être étendue aux attributs statiques
       des classes.
     </para>
 
@@ -376,8 +376,8 @@ class DatabaseTest extends TestCase
       </para>
       <para>
         Les objets de certaines classes (tel que <literal>PDO</literal> par exemple), ne peuvent
-        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera e
-        nregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
+        pas être sérialisés si bien que l'opération de sauvegarde va échouer quand un tel objet sera
+        enregistré dans le tableau <literal>$GLOBALS</literal>, par exemple.
       </para>
     </note>
 
@@ -424,7 +424,7 @@ class DatabaseTest extends TestCase
     <note>
       <para>
         L'opération <literal>@backupStaticAttributes</literal> est exécutée
-        avant une méthode de test, mais seulment si c'est activé. Si une valeur statique a été changée
+        avant une méthode de test, mais seulement si c'est activé. Si une valeur statique a été changée
         par un test exécuté précédement qui n'as activé
         <literal>@backupStaticAttributes</literal>, alors cette valeur sera
         sauvegardée et restaurée — pas la valeur par défaut originale.
@@ -441,7 +441,7 @@ class DatabaseTest extends TestCase
         Pour un test unitaire, il est recommandé de plutôt réinitialiser explicitement
         les valeurs des propriétés statiques testées dans le code de <literal>setUp()</literal>
         (et idéalement aussi <literal>tearDown()</literal>, de manière à ne pas affecter
-        les prochains tests executés).
+        les prochains tests exécutés).
       </para>
     </note>
 

--- a/src/7.0/fr/incomplete-and-skipped-tests.xml
+++ b/src/7.0/fr/incomplete-and-skipped-tests.xml
@@ -289,7 +289,7 @@ class DatabaseTest extends TestCase
     </example>
 
  	  <para>
-		  Si vous utilisez une syntaxe qui ne compile pas avec une version données de PHP, regardez
+		  Si vous utilisez une syntaxe qui ne compile pas avec une version donnée de PHP, regardez
       dans la configuration xml pour les inclusions dépendant de la version dans <xref linkend="appendixes.configuration.testsuites" />
     </para>
   </section>

--- a/src/7.0/fr/installation.xml
+++ b/src/7.0/fr/installation.xml
@@ -45,7 +45,7 @@
     <title>PHP Archive (PHAR)</title>
 
     <para>
-      La manière la plus simple d'obtenir PHPUnit est de télécharger<ulink
+      La manière la plus simple d'obtenir PHPUnit est de télécharger <ulink
       url="http://php.net/phar">l'Archive PHP (PHAR)</ulink> qui contient toutes les
       dépendances requises (ainsi que certaines optionnelles) de PHPUnit archivées en un seul
       fichier.
@@ -53,12 +53,12 @@
 
     <para>
       L'extension <ulink url="http://php.net/manual/en/phar.installation.php">phar</ulink>
-      est requise pour utilisé les archives PHP (PHAR).
+      est requise pour utiliser les archives PHP (PHAR).
     </para>
 
     <para>
       Si l'extension <ulink url="http://suhosin.org/">Suhosin</ulink> est
-      activé, vous devez autoriser l'exécution des PHAR dans votre
+      activée, vous devez autoriser l'exécution des PHAR dans votre
       <literal>php.ini</literal>:
 
       <screen>
@@ -151,7 +151,7 @@ suhosin.executor.include.whitelist = phar
         Pour les environments shell Cygwin et/ou MingW32 (ex: TortoiseGit), vous
         passer l'étape 5. ci-dessus, il suffit de sauvegarder le fichier
         <filename>phpunit</filename> (sans l'extension <filename>.phar</filename>),
-        et de le rendre executable via
+        et de le rendre exécutable via
         <userinput>chmod 775 phpunit</userinput>.
       </para>
 
@@ -169,7 +169,7 @@ suhosin.executor.include.whitelist = phar
 
       <para>
         L'exemple suivant détaille le fonctionnement de la vérification de version. Nous commençons
-        par tlécharger <filename>phpunit.phar</filename> ainsi que sa
+        par télécharger <filename>phpunit.phar</filename> ainsi que sa
         signature PGP détachée <filename>phpunit.phar.asc</filename>:
       </para>
 
@@ -336,7 +336,7 @@ fi
 
           <para>
             Ce package est inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivate:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/php-invoker</userinput></screen>
@@ -355,7 +355,7 @@ fi
 
           <para>
             Ce package n'est pas inclus dans la distribution PHAR de PHPUnit. Il peut
-            être installée via Composer en utilisant la commande suivante:
+            être installé via Composer en utilisant la commande suivante :
           </para>
 
           <screen><userinput>composer require --dev phpunit/dbunit</userinput></screen>

--- a/src/7.0/fr/logging.xml
+++ b/src/7.0/fr/logging.xml
@@ -155,7 +155,7 @@ Exception:
       Ceci peut uniquement être modifié via l'option de configuration xml <literal>showUncoveredFiles</literal>
       Voir <xref linkend="appendixes.configuration.logging"/>.
 
-      Par défaut, tous les fichier et leur status de couverture sont affichés dans le rapport détaillé.
+      Par défaut, tous les fichiers et leur status de couverture sont affichés dans le rapport détaillé.
       Ceci peut être changé via l'option de configuration xml
       <literal>showOnlySummary</literal>.
     </para>

--- a/src/7.0/fr/other-uses-for-tests.xml
+++ b/src/7.0/fr/other-uses-for-tests.xml
@@ -37,7 +37,7 @@
       ne diffèrent que par un suffixe constitué de un ou plusieurs chiffres, telles que
       <literal>testBalanceCannotBecomeNegative()</literal> et
       <literal>testBalanceCannotBecomeNegative2()</literal>, la phrase
-      "Balance ne peut pas etre négative" n'apparaîtra qu'une seule fois, en supposant que
+      "Balance ne peut pas être négative" n'apparaîtra qu'une seule fois, en supposant que
       tous ces tests ont réussi.
     </para>
 
@@ -81,7 +81,7 @@ BankAccount
     <para>
       Quand vous documentez des hypothèses avec des tests, vous êtes
       propriétaire des tests. Le fournisseur du paquet -- sur lequel vous
-      faîtes des hypothèses -- ne connaît rien de vos tests. Si vous voulez
+      faites des hypothèses -- ne connaît rien de vos tests. Si vous voulez
       avoir une relation plus étroite avec le fournisseur du paquet, vous
       pouvez utiliser les tests pour communiquer et coordonner vos activités.
     </para>

--- a/src/7.0/fr/risky-tests.xml
+++ b/src/7.0/fr/risky-tests.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Un test qui est annoté avec <code>@covers</code> et execute du code qui
+      Un test qui est annoté avec <code>@covers</code> et exécute du code qui
       n'est pas listé avec les annotations <code>@covers</code> ou <code>@uses</code>
       sera marqué comme risqué quand cette vérification est activée.
     </para>
@@ -56,14 +56,14 @@
     </para>
 
     <para>
-      Un test qui émet une sortie écran, par exemple en appelant <code>print</code> dans
+      Un test qui émet une sortie écran, par exemple en appelant <code>print</code>
       dans le code du test ou dans le code testé, sera marqué comme risqué quand
       cette vérification est activée.
     </para>
   </section>
 
   <section id="risky-tests.test-execution-timeout">
-    <title>Délai d'execution des tests</title>
+    <title>Délai d'exécution des tests</title>
 
     <para>
       Une limite de temps peut être appliquée pour l'exécution d'un test si le
@@ -77,14 +77,14 @@
 
     <para>
       Un test annoté avec <literal>@large</literal> échouera s'il prend
-      plus de 60 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 60 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForLargeTests</literal> dans le fichier
       de configuration XML.
     </para>
 
     <para>
       Un test annoté avec <literal>@medium</literal> échouera s'il prend
-      plus de 10 secondes à s'executer. Ce délai d'execution est configurable via l'attribut
+      plus de 10 secondes à s'exécuter. Ce délai d'exécution est configurable via l'attribut
       <literal>timeoutForMediumTests</literal> dans le fichier
       de configuration XML.
     </para>
@@ -93,7 +93,7 @@
       Un test qui n'est pas annoté avec <literal>@medium</literal> ou
       <literal>@large</literal> sera traité comme s'il était annoté avec
       <literal>@small</literal>. Un test "small" échouera s'il prend
-      plus de 1 seconde à s'executer. Ce délai d'execution est configurable via
+      plus de 1 seconde à s'exécuter. Ce délai d'exécution est configurable via
       l'attribut <literal>timeoutForMediumTests</literal> dans le fichier de
       configuration XML.
     </para>

--- a/src/7.0/fr/test-doubles.xml
+++ b/src/7.0/fr/test-doubles.xml
@@ -45,10 +45,10 @@
   <para>
     La méthode <literal>createMock($type)</literal> retourne immédiatement une doublure de
     test pour le type spécifié (interface ou classe). La création de cette doublure est
-    effectuée en suivant par défaut les bonne pratiques (les méthodes <literal>__construct()
-    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas executées
+    effectuée en suivant par défaut les bonnes pratiques (les méthodes <literal>__construct()
+    </literal> et <literal>__clone()</literal> de la classe originale ne sont pas exécutées
     et les arguments passés à une méthode de la doublure de tests ne sont pas clonés. Si ce
-    comportement par défaut ne correspondent pas à ce don vous avez besoin vous pouvez
+    comportement par défaut ne correspond pas à ce dont vous avez besoin vous pouvez
     alors utiliser la méthode <literal>getMockBuilder($type)</literal> pour personnaliser la
     génération de doublure de test en utilisant un interface souple (fluent interface).
   </para>
@@ -148,7 +148,7 @@ class StubTest extends TestCase
       <title>Limitation: Méthodes nommées "method"</title>
 
       <para>
-        L'exemple ci dessus ne fonctionne que si la classe originale ne déclare
+        L'exemple ci-dessus ne fonctionne que si la classe originale ne déclare
         pas de méthode appelé "method".
       </para>
 
@@ -174,7 +174,7 @@ class StubTest extends TestCase
       <indexterm><primary>createMock()</primary></indexterm>
       <indexterm><primary>method()</primary></indexterm>
       <indexterm><primary>willReturn()</primary></indexterm>
-      <title>L'API de construction des mocks peut-être utilisée pour configurer la doublure de test générée.</title>
+      <title>L'API de construction des mocks peut être utilisée pour configurer la doublure de test générée.</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -767,7 +767,7 @@ class FooTest extends TestCase
     </example>
 
     <example id="test-doubles.mock-objects.examples.enable-clone-object-parameters.php">
-      <title>Créer un OBJET mock avec les paramètres de clonnage activés</title>
+      <title>Créer un OBJET mock avec les paramètres de clonage activés</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -856,8 +856,8 @@ class FooTest extends TestCase
     </para>
 
     <itemizedlist>
-      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
-      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appeler pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
+      <listitem><para><literal>setMethods(array $methods)</literal> peut être appelé sur l'objet Mock Builder pour spécifier les méthodes qui doivent être remplacées par une doublure de test configurable. Le comportement des autres méthodes n'est pas changé. Si vous appelez <literal>setMethods(null)</literal>, alors aucune méthode ne sera remplacé.</para></listitem>
+      <listitem><para><literal>setConstructorArgs(array $args)</literal> peut être appelé pour fournir un tableau de paramètres qui est passé au constructeur de la classe originale (qui n'est pas remplacé par une implémentation factice par défaut).</para></listitem>
       <listitem><para><literal>setMockClassName($name)</literal> peut être utilisé pour spécifier un nom de classe pour la classe de la doublure de test générée.</para></listitem>
       <listitem><para><literal>disableOriginalConstructor()</literal> peut être utilisé pour désactiver l'appel au constructeur de la classe originale.</para></listitem>
       <listitem><para><literal>disableOriginalClone()</literal> peut être utilisé pour désactiver l'appel au constructeur de clonage de la classe originale.</para></listitem>
@@ -917,8 +917,8 @@ class SubjectTest extends TestCase
     </example>
 
     <para>
-      Reportez-vous a la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
-      de Prophecy pour  pour plus de détails sur la création, la configuration et l'utilisation de
+      Reportez-vous à la <ulink url="https://github.com/phpspec/prophecy#how-to-use-it">documentation</ulink>
+      de Prophecy pour plus de détails sur la création, la configuration et l'utilisation de
       stubs, espions, et mocks en utilisant ce framework alternatif de doublure de test.
     </para>
   </section>
@@ -975,7 +975,7 @@ class TraitClassTest extends TestCase
     </para>
 
     <example id="test-doubles.mock-objects.examples.AbstractClassTest.php">
-      <title>Tester les méthodes concrêtes d'une classe abstraite</title>
+      <title>Tester les méthodes concrètes d'une classe abstraite</title>
       <programlisting><![CDATA[<?php
 use PHPUnit\Framework\TestCase;
 
@@ -1113,7 +1113,7 @@ class GoogleTest extends TestCase
       fichier <literal>composer.json</literal> de votre projet si vous utilisez
       <ulink url="https://getcomposer.org/">Composer</ulink> pour gérer les
       dépendances de votre project. Vous trouverez ci-dessous un exemple minimal de fichier
-      <literal>composer.json</literal> qui définie en dépendence de développement
+      <literal>composer.json</literal> qui définie en dépendance de développement
       PHPUnit 4.6 et vfsStream:
     </para>
 

--- a/src/7.0/fr/textui.xml
+++ b/src/7.0/fr/textui.xml
@@ -101,7 +101,7 @@ OK (2 tests, 2 assertions)</screen>
     cette distinction s'avère utile car les erreurs tendent à être plus faciles
     à corriger que les échecs. Si vous avez une longue liste de problèmes, il vaut
     mieux éradiquer d'abord les erreurs pour voir s'il reste encore des échecs
-    uen fois qu'elles ont été corrigées.
+    une fois qu'elles ont été corrigées.
   </para>
 
   <section id="textui.clioptions">
@@ -256,7 +256,7 @@ Miscellaneous Options:
         <term><literal>--coverage-crap4j</literal></term>
         <listitem>
           <para>
-            Génère un raport de couverture de code au format Crap4j. Voir
+            Génère un rapport de couverture de code au format Crap4j. Voir
             <xref linkend="code-coverage-analysis" /> pour plus de détails.
           </para>
           <para>
@@ -572,7 +572,7 @@ class TestCaseClass extends TestCase
         <term><literal>--disallow-todo-tests</literal></term>
         <listitem>
           <para>
-            Ne pas executer les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
+            Ne pas exécuter les tests qui ont l'annotation <literal>@todo</literal> dans son docblock.
           </para>
         </listitem>
       </varlistentry>
@@ -677,7 +677,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-error</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur.
+            Arrête l'exécution à la première erreur.
           </para>
         </listitem>
       </varlistentry>
@@ -686,7 +686,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-failure</literal></term>
         <listitem>
           <para>
-            Arrête l'execution à la première erreur ou au premier échec.
+            Arrête l'exécution à la première erreur ou au premier échec.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-risky</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test risqué.
+            Arrête l'exécution au premier test risqué.
           </para>
         </listitem>
       </varlistentry>
@@ -704,7 +704,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-skipped</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test sauté.
+            Arrête l'exécution au premier test sauté.
           </para>
         </listitem>
       </varlistentry>
@@ -713,7 +713,7 @@ class TestCaseClass extends TestCase
         <term><literal>--stop-on-incomplete</literal></term>
         <listitem>
           <para>
-            Arrête l'execution au premier test incomplet.
+            Arrête l'exécution au premier test incomplet.
           </para>
         </listitem>
       </varlistentry>

--- a/src/7.0/fr/writing-tests-for-phpunit.xml
+++ b/src/7.0/fr/writing-tests-for-phpunit.xml
@@ -73,7 +73,7 @@ class StackTest extends TestCase
 
       PHPUnit gère la déclaration de dépendances explicites entre les
       méthodes de test. De telles dépendances ne définissent pas l'ordre dans lequel les méthodes de test
-      doivent être exécutées mais elles permettent de renvoyer une instance de
+      doivent être exécutées, mais elles permettent de renvoyer une instance de
       la fixture de test par un producteur à des consommateurs qui en dépendent.
     </para>
 
@@ -1001,7 +1001,7 @@ Tests: 1, Assertions: 1, Failures: 1.]]></screen>
       <title>Cas limite</title>
 
       <para>
-        Quand une comparaison échoue, PHPUnit crée une représentation textuel des
+        Quand une comparaison échoue, PHPUnit crée une représentation textuelle des
         valeurs d'entrées et les compare. A cause de cette implémentation un diff
         peut montrer plus de problèmes qu'il n'en existe réellement.
       </para>


### PR DESCRIPTION
- fixed some spelling errors in French translation (5.7 to 7.0 versions) 
- used a markdown array for "Guide de traduction" in src/*/fr/README.md  instead of no formated text.

ping @gbprod