### PR TITLE
Add info about OSFAMILY

### DIFF
--- a/src/6.3/en/incomplete-and-skipped-tests.xml
+++ b/src/6.3/en/incomplete-and-skipped-tests.xml
@@ -250,6 +250,12 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
             <entry>@requires OS WIN32|WINNT</entry>
           </row>
           <row>
+            <entry><literal>OSFAMILY</literal></entry>
+            <entry>Any <ulink url="http://php.net/manual/en/reserved.constants.php#constant.php-os-family">OS family</ulink></entry>
+            <entry>@requires OSFAMILY Solaris</entry>
+            <entry>@requires OSFAMILY Windows</entry>
+          </row>
+          <row>
             <entry><literal>function</literal></entry>
             <entry>Any valid parameter to <ulink url="http://php.net/function_exists">function_exists</ulink></entry>
             <entry>@requires function imap_open</entry>

--- a/src/6.4/en/incomplete-and-skipped-tests.xml
+++ b/src/6.4/en/incomplete-and-skipped-tests.xml
@@ -250,6 +250,12 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
             <entry>@requires OS WIN32|WINNT</entry>
           </row>
           <row>
+            <entry><literal>OSFAMILY</literal></entry>
+            <entry>Any <ulink url="http://php.net/manual/en/reserved.constants.php#constant.php-os-family">OS family</ulink></entry>
+            <entry>@requires OSFAMILY Solaris</entry>
+            <entry>@requires OSFAMILY Windows</entry>
+          </row>
+          <row>
             <entry><literal>function</literal></entry>
             <entry>Any valid parameter to <ulink url="http://php.net/function_exists">function_exists</ulink></entry>
             <entry>@requires function imap_open</entry>

--- a/src/6.5/en/incomplete-and-skipped-tests.xml
+++ b/src/6.5/en/incomplete-and-skipped-tests.xml
@@ -250,6 +250,12 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
             <entry>@requires OS WIN32|WINNT</entry>
           </row>
           <row>
+            <entry><literal>OSFAMILY</literal></entry>
+            <entry>Any <ulink url="http://php.net/manual/en/reserved.constants.php#constant.php-os-family">OS family</ulink></entry>
+            <entry>@requires OSFAMILY Solaris</entry>
+            <entry>@requires OSFAMILY Windows</entry>
+          </row>
+          <row>
             <entry><literal>function</literal></entry>
             <entry>Any valid parameter to <ulink url="http://php.net/function_exists">function_exists</ulink></entry>
             <entry>@requires function imap_open</entry>

--- a/src/7.0/en/incomplete-and-skipped-tests.xml
+++ b/src/7.0/en/incomplete-and-skipped-tests.xml
@@ -250,6 +250,12 @@ Tests: 1, Assertions: 0, Skipped: 1.</screen>
             <entry>@requires OS WIN32|WINNT</entry>
           </row>
           <row>
+            <entry><literal>OSFAMILY</literal></entry>
+            <entry>Any <ulink url="http://php.net/manual/en/reserved.constants.php#constant.php-os-family">OS family</ulink></entry>
+            <entry>@requires OSFAMILY Solaris</entry>
+            <entry>@requires OSFAMILY Windows</entry>
+          </row>
+          <row>
             <entry><literal>function</literal></entry>
             <entry>Any valid parameter to <ulink url="http://php.net/function_exists">function_exists</ulink></entry>
             <entry>@requires function imap_open</entry>


### PR DESCRIPTION
I noticed that `OSFAMILY` introduced in PHPUnit 6.3.0 (note: https://github.com/sebastianbergmann/phpunit/blob/6.3/ChangeLog-6.3.md#630---2017-08-04) is not listed in documentation. This PR is adding it.

As a first time contributor here (sorry, I didn't found any contributing guide here) please guide me how to:
- apply doc change from 6.3 to any 6.4+ (shall I just copy-paste, or there is sth "smart" to do ?)
- add docs for other languages (I know that this feature shall be mentioned in all languages, yet I have no clue what to put in Japanese translation and so)
