### PR TITLE
Document doesNotPerformAssertions annotation

### DIFF
--- a/src/5.6/en/annotations.xml
+++ b/src/5.6/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/5.7/en/annotations.xml
+++ b/src/5.7/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/6.0/en/annotations.xml
+++ b/src/6.0/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/6.1/en/annotations.xml
+++ b/src/6.1/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/6.2/en/annotations.xml
+++ b/src/6.2/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/6.3/en/annotations.xml
+++ b/src/6.3/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/6.4/en/annotations.xml
+++ b/src/6.4/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/6.5/en/annotations.xml
+++ b/src/6.5/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 

--- a/src/7.0/en/annotations.xml
+++ b/src/7.0/en/annotations.xml
@@ -448,6 +448,15 @@ class CoversDefaultClassTest extends TestCase
     </para>
   </section>
 
+  <section id="appendixes.annotations.doesNotPerformAssertions">
+    <title>@doesNotPerformAssertions</title>
+
+    <para>
+    <indexterm><primary>@doesNotPerformAssertions</primary></indexterm>
+      Specifies that test performs no assertions, so it won't be marked as risky.
+    </para>
+  </section>
+
   <section id="appendixes.annotations.expectedException">
     <title>@expectedException</title>
 


### PR DESCRIPTION
Feature was introduced in 5.6.

I've seen people asking for feature like this, it's not documented so not everybody knows it exists.

Assertion name is self-explanatory, should I add more extensive description?