### PR TITLE
Add note about the way exception messages are compared.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - PHP 5 (with DOM, PCRE, SPL, and Tokenizer extensions enabled)
 - Ruby
 - xsltproc
+- libxml2-utils
 
 ## Building the Documentation
 

--- a/src/5.2/en/writing-tests-for-phpunit.xml
+++ b/src/5.2/en/writing-tests-for-phpunit.xml
@@ -607,6 +607,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/5.3/en/writing-tests-for-phpunit.xml
+++ b/src/5.3/en/writing-tests-for-phpunit.xml
@@ -607,6 +607,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/5.4/en/writing-tests-for-phpunit.xml
+++ b/src/5.4/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/5.5/en/writing-tests-for-phpunit.xml
+++ b/src/5.5/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/5.6/en/writing-tests-for-phpunit.xml
+++ b/src/5.6/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/5.7/en/writing-tests-for-phpunit.xml
+++ b/src/5.7/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/6.0/en/writing-tests-for-phpunit.xml
+++ b/src/6.0/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/6.1/en/writing-tests-for-phpunit.xml
+++ b/src/6.1/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/6.2/en/writing-tests-for-phpunit.xml
+++ b/src/6.2/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/6.3/en/writing-tests-for-phpunit.xml
+++ b/src/6.3/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/6.4/en/writing-tests-for-phpunit.xml
+++ b/src/6.4/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/6.5/en/writing-tests-for-phpunit.xml
+++ b/src/6.5/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>

--- a/src/7.0/en/writing-tests-for-phpunit.xml
+++ b/src/7.0/en/writing-tests-for-phpunit.xml
@@ -627,6 +627,16 @@ Tests: 1, Assertions: 1, Failures: 1.</screen>
       expectations for exceptions raised by the code under test.
     </para>
 
+    <note>
+      <para>
+        <indexterm><primary>expectExceptionMessage()</primary></indexterm>
+
+        Note that expectExceptionMessage asserts that the <literal>$actual</literal>
+        message contains the <literal>$expected</literal> message and doesn't perform
+        an exact string comparison.
+      </para>
+    </note>
+
     <para>
       <indexterm><primary>Annotation</primary></indexterm>
       <indexterm><primary>@expectedException</primary></indexterm>


### PR DESCRIPTION
Added note that `expectExceptionMessage` checks if the exception message contains `$expected` string to address issue [2943](https://github.com/sebastianbergmann/phpunit/issues/2943).

Not sure if I made the change conform your style. Let me know. ;)