### PR TITLE
fixed a typo on database (fr)

### DIFF
--- a/src/6.5/fr/database.xml
+++ b/src/6.5/fr/database.xml
@@ -580,8 +580,7 @@ abstract class Generic_Tests_DatabaseTestCase extends TestCase
           de décrire dans le format XML à plat. Vous pouvez représenter une valeur NULL
           en omettant d'attribut indiquant la ligne. Si votre livre d'or autorise les entrées
           anonymes représentées par une valeur NULL dans la colonne utilisateur, un état
-          hypothétique de la table guestbook pourrait r
-          essembler à ceci:
+          hypothétique de la table guestbook pourrait ressembler à ceci:
         </para>
         <screen><![CDATA[
 <?xml version="1.0" ?>


### PR DESCRIPTION
Hello
I find a typo in the french translation of the documentation.
Here a PR to fix it.
Thanks